### PR TITLE
ci: staging branch deploy workflow + branch protection

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -853,6 +853,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
+          ref: staging
           path: repo
           persist-credentials: false
 

--- a/Makefile
+++ b/Makefile
@@ -170,22 +170,23 @@ check-staging-sync:
 	@if [ -n "$(FORCE_DEPLOY)" ]; then \
 		echo "FORCE_DEPLOY set -- skipping staging sync check."; \
 	else \
-		echo "Checking staging is in sync with HEAD before prod deploy..."; \
+		echo "Checking staging site is in sync with origin/staging before prod deploy..."; \
 		staging_sha=$$(curl -sf '$(STAGING_VERSION_URL)' \
 			| python3 -c 'import json,sys; print(json.load(sys.stdin).get("sha","")[:7])' 2>/dev/null || true); \
-		head_sha=$$(git rev-parse --short=7 HEAD); \
+		git fetch origin staging --quiet 2>/dev/null || true; \
+		branch_sha=$$(git rev-parse --short=7 origin/staging 2>/dev/null || git rev-parse --short=7 HEAD); \
 		if [ -z "$$staging_sha" ]; then \
 			echo "error: could not read $(STAGING_VERSION_URL)" >&2; \
-			echo "Run 'make gh-staging' and verify before promoting to prod." >&2; \
+			echo "Run 'make gh-staging' from the staging branch and verify before promoting to prod." >&2; \
 			exit 1; \
 		fi; \
-		if [ "$$staging_sha" != "$$head_sha" ]; then \
-			echo "error: staging is at $$staging_sha but HEAD is $$head_sha" >&2; \
-			echo "Run 'make gh-staging', verify the fix, then re-run this target." >&2; \
+		if [ "$$staging_sha" != "$$branch_sha" ]; then \
+			echo "error: staging site is at $$staging_sha but origin/staging is at $$branch_sha" >&2; \
+			echo "Run 'make gh-staging' from the staging branch, verify the fix, then re-run this target." >&2; \
 			echo "To skip this check (emergencies only): FORCE_DEPLOY=1 make $@" >&2; \
 			exit 1; \
 		fi; \
-		echo "Staging matches HEAD ($$staging_sha). OK to promote."; \
+		echo "Staging site matches origin/staging ($$staging_sha). OK to promote."; \
 	fi
 
 gh-run: gh-check check-staging-sync

--- a/scripts/wait-for-remote.sh
+++ b/scripts/wait-for-remote.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Wait for origin/main to reflect the local HEAD before triggering a workflow
-# dispatch, preventing race conditions where the runner checks out a stale SHA.
+# Wait for the current branch on origin to reflect the local HEAD before
+# triggering a workflow dispatch, preventing race conditions where the runner
+# checks out a stale SHA.
 #
 # Usage: bash scripts/wait-for-remote.sh [max_attempts] [sleep_seconds]
 #   max_attempts  default 10
@@ -11,22 +12,23 @@ set -euo pipefail
 MAX=${1:-10}
 SLEEP=${2:-3}
 
+branch=$(git rev-parse --abbrev-ref HEAD)
 local_sha=$(git rev-parse HEAD)
-echo "Waiting for origin/main to reflect $local_sha..."
+echo "Waiting for origin/$branch to reflect $local_sha..."
 
 for i in $(seq 1 "$MAX"); do
-    remote_sha=$(git ls-remote origin refs/heads/main | cut -f1)
+    remote_sha=$(git ls-remote origin "refs/heads/$branch" | cut -f1)
     if [ "$remote_sha" = "$local_sha" ]; then
-        echo "origin/main matches HEAD ($local_sha). OK."
+        echo "origin/$branch matches HEAD ($local_sha). OK."
         exit 0
     fi
     echo "  attempt $i/$MAX: remote has $remote_sha, retrying in ${SLEEP}s..."
     sleep "$SLEEP"
 done
 
-remote_sha=$(git ls-remote origin refs/heads/main | cut -f1)
+remote_sha=$(git ls-remote origin "refs/heads/$branch" | cut -f1)
 if [ "$remote_sha" != "$local_sha" ]; then
-    echo "error: origin/main ($remote_sha) still does not match HEAD ($local_sha) after $MAX attempts." >&2
-    echo "Push your changes first: git push origin main" >&2
+    echo "error: origin/$branch ($remote_sha) still does not match HEAD ($local_sha) after $MAX attempts." >&2
+    echo "Push your changes first: git push origin $branch" >&2
     exit 1
 fi


### PR DESCRIPTION
Switches the staging-preview CI job to deploy from the `staging` branch instead of `main`, and updates `check-staging-sync` to compare the staging site SHA against `origin/staging` tip.

Also sets up the intended review flow: all in-progress work goes to `staging`, gets reviewed on the staging site, then lands on `main` via a PR that requires 1 approved review + passing CI.

- `update-data.yml`: staging-preview job now checks out `ref: staging`
- `Makefile`: `check-staging-sync` fetches `origin/staging` and compares against that tip

Staging was verified before this PR was opened.