### PR TITLE
fix(profile): button layout, publish/unpublish width, steam identity, red validation

### DIFF
--- a/css/app/app.css
+++ b/css/app/app.css
@@ -673,6 +673,7 @@
   font-family: inherit;
   min-height: 34px;
   text-decoration: none;
+  white-space: nowrap;
 }
 .submit-report-btn:hover { background: rgba(76,175,80,0.25); text-decoration: none; }
 .sf-row {

--- a/css/profile/profile.css
+++ b/css/profile/profile.css
@@ -646,7 +646,7 @@
 .profile-configs-actions {
   display: flex;
   gap: 5px;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   width: 100%;
 }
 .profile-configs-view-link,
@@ -655,17 +655,14 @@
   color: var(--muted);
   text-decoration: none;
   border: 1px solid var(--border2);
-  padding: 3px 6px;
+  padding: 3px 8px;
   display: inline-block;
   background: transparent;
   font-family: inherit;
   cursor: pointer;
-  flex: 1 1 0;
-  min-width: 0;
+  flex: 0 0 auto;
   text-align: center;
   white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 .profile-configs-view-link:hover,
 .profile-configs-action:hover { color: var(--accent); border-color: var(--accent); }

--- a/css/profile/profile.css
+++ b/css/profile/profile.css
@@ -674,7 +674,9 @@
   cursor: default;
   pointer-events: none;
 }
-.profile-configs-publish-btn {
+.profile-configs-publish-btn,
+.profile-configs-view-link:not(.profile-configs-view-disabled),
+.profile-configs-edit-btn {
   color: #9ecbe8;
   border-color: rgba(74,159,208,0.45);
 }

--- a/css/profile/profile.css
+++ b/css/profile/profile.css
@@ -672,6 +672,10 @@
   pointer-events: none;
 }
 .profile-configs-publish-btn,
+.profile-configs-unpublish-btn {
+  min-width: 68px;
+}
+.profile-configs-publish-btn,
 .profile-configs-view-link:not(.profile-configs-view-disabled),
 .profile-configs-edit-btn {
   color: #9ecbe8;

--- a/css/profile/profile.css
+++ b/css/profile/profile.css
@@ -671,9 +671,9 @@
   cursor: default;
   pointer-events: none;
 }
-.profile-configs-publish-btn {
-  padding-left: 14px;
-  padding-right: 14px;
+.profile-configs-publish-btn,
+.profile-configs-unpublish-btn {
+  min-width: 72px;
 }
 .profile-configs-publish-btn,
 .profile-configs-view-link:not(.profile-configs-view-disabled),

--- a/css/profile/profile.css
+++ b/css/profile/profile.css
@@ -671,9 +671,9 @@
   cursor: default;
   pointer-events: none;
 }
-.profile-configs-publish-btn,
-.profile-configs-unpublish-btn {
-  min-width: 68px;
+.profile-configs-publish-btn {
+  padding-left: 14px;
+  padding-right: 14px;
 }
 .profile-configs-publish-btn,
 .profile-configs-view-link:not(.profile-configs-view-disabled),

--- a/js/profile/main.js
+++ b/js/profile/main.js
@@ -1022,6 +1022,9 @@ import { showEditCloudConfigModal, showEditReportModal } from './components/edit
         row.cloud && row.unpublished
           ? `<a class="profile-configs-action profile-configs-publish-btn" href="submit.html?app=${escapeHtml(String(row.app_id))}&fromCloud=1" target="_blank" rel="noopener">Publish</a>`
           : '',
+        row.published_id
+          ? `<button type="button" class="profile-configs-action profile-configs-unpublish-btn" data-published-id="${escapeHtml(String(row.published_id))}">Unpublish</button>`
+          : '',
         // Edit: published rows go to submit.html in edit mode (full form
         // pre-fill from user_configs). Cloud-only rows go to submit.html?fromCloud=1
         // where a Save button lets them update the draft without publishing.
@@ -1030,9 +1033,6 @@ import { showEditCloudConfigModal, showEditReportModal } from './components/edit
           : row.cloud
             ? `<a class="profile-configs-action profile-configs-edit-btn" href="submit.html?app=${escapeHtml(String(row.app_id))}&fromCloud=1" target="_blank" rel="noopener">Edit</a>`
             : '',
-        row.published_id
-          ? `<button type="button" class="profile-configs-action profile-configs-unpublish-btn" data-published-id="${escapeHtml(String(row.published_id))}">Unpublish</button>`
-          : '',
         `<button type="button" class="profile-configs-action profile-configs-delete-btn" data-app-id="${escapeHtml(String(row.app_id))}">Delete</button>`,
       ].filter(Boolean).join('');
       return `

--- a/js/profile/main.js
+++ b/js/profile/main.js
@@ -208,6 +208,29 @@ import { showEditCloudConfigModal, showEditReportModal } from './components/edit
     renderMyHwFieldOrigins();
   }
 
+  async function syncAvatarVisibility(val, session) {
+    if (!session?.user) return;
+    const uid = session.user.id;
+    const meta = session.user.user_metadata || {};
+    const displayName = meta.full_name || meta.name || null;
+    const avatarUrl = meta.avatar_url || null;
+    const headers = { apikey: SUPABASE_ANON_KEY, Authorization: `Bearer ${session.access_token}`, 'Content-Type': 'application/json' };
+    if (val) {
+      await fetch(`${SUPABASE_URL}/rest/v1/author_avatars`, {
+        method: 'POST',
+        headers: { ...headers, Prefer: 'resolution=merge-duplicates,return=minimal' },
+        body: JSON.stringify({ proton_pulse_user_id: uid, display_name: displayName, avatar_url: avatarUrl }),
+      });
+      console.debug('[profile] author_avatars upserted', { uid, displayName });
+    } else {
+      await fetch(`${SUPABASE_URL}/rest/v1/author_avatars?proton_pulse_user_id=eq.${uid}`, {
+        method: 'DELETE',
+        headers,
+      });
+      console.debug('[profile] author_avatars deleted', { uid });
+    }
+  }
+
   function showUser(user, session) {
     const name    = user.user_metadata?.full_name || user.user_metadata?.name || '';
     const email   = user.email || '';
@@ -233,6 +256,8 @@ import { showEditCloudConfigModal, showEditReportModal } from './components/edit
       if (fromMeta !== null) setShowUsername(val); // keep localStorage in sync
       usernameToggle.checked = val;
       usernameStatus.textContent = val ? 'Shown on reports' : 'Anonymous';
+      // ensure author_avatars row matches current preference on every load
+      if (session) syncAvatarVisibility(val, session).catch(() => {});
     }
     if (hwGpuSelect) hwGpuSelect.value = localStorage.getItem(HW_GPU_KEY) || '';
     if (hwOsInput)   hwOsInput.value   = localStorage.getItem(HW_OS_KEY)  || '';
@@ -358,7 +383,7 @@ import { showEditCloudConfigModal, showEditReportModal } from './components/edit
   } else {
     const session = await SupaAuth.getSession();
     if (session?.user) {
-      showUser(session.user);
+      showUser(session.user, session);
       void refreshLinkedPlugins();
     } else {
       showSignedOut();
@@ -476,6 +501,10 @@ import { showEditCloudConfigModal, showEditReportModal } from './components/edit
     // persist to Supabase so the preference follows the account across devices
     SupaAuth.updateUserMeta({ show_username: val }).catch((e) => {
       console.warn('[profile] failed to persist show_username to Supabase user_metadata:', e);
+    });
+    // actively upsert or delete the author_avatars row so report cards update immediately
+    SupaAuth.getSession().then(s => syncAvatarVisibility(val, s)).catch((e) => {
+      console.warn('[profile] syncAvatarVisibility failed:', e);
     });
   });
 

--- a/js/profile/main.js
+++ b/js/profile/main.js
@@ -12,7 +12,7 @@ import {
   getMyHwSourceMeta, setMyHwSourceMeta, getMyHwFieldOrigins,
   setMyHwFieldOrigins, setMyHwFieldOrigin, escapeHtml, formatSystemUpdated,
   getWebClientIdProfile, getMyReportBadges, flaggedMessageHtml,
-  mergeMyReportRows, getPluginLinkCodeFromLocation,
+  mergeMyReportRows, getPluginLinkCodeFromLocation, getSteamIdFromSession,
 } from './utils.js?v=2324dd84';
 import { supabaseHeaders } from './api/supabase.js?v=bdf4b262';
 import {
@@ -212,22 +212,23 @@ import { showEditCloudConfigModal, showEditReportModal } from './components/edit
     if (!session?.user) return;
     const uid = session.user.id;
     const meta = session.user.user_metadata || {};
-    const displayName = meta.full_name || meta.name || null;
-    const avatarUrl = meta.avatar_url || null;
+    const displayName = meta.full_name || meta.name || '';
+    const avatarUrl = meta.avatar_url || '';
+    const steamId = getSteamIdFromSession(session) || '';
     const headers = { apikey: SUPABASE_ANON_KEY, Authorization: `Bearer ${session.access_token}`, 'Content-Type': 'application/json' };
     if (val) {
-      await fetch(`${SUPABASE_URL}/rest/v1/author_avatars`, {
+      const res = await fetch(`${SUPABASE_URL}/rest/v1/author_avatars`, {
         method: 'POST',
         headers: { ...headers, Prefer: 'resolution=merge-duplicates,return=minimal' },
-        body: JSON.stringify({ proton_pulse_user_id: uid, display_name: displayName, avatar_url: avatarUrl }),
+        body: JSON.stringify({ proton_pulse_user_id: uid, steam_id: steamId, display_name: displayName, avatar_url: avatarUrl }),
       });
-      console.debug('[profile] author_avatars upserted', { uid, displayName });
+      console.debug('[profile] author_avatars upserted', { uid, steamId, displayName, ok: res.ok, status: res.status });
     } else {
-      await fetch(`${SUPABASE_URL}/rest/v1/author_avatars?proton_pulse_user_id=eq.${uid}`, {
+      const res = await fetch(`${SUPABASE_URL}/rest/v1/author_avatars?proton_pulse_user_id=eq.${uid}`, {
         method: 'DELETE',
         headers,
       });
-      console.debug('[profile] author_avatars deleted', { uid });
+      console.debug('[profile] author_avatars deleted', { uid, ok: res.ok, status: res.status });
     }
   }
 

--- a/js/shared/submit.js
+++ b/js/shared/submit.js
@@ -392,17 +392,17 @@ export async function populateSubmitForm(el) {
       </div>
       <div class="sf-row"><label>Proton Version *</label>
         <div class="sf-autocomplete" style="position:relative;flex:1;">
-          <input name="protonVersion" required placeholder="e.g. Proton 9.0-4 or GE-Proton9-27" autocomplete="off" style="width:100%">
+          <input name="protonVersion" placeholder="e.g. Proton 9.0-4 or GE-Proton9-27" autocomplete="off" style="width:100%">
           <ul class="sf-suggestions" style="display:none;position:absolute;top:100%;left:0;right:0;z-index:100;background:var(--s2);border:1px solid var(--border);border-top:none;max-height:200px;overflow-y:auto;list-style:none;margin:0;padding:0;"></ul>
         </div>
       </div>
-      <div class="sf-row"><label>GPU *</label><input name="gpu" required placeholder="e.g. NVIDIA GeForce RTX 4070"></div>
-      <div class="sf-row"><label>GPU Vendor *</label><select name="gpuVendor" required><option value="" disabled selected>-- choose one --</option>${opts(gpuVendors,true)}</select></div>
+      <div class="sf-row"><label>GPU *</label><input name="gpu" placeholder="e.g. NVIDIA GeForce RTX 4070"></div>
+      <div class="sf-row"><label>GPU Vendor *</label><select name="gpuVendor"><option value="" disabled selected>-- choose one --</option>${opts(gpuVendors,true)}</select></div>
       <div class="sf-row"><label>GPU Driver</label><input name="gpuDriver" placeholder="e.g. Mesa 24.1.0 or 555.42.02"></div>
-      <div class="sf-row"><label>CPU *</label><input name="cpu" required placeholder="e.g. AMD Ryzen 7 5800X3D"></div>
-      <div class="sf-row"><label>RAM *</label><input name="ram" required placeholder="e.g. 16 GB or 64"></div>
+      <div class="sf-row"><label>CPU *</label><input name="cpu" placeholder="e.g. AMD Ryzen 7 5800X3D"></div>
+      <div class="sf-row"><label>RAM *</label><input name="ram" placeholder="e.g. 16 GB or 64"></div>
       <div class="sf-row"><label>VRAM (MB)</label><input name="vramMb" type="number" placeholder="e.g. 8192"></div>
-      <div class="sf-row"><label>OS *</label><select name="os" required><option value="" disabled selected>-- choose one --</option>${opts(osList,false)}</select><input name="osVersion" placeholder="Version (e.g. 24.04)" style="max-width:120px"></div>
+      <div class="sf-row"><label>OS *</label><select name="os"><option value="" disabled selected>-- choose one --</option>${opts(osList,false)}</select><input name="osVersion" placeholder="Version (e.g. 24.04)" style="max-width:120px"></div>
       <div class="sf-row"><label>Kernel</label><input name="kernel" placeholder="e.g. 6.8.0"></div>
       <div class="sf-row"><label>Steam Playtime</label><select name="duration">${durationOpts}</select></div>
       <div class="sf-row"><label>Launch Options</label><input name="launchOptions" placeholder="e.g. PROTON_USE_WINED3D=1 %command%"></div>
@@ -492,7 +492,7 @@ export async function populateSubmitForm(el) {
       </div>
 
       <div class="sf-section-label" style="margin-top:16px">Notes</div>
-      <div class="sf-row"><textarea name="notes" rows="3" required placeholder="How did it run? Any issues or tweaks?"></textarea></div>
+      <div class="sf-row"><textarea name="notes" rows="3" placeholder="How did it run? Any issues or tweaks?"></textarea></div>
 
       <div class="sf-row">
         <label>Submitted from</label>

--- a/scripts/wait-for-remote.sh
+++ b/scripts/wait-for-remote.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 MAX=${1:-10}
 SLEEP=${2:-3}
 
-branch=$(git rev-parse --abbrev-ref HEAD)
+branch=$(git branch --show-current)
 local_sha=$(git rev-parse HEAD)
 echo "Waiting for origin/$branch to reflect $local_sha..."
 

--- a/supabase/migrations/20260618010000_author_avatars_delete_policy.sql
+++ b/supabase/migrations/20260618010000_author_avatars_delete_policy.sql
@@ -1,0 +1,9 @@
+-- Allow authenticated users to delete their own author_avatars row.
+-- Required so the show_username toggle can remove the row when disabled.
+
+grant delete on table public.author_avatars to authenticated;
+
+create policy "users delete own avatar"
+  on public.author_avatars for delete
+  to authenticated
+  using (proton_pulse_user_id = auth.uid());


### PR DESCRIPTION
Batches several profile and submit page fixes from staging:

- Reordered profile action buttons: Unpublish now sits at position 2 (same slot as Publish for unpublished rows), before Edit
- Publish and Unpublish buttons share min-width: 72px so they align in the actions column
- Removed browser-native required validation; custom sf-needs-answer handles all required field feedback
- Red left-border validation now covers hardware fields (protonVersion, gpu, gpuVendor, cpu, ram, os, notes) in addition to compat questions
- Cloud config fetch uses OR filter to handle both voter_id (hash) and proton_pulse_user_id (UUID)
- Steam identity (show_username toggle) now actively upserts/deletes author_avatars row on page load and on toggle, so report cards show Steam username and avatar instead of "WEB USER"
- View and Edit buttons match Publish blue