### PR TITLE
Toast feedback, edit-return, and UI fixes

### DIFF
--- a/about.html
+++ b/about.html
@@ -12,7 +12,7 @@
 <meta property="og:description" content="What Proton Pulse is, how it compares to ProtonDB, and how the open data pipeline works.">
 <meta property="og:type" content="website">
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=54609d3c">
+<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
 <link rel="stylesheet" href="css/index/index.css?v=857e41cf">
 </head>
 <body>
@@ -192,6 +192,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/about/version.js?v=30fa403d"></script>
 </body>
 </html>

--- a/about.html
+++ b/about.html
@@ -12,7 +12,7 @@
 <meta property="og:description" content="What Proton Pulse is, how it compares to ProtonDB, and how the open data pipeline works.">
 <meta property="og:type" content="website">
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
+<link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
 <link rel="stylesheet" href="css/index/index.css?v=857e41cf">
 </head>
 <body>

--- a/about.html
+++ b/about.html
@@ -191,7 +191,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/about/version.js?v=30fa403d"></script>
 </body>

--- a/admin.html
+++ b/admin.html
@@ -264,6 +264,6 @@
 <script src="js/lib/analytics.js?v=89bd7747"></script>
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/admin/main.js?v=97e00bd6"></script>
+<script type="module" src="js/admin/main.js?v=5bb293bb"></script>
 </body>
 </html>

--- a/admin.html
+++ b/admin.html
@@ -8,7 +8,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Admin — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
+<link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
 <link rel="stylesheet" href="css/admin/admin.css?v=ff268395">
 </head>
 <body>

--- a/admin.html
+++ b/admin.html
@@ -8,7 +8,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Admin — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=54609d3c">
+<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
 <link rel="stylesheet" href="css/admin/admin.css?v=ff268395">
 </head>
 <body>
@@ -263,6 +263,7 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/analytics.js?v=89bd7747"></script>
 <script src="js/lib/topbar.js?v=e210caf6"></script>
-<script type="module" src="js/admin/main.js?v=38cf6a5f"></script>
+<script src="js/lib/toast.js?v=7bb23014"></script>
+<script type="module" src="js/admin/main.js?v=97e00bd6"></script>
 </body>
 </html>

--- a/admin.html
+++ b/admin.html
@@ -262,7 +262,7 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/analytics.js?v=89bd7747"></script>
-<script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/admin/main.js?v=97e00bd6"></script>
 </body>

--- a/app.html
+++ b/app.html
@@ -49,6 +49,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=e210caf6"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=42e28f80"></script>
+<script type="module" src="js/app/main.js?v=cf9177cc"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -12,7 +12,7 @@
 <meta property="og:description" content="Browse merged ProtonDB community reports and hardware-scored Proton Pulse configs. Filter by GPU, driver, and Proton version. Searchable, filterable, and updated daily.">
 <meta property="og:type" content="website">
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=54609d3c">
+<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
 <link rel="stylesheet" href="css/app/app.css?v=2b4c5354">
 </head>
 <body>
@@ -48,7 +48,8 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=cf9177cc"></script>
+<script type="module" src="js/app/main.js?v=bf834cc8"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -12,7 +12,7 @@
 <meta property="og:description" content="Browse merged ProtonDB community reports and hardware-scored Proton Pulse configs. Filter by GPU, driver, and Proton version. Searchable, filterable, and updated daily.">
 <meta property="og:type" content="website">
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
+<link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
 <link rel="stylesheet" href="css/app/app.css?v=2b4c5354">
 </head>
 <body>
@@ -50,6 +50,6 @@
 <script src="js/lib/topbar.js?v=e210caf6"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=bf834cc8"></script>
+<script type="module" src="js/app/main.js?v=a5b21752"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -50,6 +50,6 @@
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=4a5b4648"></script>
+<script type="module" src="js/app/main.js?v=f5e0002a"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -50,6 +50,6 @@
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=092b3942"></script>
+<script type="module" src="js/app/main.js?v=a55e9be4"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -47,9 +47,9 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=a5b21752"></script>
+<script type="module" src="js/app/main.js?v=092b3942"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -50,6 +50,6 @@
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=a55e9be4"></script>
+<script type="module" src="js/app/main.js?v=4a5b4648"></script>
 </body>
 </html>

--- a/auth.html
+++ b/auth.html
@@ -8,7 +8,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Sign In With Steam — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
+<link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/auth.html
+++ b/auth.html
@@ -68,6 +68,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script type="module" src="js/auth/main.js?v=0016214c"></script>
+<script src="js/lib/toast.js?v=7bb23014"></script>
+<script type="module" src="js/auth/main.js?v=461034e1"></script>
 </body>
 </html>

--- a/auth.html
+++ b/auth.html
@@ -8,7 +8,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Sign In With Steam — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=54609d3c">
+<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/confidence.html
+++ b/confidence.html
@@ -9,7 +9,7 @@
 <title>Confidence Breakdown - Proton Pulse</title>
 <meta name="description" content="Per-report and per-game confidence breakdown showing exactly how Proton Pulse computed its trust score.">
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=54609d3c">
+<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
 <link rel="stylesheet" href="css/app/app.css?v=2b4c5354">
 <style>
 h1 {
@@ -197,6 +197,7 @@ h1 {
 </head>
 <body>
 <script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">
 

--- a/confidence.html
+++ b/confidence.html
@@ -9,7 +9,7 @@
 <title>Confidence Breakdown - Proton Pulse</title>
 <meta name="description" content="Per-report and per-game confidence breakdown showing exactly how Proton Pulse computed its trust score.">
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
+<link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
 <link rel="stylesheet" href="css/app/app.css?v=2b4c5354">
 <style>
 h1 {

--- a/confidence.html
+++ b/confidence.html
@@ -196,7 +196,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/css/profile/profile.css
+++ b/css/profile/profile.css
@@ -566,6 +566,12 @@
   font-weight: 600;
 }
 .profile-configs-table tbody tr:last-child td { border-bottom: none; }
+/* Rating values are short (gold / platinum / dash), so cap the column small.
+   The table is table-layout:fixed, so a wide Rating column was starving the
+   actions column and wrapping the View/Publish/Edit/Delete buttons onto two
+   rows. A narrow Rating column gives the actions room to stay on one line. */
+.profile-configs-table th:nth-child(2),
+.profile-configs-table td:nth-child(2) { width: 92px; }
 .profile-configs-table td.col-action,
 .profile-configs-table th.col-action {
   text-align: right;

--- a/css/shared/site.css
+++ b/css/shared/site.css
@@ -1342,9 +1342,9 @@ html[data-motion="off"] .banner-atoms {
   white-space: nowrap;
   font-weight: 500;
 }
-@media (min-width: 1100px) { .auth-username { max-width: 220px; } }
-@media (min-width: 1400px) { .auth-username { max-width: 320px; } }
-@media (min-width: 1700px) { .auth-username { max-width: none; } }
+/* On desktop there's plenty of room in the topbar, so show the full username
+   instead of truncating it. */
+@media (min-width: 1024px) { .auth-username { max-width: none; overflow: visible; } }
 
 .auth-admin-navlink {
   color: #e88a8a !important;

--- a/css/shared/site.css
+++ b/css/shared/site.css
@@ -1729,3 +1729,56 @@ html[data-motion="off"] .banner-atoms {
   z-index: 10;
 }
 .copy-tooltip--show { opacity: 1; }
+
+/* ---- Toasts (js/lib/toast.js) -------------------------------------------
+   Transient action feedback. Stacks bottom-right, slides in/out, auto-dismiss.
+   Sits above modals/overlays. */
+.pp-toast-container {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  z-index: 100000;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: min(360px, calc(100vw - 32px));
+  pointer-events: none;
+}
+.pp-toast {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 11px 12px 11px 14px;
+  border-radius: 8px;
+  background: var(--s2);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--muted);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+  font-size: 0.88rem;
+  line-height: 1.4;
+  pointer-events: auto;
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+.pp-toast--in { opacity: 1; transform: translateY(0); }
+.pp-toast--out { opacity: 0; transform: translateY(8px); }
+.pp-toast--success { border-left-color: var(--green); }
+.pp-toast--error { border-left-color: var(--red); }
+.pp-toast--info { border-left-color: var(--accent); }
+.pp-toast-msg { flex: 1 1 auto; min-width: 0; word-wrap: break-word; }
+.pp-toast-close {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--muted);
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 2px;
+}
+.pp-toast-close:hover { color: var(--fg); }
+@media (max-width: 480px) {
+  .pp-toast-container { right: 10px; left: 10px; bottom: 10px; max-width: none; }
+}

--- a/game-stats.html
+++ b/game-stats.html
@@ -9,7 +9,7 @@
 <title>Game Stats - Proton Pulse</title>
 <meta name="description" content="Per-game Proton compatibility analysis with confidence breakdown, monthly report trends, working status, version success rates, and proven launch options.">
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
+<link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
 <link rel="stylesheet" href="css/app/app.css?v=2b4c5354">
 <style>
 h1 {

--- a/game-stats.html
+++ b/game-stats.html
@@ -9,7 +9,7 @@
 <title>Game Stats - Proton Pulse</title>
 <meta name="description" content="Per-game Proton compatibility analysis with confidence breakdown, monthly report trends, working status, version success rates, and proven launch options.">
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=54609d3c">
+<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
 <link rel="stylesheet" href="css/app/app.css?v=2b4c5354">
 <style>
 h1 {
@@ -303,6 +303,7 @@ h1 {
 </head>
 <body>
 <script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">
 

--- a/game-stats.html
+++ b/game-stats.html
@@ -302,7 +302,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/gh-pages-manifest.txt
+++ b/gh-pages-manifest.txt
@@ -85,6 +85,7 @@ js/lib/gpu-arch-detector.js
 js/lib/supabase-client.js
 js/lib/analytics.js
 js/lib/topbar.js
+js/lib/toast.js
 js/lib/gh-gist.js
 js/lib/gh-auth.js
 js/lib/scoring/gameStats.js

--- a/index.html
+++ b/index.html
@@ -188,6 +188,6 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=e210caf6"></script>
-<script type="module" src="js/index/main.js?v=84692ed0"></script>
+<script type="module" src="js/index/main.js?v=76eff07f"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 <meta property="og:description" content="Stop copying and pasting launch flags. View weighted ProtonDB hardware scores, filter compatibility reports by your GPU and driver, and apply Proton launch options directly to your Steam Deck library.">
 <meta property="og:type" content="website">
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=54609d3c">
+<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
 <link rel="stylesheet" href="css/index/index.css?v=857e41cf">
 </head>
 <body>
@@ -188,6 +188,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/index/main.js?v=76eff07f"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 <meta property="og:description" content="Stop copying and pasting launch flags. View weighted ProtonDB hardware scores, filter compatibility reports by your GPU and driver, and apply Proton launch options directly to your Steam Deck library.">
 <meta property="og:type" content="website">
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
+<link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
 <link rel="stylesheet" href="css/index/index.css?v=857e41cf">
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -187,7 +187,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/index/main.js?v=76eff07f"></script>
 </body>

--- a/js/admin/components/userDetail.js
+++ b/js/admin/components/userDetail.js
@@ -249,9 +249,10 @@ export function renderUserDetail(user, reports, authEvents, { session, onBack, o
         btn.closest('tr').remove();
         const remaining = reportsWrap.querySelectorAll('tbody tr').length;
         el.querySelector('.user-detail-section:last-of-type .user-detail-count').textContent = `(${remaining})`;
+        window.ppToast?.success('Report deleted.');
       } catch (err) {
         btn.disabled = false;
-        alert(err.message);
+        window.ppToast?.error(err.message);
       }
     }
 
@@ -272,8 +273,9 @@ export function renderUserDetail(user, reports, authEvents, { session, onBack, o
             existing.remove();
           }
         }
+        window.ppToast?.success(hide ? 'Report hidden.' : 'Report restored.');
       } catch (err) {
-        alert(err.message);
+        window.ppToast?.error(err.message);
       } finally {
         btn.disabled = false;
       }
@@ -322,8 +324,9 @@ export function renderUserDetail(user, reports, authEvents, { session, onBack, o
       }
       editModal.hidden = true;
       editingId = null;
+      window.ppToast?.success('Report updated.');
     } catch (err) {
-      alert(err.message);
+      window.ppToast?.error(err.message);
     } finally {
       saveBtn.disabled = false;
     }

--- a/js/admin/main.js
+++ b/js/admin/main.js
@@ -446,10 +446,11 @@ function wireEvents() {
         if (target) target.status = newStatus;
         btn.disabled = false;
         btn.textContent = origText;
+        window.ppToast?.success(`Status set to ${STATUS_LABELS[newStatus] || newStatus}.`);
       } catch (err) {
         btn.disabled = false;
         btn.textContent = origText;
-        alert(`Error: ${err.message}`);
+        window.ppToast?.error(`Could not update status: ${err.message}`);
       }
     }
 
@@ -462,10 +463,11 @@ function wireEvents() {
         await deleteFlaggedReport(currentSession, id);
         flaggedRows = flaggedRows.filter(r => String(r.id) !== id);
         activateTab('flagged');
+        window.ppToast?.success('Flag entry deleted.');
       } catch (err) {
         btn.disabled = false;
         btn.textContent = 'Delete';
-        alert(`Error: ${err.message}`);
+        window.ppToast?.error(`Could not delete flag: ${err.message}`);
       }
     }
 
@@ -506,10 +508,16 @@ function wireEvents() {
         // flips to Un-shadow ban) instead of bouncing back to the list. Only the
         // Back button / browser back should leave this screen.
         await loadFlagDetail(target || flag);
+        const doneMsg = {
+          'flag-shadowban': 'Report shadow banned.',
+          'flag-release': 'Report released and made visible.',
+          'flag-delete-report': 'Report deleted.',
+        }[action];
+        window.ppToast?.success(doneMsg);
       } catch (err) {
         btn.disabled = false;
         btn.textContent = origText;
-        alert(`Error: ${err.message}`);
+        window.ppToast?.error(`Action failed: ${err.message}`);
       }
     }
   });

--- a/js/admin/main.js
+++ b/js/admin/main.js
@@ -13,7 +13,7 @@ import { fetchBannedPhrases, addBannedPhrase, removeBannedPhrase, toggleBannedPh
 import { renderPhrases } from './components/phrases.js?v=79051c31';
 import { loadWordlist, checkAgainstWordlist } from './api/wordlist.js?v=51c55965';
 import { fetchUserReports, fetchUserActivity } from './api/userDetail.js?v=916aedfc';
-import { renderUserDetail } from './components/userDetail.js?v=7025c758';
+import { renderUserDetail } from './components/userDetail.js?v=74450110';
 import { fetchAnalytics } from './api/analytics.js?v=1b3f4599';
 import { renderAnalytics } from './components/analytics.js?v=7d29939b';
 import { renderCacheStatus } from './components/cache-status.js?v=764c4d18';
@@ -551,11 +551,12 @@ function wireEvents() {
       btn.textContent = '...';
       try {
         await unbanUser(currentSession, btn.dataset.banId, { protonPulseUserId: btn.dataset.userid, clientId: btn.dataset.clientid });
+        window.ppToast?.success('User unbanned. Their reports are visible again.');
         loadUsers();
       } catch (err) {
         btn.disabled = false;
         btn.textContent = 'Unban';
-        alert(`Error: ${err.message}`);
+        window.ppToast?.error(err.message);
       }
     }
     if (action === 'view-user-detail') {
@@ -563,7 +564,7 @@ function wireEvents() {
       try {
         user = JSON.parse(btn.dataset.userobj);
       } catch (_) {
-        alert('Could not parse user data.');
+        window.ppToast?.error('Could not parse user data.');
         return;
       }
       loadUserDetail(user);
@@ -587,11 +588,12 @@ function wireEvents() {
       btn.textContent = '...';
       try {
         await unbanUser(currentSession, btn.dataset.banId, { protonPulseUserId: btn.dataset.userid, clientId: btn.dataset.clientid });
+        window.ppToast?.success('User unbanned.');
         activateTab('users');
       } catch (err) {
         btn.disabled = false;
         btn.textContent = 'Unban';
-        alert(`Error: ${err.message}`);
+        window.ppToast?.error(err.message);
       }
     }
   });
@@ -606,10 +608,11 @@ function wireEvents() {
     try {
       await unbanUser(currentSession, btn.dataset.banId, { protonPulseUserId: btn.dataset.userId, clientId: btn.dataset.clientId });
       btn.closest('tr').remove();
+      window.ppToast?.success('User unbanned.');
     } catch (err) {
       btn.disabled = false;
       btn.textContent = 'Unban';
-      alert(`Error: ${err.message}`);
+      window.ppToast?.error(err.message);
     }
   });
 
@@ -635,10 +638,11 @@ function wireEvents() {
         reason,
       });
       closeBanModal();
+      window.ppToast?.success(`Banned ${pendingBan.username || 'user'}.`);
       // Refresh the users list so the newly banned user shows Unban.
       loadUsers();
     } catch (err) {
-      alert(`Error: ${err.message}`);
+      window.ppToast?.error(err.message);
       confirmBtn.disabled = false;
       confirmBtn.textContent = 'Ban';
     }
@@ -667,8 +671,8 @@ function wireEvents() {
     const permissions = newAdminRole === 'super_admin' ? presetFor('super_admin') : newAdminPerms;
     try {
       await addAdmin(currentSession, { uuid, username, role, permissions });
-      status.textContent = `Added ${username}.`;
-      status.style.color = 'var(--green)';
+      window.ppToast?.success(`Added ${username} as admin.`);
+      status.textContent = '';
       document.getElementById('new-admin-uuid').value = '';
       document.getElementById('new-admin-username').value = '';
       newAdminRole = 'moderator';
@@ -676,8 +680,7 @@ function wireEvents() {
       syncNewAdminForm();
       loadAdmins();
     } catch (e) {
-      status.textContent = e.message;
-      status.style.color = 'var(--red)';
+      window.ppToast?.error(e.message);
     }
   });
 
@@ -704,7 +707,7 @@ function wireEvents() {
         await applyAdminChange(uuid, resolveRoleLabel('moderator', perms), perms);
       }
     } catch (err) {
-      alert(`Error: ${err.message}`);
+      window.ppToast?.error(err.message);
       if (uuid !== 'new') loadAdmins();
     }
   });
@@ -718,17 +721,18 @@ function wireEvents() {
       btn.disabled = true; btn.textContent = '...';
       try {
         await removeAdmin(currentSession, uuid);
+        window.ppToast?.success(`Removed ${btn.dataset.name} as admin.`);
         loadAdmins();
       } catch (err) {
         btn.disabled = false; btn.textContent = 'Remove';
-        alert(`Error: ${err.message}`);
+        window.ppToast?.error(err.message);
       }
     } else if (action === 'remove-perm') {
       try {
         const perms = removePermission(currentRowPerms(uuid), btn.dataset.perm);
         await applyAdminChange(uuid, resolveRoleLabel('moderator', perms), perms);
       } catch (err) {
-        alert(`Error: ${err.message}`);
+        window.ppToast?.error(err.message);
         if (uuid !== 'new') loadAdmins();
       }
     }
@@ -807,9 +811,10 @@ function wireEvents() {
       try {
         await removeBannedPhrase(currentSession, id);
         btn.closest('tr').remove();
+        window.ppToast?.success('Banned phrase removed.');
       } catch (err) {
         btn.disabled = false; btn.textContent = 'Remove';
-        alert(`Error: ${err.message}`);
+        window.ppToast?.error(err.message);
       }
     }
 
@@ -818,10 +823,11 @@ function wireEvents() {
       btn.disabled = true; btn.textContent = '...';
       try {
         await toggleBannedPhrase(currentSession, id, enabled);
+        window.ppToast?.success(enabled ? 'Phrase enabled.' : 'Phrase disabled.');
         loadPhrases();
       } catch (err) {
         btn.disabled = false;
-        alert(`Error: ${err.message}`);
+        window.ppToast?.error(err.message);
       }
     }
   });

--- a/js/app/api/votes.js
+++ b/js/app/api/votes.js
@@ -57,7 +57,7 @@ export async function castVote(appId, rKey, vote, upBtn, dnBtn) {
         method: 'DELETE',
         headers: { apikey: SB_KEY, Authorization: `Bearer ${SB_KEY}`, Prefer: 'return=minimal' },
       });
-    } catch { /* silently fail */ }
+    } catch { window.ppToast?.error('Could not update your vote. Check your connection.'); }
     return;
   }
 
@@ -86,7 +86,7 @@ export async function castVote(appId, rKey, vote, upBtn, dnBtn) {
         body: JSON.stringify({ vote }),
       });
     }
-  } catch { /* silently fail */ }
+  } catch { window.ppToast?.error('Could not save your vote. Check your connection.'); }
 }
 
 // - Helpers ------------------------------------------

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=eb8a974f';
+import { route } from '../router.js?v=efa84dd6';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=a8b12479';
+import { route } from '../router.js?v=c4509374';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=3ac9633a';
+import { route } from '../router.js?v=e6408adc';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=c4509374';
+import { route } from '../router.js?v=eb8a974f';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=f3272608';
+import { route } from '../router.js?v=24b3f49e';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=efa84dd6';
+import { route } from '../router.js?v=3ac9633a';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=e6408adc';
+import { route } from '../router.js?v=f3272608';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -6,12 +6,12 @@ import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.js?v=64d7ee9d';
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=0ed723fb';
-import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=f85fdd11';
-import { enhanceAuthorBlocks } from './author.js?v=16bb1a46';
+import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=6d4d6884';
+import { enhanceAuthorBlocks } from './author.js?v=b8542834';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=a44b0b02';
-import { loadSearchIndex, searchIndex } from './search.js?v=55c4c279';
+import { renderCard } from './report-card.js?v=a955b4e0';
+import { loadSearchIndex, searchIndex } from './search.js?v=8f0d7c0f';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';
@@ -103,9 +103,11 @@ function _showFlagModal(btn) {
       btn.classList.add('flagged');
       btn.title = 'Flagged for review';
       modal.remove();
+      window.ppToast?.success('Report flagged for review. Thanks for the heads-up.');
     } else {
       submitEl.textContent = 'Failed - try again';
       submitEl.disabled = false;
+      window.ppToast?.error('Could not flag the report. Please try again.');
     }
   });
 }

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=0ed723fb';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=6d4d6884';
-import { enhanceAuthorBlocks } from './author.js?v=a3d8d81d';
+import { enhanceAuthorBlocks } from './author.js?v=09a3a8a3';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=99bea4ed';
-import { loadSearchIndex, searchIndex } from './search.js?v=dc0b704a';
+import { renderCard } from './report-card.js?v=8199849f';
+import { loadSearchIndex, searchIndex } from './search.js?v=91907ef7';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=0ed723fb';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=f85fdd11';
-import { enhanceAuthorBlocks } from './author.js?v=1934bbfc';
+import { enhanceAuthorBlocks } from './author.js?v=16bb1a46';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=36dd2fd4';
-import { loadSearchIndex, searchIndex } from './search.js?v=ba3209c7';
+import { renderCard } from './report-card.js?v=a44b0b02';
+import { loadSearchIndex, searchIndex } from './search.js?v=55c4c279';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=0ed723fb';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=6d4d6884';
-import { enhanceAuthorBlocks } from './author.js?v=b8542834';
+import { enhanceAuthorBlocks } from './author.js?v=e0dee311';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=a955b4e0';
-import { loadSearchIndex, searchIndex } from './search.js?v=8f0d7c0f';
+import { renderCard } from './report-card.js?v=fc17ded0';
+import { loadSearchIndex, searchIndex } from './search.js?v=d2abd0b4';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=0ed723fb';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=6d4d6884';
-import { enhanceAuthorBlocks } from './author.js?v=660687a9';
+import { enhanceAuthorBlocks } from './author.js?v=a649ee85';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=fe7c60bd';
-import { loadSearchIndex, searchIndex } from './search.js?v=13827ba1';
+import { renderCard } from './report-card.js?v=08c806fb';
+import { loadSearchIndex, searchIndex } from './search.js?v=7d01b525';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';
@@ -492,17 +492,6 @@ export async function renderGamePage(appId) {
         </button>
       </div>`;
 
-    // Show a banner if the signed-in client already has a public report on this
-    // game (matched via client id on user_configs). No draft concept: upload means publish.
-    const myCid = getWebClientId();
-    const myPublished = nativeReports.find(r => r.clientId && r.clientId === myCid);
-    const myStatusBadge = myPublished ? `
-      <div class="my-config-banner my-config-banner--published" title="Your report for this game">
-        <span class="my-config-banner-dot"></span>
-        <span class="my-config-banner-label">Your report:</span>
-        <span class="my-config-banner-status">Published</span>
-      </div>` : '';
-
     el.innerHTML = `
       <div class="game-header">
         <div class="game-header-main">
@@ -515,7 +504,6 @@ export async function renderGamePage(appId) {
               &nbsp;/&nbsp; <strong>${configs.length}</strong> Pulse config${configs.length !== 1 ? 's' : ''}
               ${totalCommunityMinutes > 0 ? `&nbsp;/&nbsp; <strong>${fmtMinutes(totalCommunityMinutes)}</strong> community playtime (${totalSessionCount} session${totalSessionCount !== 1 ? 's' : ''})` : ''}
             </div>
-            ${myStatusBadge}
           </div>
           <img src="${STEAM_IMG(appId)}" data-appid="${appId}" alt="" onerror="window.__steamImgLoad(this)">
         </div>

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=0ed723fb';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=6d4d6884';
-import { enhanceAuthorBlocks } from './author.js?v=e0dee311';
+import { enhanceAuthorBlocks } from './author.js?v=660687a9';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=fc17ded0';
-import { loadSearchIndex, searchIndex } from './search.js?v=d2abd0b4';
+import { renderCard } from './report-card.js?v=fe7c60bd';
+import { loadSearchIndex, searchIndex } from './search.js?v=13827ba1';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=0ed723fb';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=6d4d6884';
-import { enhanceAuthorBlocks } from './author.js?v=a649ee85';
+import { enhanceAuthorBlocks } from './author.js?v=a3d8d81d';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=08c806fb';
-import { loadSearchIndex, searchIndex } from './search.js?v=7d01b525';
+import { renderCard } from './report-card.js?v=99bea4ed';
+import { loadSearchIndex, searchIndex } from './search.js?v=dc0b704a';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=55c4c279';
+import { loadSearchIndex, searchIndex } from './search.js?v=8f0d7c0f';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=8f0d7c0f';
+import { loadSearchIndex, searchIndex } from './search.js?v=d2abd0b4';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=ba3209c7';
+import { loadSearchIndex, searchIndex } from './search.js?v=55c4c279';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=dc0b704a';
+import { loadSearchIndex, searchIndex } from './search.js?v=91907ef7';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=13827ba1';
+import { loadSearchIndex, searchIndex } from './search.js?v=7d01b525';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=7d01b525';
+import { loadSearchIndex, searchIndex } from './search.js?v=dc0b704a';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=d2abd0b4';
+import { loadSearchIndex, searchIndex } from './search.js?v=13827ba1';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=660687a9';
+import { renderAuthorBlock } from './author.js?v=a649ee85';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=a3d8d81d';
+import { renderAuthorBlock } from './author.js?v=09a3a8a3';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=b8542834';
+import { renderAuthorBlock } from './author.js?v=e0dee311';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=16bb1a46';
+import { renderAuthorBlock } from './author.js?v=b8542834';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=1934bbfc';
+import { renderAuthorBlock } from './author.js?v=16bb1a46';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=e0dee311';
+import { renderAuthorBlock } from './author.js?v=660687a9';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=a649ee85';
+import { renderAuthorBlock } from './author.js?v=a3d8d81d';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=01c3d072';
+import { renderGamePage } from './game-page.js?v=99649303';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=c02da1b5';
+import { renderGamePage } from './game-page.js?v=4cea7c51';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=99649303';
+import { renderGamePage } from './game-page.js?v=c02da1b5';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=6b684f75';
+import { renderGamePage } from './game-page.js?v=fa355a8f';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=e0078aca';
+import { renderGamePage } from './game-page.js?v=6033169d';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=4cea7c51';
+import { renderGamePage } from './game-page.js?v=6b684f75';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=fa355a8f';
+import { renderGamePage } from './game-page.js?v=e0078aca';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=c4509374';
-import { wireSearch } from './components/search.js?v=8f0d7c0f';
+import { route } from './router.js?v=eb8a974f';
+import { wireSearch } from './components/search.js?v=d2abd0b4';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=eb8a974f';
-import { wireSearch } from './components/search.js?v=d2abd0b4';
+import { route } from './router.js?v=efa84dd6';
+import { wireSearch } from './components/search.js?v=13827ba1';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=f3272608';
-import { wireSearch } from './components/search.js?v=91907ef7';
+import { route } from './router.js?v=24b3f49e';
+import { wireSearch } from './components/search.js?v=b05fe84a';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=3ac9633a';
-import { wireSearch } from './components/search.js?v=7d01b525';
+import { route } from './router.js?v=e6408adc';
+import { wireSearch } from './components/search.js?v=dc0b704a';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=a8b12479';
-import { wireSearch } from './components/search.js?v=55c4c279';
+import { route } from './router.js?v=c4509374';
+import { wireSearch } from './components/search.js?v=8f0d7c0f';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=efa84dd6';
-import { wireSearch } from './components/search.js?v=13827ba1';
+import { route } from './router.js?v=3ac9633a';
+import { wireSearch } from './components/search.js?v=7d01b525';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=e6408adc';
-import { wireSearch } from './components/search.js?v=dc0b704a';
+import { route } from './router.js?v=f3272608';
+import { wireSearch } from './components/search.js?v=91907ef7';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=e0078aca';
-import { renderHomePage } from './components/home.js?v=07616ca3';
-import { renderSearchPage } from './components/search.js?v=91907ef7';
+import { renderGamePage } from './components/game-page.js?v=6033169d';
+import { renderHomePage } from './components/home.js?v=3ea431c7';
+import { renderSearchPage } from './components/search.js?v=b05fe84a';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=01c3d072';
-import { renderHomePage } from './components/home.js?v=eb98da03';
-import { renderSearchPage } from './components/search.js?v=55c4c279';
+import { renderGamePage } from './components/game-page.js?v=99649303';
+import { renderHomePage } from './components/home.js?v=b6a321cf';
+import { renderSearchPage } from './components/search.js?v=8f0d7c0f';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=6b684f75';
-import { renderHomePage } from './components/home.js?v=87d7b24a';
-import { renderSearchPage } from './components/search.js?v=7d01b525';
+import { renderGamePage } from './components/game-page.js?v=fa355a8f';
+import { renderHomePage } from './components/home.js?v=da5a38a8';
+import { renderSearchPage } from './components/search.js?v=dc0b704a';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=99649303';
-import { renderHomePage } from './components/home.js?v=b6a321cf';
-import { renderSearchPage } from './components/search.js?v=8f0d7c0f';
+import { renderGamePage } from './components/game-page.js?v=c02da1b5';
+import { renderHomePage } from './components/home.js?v=3a583a03';
+import { renderSearchPage } from './components/search.js?v=d2abd0b4';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=c02da1b5';
-import { renderHomePage } from './components/home.js?v=3a583a03';
-import { renderSearchPage } from './components/search.js?v=d2abd0b4';
+import { renderGamePage } from './components/game-page.js?v=4cea7c51';
+import { renderHomePage } from './components/home.js?v=7d3aa992';
+import { renderSearchPage } from './components/search.js?v=13827ba1';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=fa355a8f';
-import { renderHomePage } from './components/home.js?v=da5a38a8';
-import { renderSearchPage } from './components/search.js?v=dc0b704a';
+import { renderGamePage } from './components/game-page.js?v=e0078aca';
+import { renderHomePage } from './components/home.js?v=07616ca3';
+import { renderSearchPage } from './components/search.js?v=91907ef7';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=4cea7c51';
-import { renderHomePage } from './components/home.js?v=7d3aa992';
-import { renderSearchPage } from './components/search.js?v=13827ba1';
+import { renderGamePage } from './components/game-page.js?v=6b684f75';
+import { renderHomePage } from './components/home.js?v=87d7b24a';
+import { renderSearchPage } from './components/search.js?v=7d01b525';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/auth/main.js
+++ b/js/auth/main.js
@@ -40,7 +40,7 @@ import { SupaAuth } from '../shared/config.js?v=f6f2c00a';
       console.error('[auth] login error:', error);
       continueBtn.disabled = false;
       continueBtn.classList.remove('is-loading');
-      window.alert('Could not start Steam sign-in. Please try again.');
+      window.ppToast?.error('Could not start Steam sign-in. Please try again.');
     }
   });
 })();

--- a/js/index/main.js
+++ b/js/index/main.js
@@ -174,18 +174,20 @@ import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=85cf419
       }
     }
 
-    function wireFilter(btn, key) {
-      if (!btn) return;
-      btn.addEventListener('click', () => {
-        state[key] = !state[key];
-        btn.classList.toggle('pg-filter--active', state[key]);
-        btn.setAttribute('aria-pressed', String(state[key]));
-        shownCount = PAGE_SIZE; // restart paging when the filter changes
-        renderPopular();
-      });
+    // Rated / Not Rated are mutually exclusive (either-or): selecting one
+    // deselects the other, and exactly one is always active.
+    function selectFilter(key) {
+      state.rated = key === 'rated';
+      state.unrated = key === 'unrated';
+      ratedBtn?.classList.toggle('pg-filter--active', state.rated);
+      unratedBtn?.classList.toggle('pg-filter--active', state.unrated);
+      ratedBtn?.setAttribute('aria-pressed', String(state.rated));
+      unratedBtn?.setAttribute('aria-pressed', String(state.unrated));
+      shownCount = PAGE_SIZE; // restart paging when the filter changes
+      renderPopular();
     }
-    wireFilter(ratedBtn, 'rated');
-    wireFilter(unratedBtn, 'unrated');
+    ratedBtn?.addEventListener('click', () => selectFilter('rated'));
+    unratedBtn?.addEventListener('click', () => selectFilter('unrated'));
     renderPopular();
   } catch (err) {
     console.debug('[popular-games] failed to load most_played.json', { error: String(err) });

--- a/js/lib/toast.js
+++ b/js/lib/toast.js
@@ -1,0 +1,73 @@
+/**
+ * toast.js -- tiny shared feedback toasts for the web app.
+ *
+ * Loaded as a classic script on every page (after topbar.js), so both the ES
+ * module pages and the plain-script pages can call it the same way:
+ *
+ *   window.ppToast('Report submitted', { type: 'success' });
+ *   window.ppToast.success('Saved');
+ *   window.ppToast.error('Could not save -- try again');
+ *
+ * Toasts stack bottom-right, auto-dismiss, and can be closed manually. Errors
+ * stay up longer and use role="alert" so screen readers announce them.
+ */
+(function () {
+  const DEFAULT_TIMEOUT = 3500;
+  const ERROR_TIMEOUT = 6000;
+
+  function ensureContainer() {
+    let c = document.getElementById('pp-toast-container');
+    if (!c) {
+      c = document.createElement('div');
+      c.id = 'pp-toast-container';
+      c.className = 'pp-toast-container';
+      c.setAttribute('aria-live', 'polite');
+      document.body.appendChild(c);
+    }
+    return c;
+  }
+
+  function dismiss(el) {
+    if (!el || el._ppDismissed) return;
+    el._ppDismissed = true;
+    clearTimeout(el._ppTimer);
+    el.classList.remove('pp-toast--in');
+    el.classList.add('pp-toast--out');
+    setTimeout(() => el.remove(), 250);
+  }
+
+  function ppToast(message, opts) {
+    opts = opts || {};
+    const type = opts.type || 'info'; // 'success' | 'error' | 'info'
+    const timeout = opts.timeout != null ? opts.timeout : (type === 'error' ? ERROR_TIMEOUT : DEFAULT_TIMEOUT);
+    const container = ensureContainer();
+
+    const el = document.createElement('div');
+    el.className = `pp-toast pp-toast--${type}`;
+    el.setAttribute('role', type === 'error' ? 'alert' : 'status');
+
+    const msg = document.createElement('span');
+    msg.className = 'pp-toast-msg';
+    msg.textContent = String(message == null ? '' : message);
+    el.appendChild(msg);
+
+    const close = document.createElement('button');
+    close.type = 'button';
+    close.className = 'pp-toast-close';
+    close.setAttribute('aria-label', 'Dismiss');
+    close.innerHTML = '&times;';
+    close.addEventListener('click', () => dismiss(el));
+    el.appendChild(close);
+
+    container.appendChild(el);
+    requestAnimationFrame(() => el.classList.add('pp-toast--in'));
+    el._ppTimer = setTimeout(() => dismiss(el), timeout);
+    return el;
+  }
+
+  ppToast.success = (m, o) => ppToast(m, Object.assign({}, o, { type: 'success' }));
+  ppToast.error = (m, o) => ppToast(m, Object.assign({}, o, { type: 'error' }));
+  ppToast.info = (m, o) => ppToast(m, Object.assign({}, o, { type: 'info' }));
+
+  window.ppToast = ppToast;
+})();

--- a/js/lib/topbar.js
+++ b/js/lib/topbar.js
@@ -759,7 +759,9 @@
         if (avatarEl)  avatarEl.src = (user.user_metadata && user.user_metadata.avatar_url) || '';
         if (avatarEl)  avatarEl.alt = (user.user_metadata && user.user_metadata.name) || user.email || '';
         const rawName = (user.user_metadata && user.user_metadata.name) || user.email || '';
-        if (nameEl)    nameEl.textContent = rawName.length > 10 ? rawName.slice(0, 10) + '\u2026' : rawName;
+        // Set the full name; CSS (.auth-username) handles truncation, capping it
+        // on narrow viewports but showing it in full on desktop (>=1024px).
+        if (nameEl) { nameEl.textContent = rawName; nameEl.title = rawName; }
 
         // Show/hide the pre-rendered admin nav link based on admin status.
         checkIsAdmin(state.session).then(function (admin) {

--- a/js/profile/main.js
+++ b/js/profile/main.js
@@ -979,10 +979,9 @@ import { showEditCloudConfigModal, showEditReportModal } from './components/edit
   const myConfigsRefresh  = document.getElementById('my-configs-refresh-btn');
 
   function showMyConfigsStatus(msg, ok) {
-    if (!myConfigsStatus) return;
-    myConfigsStatus.textContent = msg;
-    myConfigsStatus.style.color = ok ? 'var(--green)' : 'var(--red)';
-    setTimeout(() => { myConfigsStatus.textContent = ''; }, 3000);
+    // Surface report actions (publish/unpublish/delete/update) through the
+    // shared toast so feedback is consistent with the rest of the site.
+    if (ok) window.ppToast?.success(msg); else window.ppToast?.error(msg);
   }
 
   function renderMyConfigs(rows) {

--- a/js/profile/main.js
+++ b/js/profile/main.js
@@ -1021,7 +1021,7 @@ import { showEditCloudConfigModal, showEditReportModal } from './components/edit
         // already have (proton version, launch options, hardware) and
         // validation enforces the rest before save
         row.cloud && row.unpublished
-          ? `<a class="profile-configs-action profile-configs-publish-btn" href="submit.html?app=${escapeHtml(String(row.app_id))}&fromCloud=1" target="_blank" rel="noopener">Publish</a>`
+          ? `<a class="profile-configs-action profile-configs-publish-btn" href="submit.html?app=${escapeHtml(String(row.app_id))}&fromCloud=1&return=profile.html" target="_blank" rel="noopener">Publish</a>`
           : '',
         row.published_id
           ? `<button type="button" class="profile-configs-action profile-configs-unpublish-btn" data-published-id="${escapeHtml(String(row.published_id))}">Unpublish</button>`
@@ -1030,9 +1030,9 @@ import { showEditCloudConfigModal, showEditReportModal } from './components/edit
         // pre-fill from user_configs). Cloud-only rows go to submit.html?fromCloud=1
         // where a Save button lets them update the draft without publishing.
         row.published_id
-          ? `<a class="profile-configs-action profile-configs-edit-btn" href="submit.html?app=${escapeHtml(String(row.app_id))}&edit=${escapeHtml(String(row.published_id))}" target="_blank" rel="noopener">Edit</a>`
+          ? `<a class="profile-configs-action profile-configs-edit-btn" href="submit.html?app=${escapeHtml(String(row.app_id))}&edit=${escapeHtml(String(row.published_id))}&return=profile.html" target="_blank" rel="noopener">Edit</a>`
           : row.cloud
-            ? `<a class="profile-configs-action profile-configs-edit-btn" href="submit.html?app=${escapeHtml(String(row.app_id))}&fromCloud=1" target="_blank" rel="noopener">Edit</a>`
+            ? `<a class="profile-configs-action profile-configs-edit-btn" href="submit.html?app=${escapeHtml(String(row.app_id))}&fromCloud=1&return=profile.html" target="_blank" rel="noopener">Edit</a>`
             : '',
         `<button type="button" class="profile-configs-action profile-configs-delete-btn" data-app-id="${escapeHtml(String(row.app_id))}">Delete</button>`,
       ].filter(Boolean).join('');

--- a/js/submit/main.js
+++ b/js/submit/main.js
@@ -345,15 +345,18 @@ import { SupaAuth } from '../shared/config.js?v=f6f2c00a';
         }
         if (result.ok) {
           if (statusEl) { statusEl.textContent = savedText; statusEl.style.color = 'var(--green)'; }
+          window.ppToast?.success(isEdit ? 'Changes saved.' : 'Report submitted. Thanks!');
           if (typeof window.ppTrack === 'function') window.ppTrack('report_submit', { app_id: String(appId), is_edit: isEdit });
           setTimeout(() => { window.location.href = `app.html#/app/${appId}`; }, 1200);
         } else {
           if (statusEl) { statusEl.textContent = result.error || 'Failed'; statusEl.style.color = 'var(--red)'; }
+          window.ppToast?.error(result.error || (isEdit ? 'Could not save changes.' : 'Could not submit the report.'));
           if (submitBtn) { submitBtn.disabled = false; submitBtn.textContent = isEdit ? 'Save Changes' : 'Submit'; }
         }
       } catch (err) {
         console.error('[submit] save failed:', err);
         if (statusEl) { statusEl.textContent = err.message || 'Failed'; statusEl.style.color = 'var(--red)'; }
+        window.ppToast?.error(`Submit failed: ${err.message || err}`);
         if (submitBtn) { submitBtn.disabled = false; submitBtn.textContent = isEdit ? 'Save Changes' : 'Submit'; }
       }
     });

--- a/js/submit/main.js
+++ b/js/submit/main.js
@@ -17,6 +17,13 @@ import { SupaAuth } from '../shared/config.js?v=f6f2c00a';
   // user_configs with form_responses)
   const fromCloud = !isEdit && params.get('fromCloud') === '1';
 
+  // Where to go after a successful save. Defaults to the game page, but the
+  // profile page passes return=profile.html so an edit returns to where the
+  // user came from. Sanitized to a same-origin relative .html path to avoid an
+  // open-redirect: no protocol, no //, must end in .html.
+  const returnRaw = params.get('return') || '';
+  const returnTo = /^[a-z0-9._-]+\.html(?:[?#].*)?$/i.test(returnRaw) ? returnRaw : null;
+
   if (!appId) {
     document.getElementById('game-title').textContent = 'No app ID provided';
     document.getElementById('submit-form-content').innerHTML =
@@ -293,7 +300,6 @@ import { SupaAuth } from '../shared/config.js?v=f6f2c00a';
       const statusEl = el.querySelector('#submit-status');
       const submitBtn = form.querySelector('button[type="submit"]');
       const savingText = isEdit ? 'Saving...' : 'Submitting...';
-      const savedText  = isEdit ? 'Saved! Redirecting...' : 'Report submitted! Redirecting...';
 
       el.querySelectorAll('.sf-question.sf-needs-answer, .sf-row.sf-needs-answer').forEach(q => q.classList.remove('sf-needs-answer'));
       const state = form._formState || {};
@@ -344,10 +350,11 @@ import { SupaAuth } from '../shared/config.js?v=f6f2c00a';
           result = await submitReport(appId, title, form);
         }
         if (result.ok) {
-          if (statusEl) { statusEl.textContent = savedText; statusEl.style.color = 'var(--green)'; }
+          // Toast is the single success confirmation now; no duplicate inline text.
           window.ppToast?.success(isEdit ? 'Changes saved.' : 'Report submitted. Thanks!');
           if (typeof window.ppTrack === 'function') window.ppTrack('report_submit', { app_id: String(appId), is_edit: isEdit });
-          setTimeout(() => { window.location.href = `app.html#/app/${appId}`; }, 1200);
+          const dest = returnTo || `app.html#/app/${appId}`;
+          setTimeout(() => { window.location.href = dest; }, 900);
         } else {
           if (statusEl) { statusEl.textContent = result.error || 'Failed'; statusEl.style.color = 'var(--red)'; }
           window.ppToast?.error(result.error || (isEdit ? 'Could not save changes.' : 'Could not submit the report.'));

--- a/options.html
+++ b/options.html
@@ -9,7 +9,7 @@
 <title>Site Options | Proton Pulse</title>
 <meta name="description" content="Browser-local display preferences for Proton Pulse, including an animations on/off toggle.">
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
+<link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
 <link rel="stylesheet" href="css/options/options.css?v=1df0e588">
 </head>
 <body>

--- a/options.html
+++ b/options.html
@@ -9,7 +9,7 @@
 <title>Site Options | Proton Pulse</title>
 <meta name="description" content="Browser-local display preferences for Proton Pulse, including an animations on/off toggle.">
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=54609d3c">
+<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
 <link rel="stylesheet" href="css/options/options.css?v=1df0e588">
 </head>
 <body>
@@ -57,6 +57,7 @@
 </footer>
 
 <script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/options/main.js?v=c4413624"></script>
 </body>
 </html>

--- a/options.html
+++ b/options.html
@@ -56,7 +56,7 @@
   <a href="terms.html">Terms</a>
 </footer>
 
-<script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/options/main.js?v=c4413624"></script>
 </body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -8,7 +8,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Link Decky Plugin — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=54609d3c">
+<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -8,7 +8,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Link Decky Plugin — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
+<link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/privacy.html
+++ b/privacy.html
@@ -8,7 +8,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Privacy Policy - Proton Pulse</title>
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
+<link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
 <link rel="stylesheet" href="css/index/index.css?v=857e41cf">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }

--- a/privacy.html
+++ b/privacy.html
@@ -8,7 +8,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Privacy Policy - Proton Pulse</title>
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=54609d3c">
+<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
 <link rel="stylesheet" href="css/index/index.css?v=857e41cf">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
@@ -85,5 +85,6 @@
 </div>
 
 <script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -84,7 +84,7 @@
 </div>
 </div>
 
-<script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -309,6 +309,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/profile/main.js?v=b7dc83bd"></script>
+<script type="module" src="js/profile/main.js?v=e87a73e0"></script>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -8,8 +8,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>My Account — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
-<link rel="stylesheet" href="css/profile/profile.css?v=f806abc2">
+<link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
+<link rel="stylesheet" href="css/profile/profile.css?v=b62240da">
 </head>
 <body>
 

--- a/profile.html
+++ b/profile.html
@@ -8,7 +8,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>My Account — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=54609d3c">
+<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
 <link rel="stylesheet" href="css/profile/profile.css?v=f806abc2">
 </head>
 <body>
@@ -308,6 +308,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/profile/main.js?v=462abf9f"></script>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -309,6 +309,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/profile/main.js?v=462abf9f"></script>
+<script type="module" src="js/profile/main.js?v=b7dc83bd"></script>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -307,7 +307,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/profile/main.js?v=462abf9f"></script>
 </body>

--- a/scoring.html
+++ b/scoring.html
@@ -9,7 +9,7 @@
 <title>How Scoring Works - Proton Pulse</title>
 <meta name="description" content="Transparent explanation of how Proton Pulse scores compatibility reports against your hardware. Identical algorithm to the Decky Loader plugin - one canonical source of truth, no hidden magic.">
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
+<link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/scoring.html
+++ b/scoring.html
@@ -9,7 +9,7 @@
 <title>How Scoring Works - Proton Pulse</title>
 <meta name="description" content="Transparent explanation of how Proton Pulse scores compatibility reports against your hardware. Identical algorithm to the Decky Loader plugin - one canonical source of truth, no hidden magic.">
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=54609d3c">
+<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
 <style>
 h1 {
   font-family: var(--font-display);
@@ -488,6 +488,7 @@ h2 small {
 </head>
 <body>
 <script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">
 

--- a/scoring.html
+++ b/scoring.html
@@ -487,7 +487,7 @@ h2 small {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/stats.html
+++ b/stats.html
@@ -9,7 +9,7 @@
 <title>Stats - Proton Pulse</title>
 <meta name="description" content="Aggregate compatibility stats for Steam on Linux: ratings, GPU and CPU breakdowns, OS distribution, Proton version share, and top-reported games. Filter by hardware to drill in.">
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
+<link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/stats.html
+++ b/stats.html
@@ -9,7 +9,7 @@
 <title>Stats - Proton Pulse</title>
 <meta name="description" content="Aggregate compatibility stats for Steam on Linux: ratings, GPU and CPU breakdowns, OS distribution, Proton version share, and top-reported games. Filter by hardware to drill in.">
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=54609d3c">
+<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
 <style>
 h1 {
   font-family: var(--font-display);
@@ -707,6 +707,7 @@ h2 {
 </head>
 <body>
 <script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">
 

--- a/stats.html
+++ b/stats.html
@@ -706,7 +706,7 @@ h2 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/submit.html
+++ b/submit.html
@@ -8,7 +8,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Submit Report — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
+<link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
 <link rel="stylesheet" href="css/app/app.css?v=2b4c5354">
 </head>
 <body>

--- a/submit.html
+++ b/submit.html
@@ -8,7 +8,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Submit Report — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=54609d3c">
+<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
 <link rel="stylesheet" href="css/app/app.css?v=2b4c5354">
 </head>
 <body>
@@ -16,6 +16,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">
   <div class="main-inner" style="max-width:860px">
@@ -46,6 +47,6 @@
   </div>
 </div>
 
-<script type="module" src="js/submit/main.js?v=5a30fc22"></script>
+<script type="module" src="js/submit/main.js?v=f8125fc1"></script>
 </body>
 </html>

--- a/submit.html
+++ b/submit.html
@@ -15,7 +15,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/submit.html
+++ b/submit.html
@@ -47,6 +47,6 @@
   </div>
 </div>
 
-<script type="module" src="js/submit/main.js?v=f8125fc1"></script>
+<script type="module" src="js/submit/main.js?v=ff057316"></script>
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -8,7 +8,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Terms of Service - Proton Pulse</title>
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
+<link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
 <link rel="stylesheet" href="css/index/index.css?v=857e41cf">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }

--- a/terms.html
+++ b/terms.html
@@ -8,7 +8,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Terms of Service - Proton Pulse</title>
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=54609d3c">
+<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
 <link rel="stylesheet" href="css/index/index.css?v=857e41cf">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
@@ -87,5 +87,6 @@
 </div>
 
 <script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -86,7 +86,7 @@
 </div>
 </div>
 
-<script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/tests/editReturn.test.js
+++ b/tests/editReturn.test.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+const read = (p) => fs.readFileSync(path.join(__dirname, '..', p), 'utf8');
+
+describe('edit/submit return-to-origin and toast-only success', () => {
+  const submitSrc = read('js/submit/main.js');
+  const profileSrc = read('js/profile/main.js');
+
+  test('profile edit/publish links pass return=profile.html', () => {
+    expect(profileSrc).toContain('&edit=${escapeHtml(String(row.published_id))}&return=profile.html');
+    expect(profileSrc).toContain('&fromCloud=1&return=profile.html');
+  });
+
+  test('submit reads and sanitizes the return param (no open redirect)', () => {
+    expect(submitSrc).toContain("const returnRaw = params.get('return') || ''");
+    // must be a same-origin relative .html path
+    expect(submitSrc).toContain('\\.html(?:[?#].*)?$/i.test(returnRaw)');
+  });
+
+  test('redirect prefers returnTo, falls back to the game page', () => {
+    expect(submitSrc).toContain('const dest = returnTo || `app.html#/app/${appId}`');
+    expect(submitSrc).toContain('window.location.href = dest');
+  });
+
+  test('success is shown only via toast, not a duplicate inline status', () => {
+    expect(submitSrc).toContain("window.ppToast?.success(isEdit ? 'Changes saved.'");
+    expect(submitSrc).not.toContain('savedText');
+  });
+});

--- a/tests/indexPopularFilters.test.js
+++ b/tests/indexPopularFilters.test.js
@@ -35,20 +35,18 @@ describe('index page popular games rating filters', () => {
     expect(indexSrc).toContain('const state = { rated: true, unrated: false }');
   });
 
-  test('render combines the two filters and supports any combination', () => {
+  test('render shows whichever single filter is active', () => {
     expect(indexSrc).toContain('...(state.rated ? ratedGames : [])');
     expect(indexSrc).toContain('...(state.unrated ? unratedGames : [])');
   });
 
-  test('each button toggles its own state independently', () => {
-    expect(indexSrc).toContain("state[key] = !state[key]");
-    expect(indexSrc).toContain("btn.classList.toggle('pg-filter--active', state[key])");
-    expect(indexSrc).toContain("wireFilter(ratedBtn, 'rated')");
-    expect(indexSrc).toContain("wireFilter(unratedBtn, 'unrated')");
-  });
-
-  test('shows an empty state when both filters are off', () => {
-    expect(indexSrc).toContain("class=\"pg-empty\"");
+  test('Rated / Not Rated are mutually exclusive (selecting one deselects the other)', () => {
+    expect(indexSrc).toContain("state.rated = key === 'rated'");
+    expect(indexSrc).toContain("state.unrated = key === 'unrated'");
+    expect(indexSrc).toContain("ratedBtn?.addEventListener('click', () => selectFilter('rated'))");
+    expect(indexSrc).toContain("unratedBtn?.addEventListener('click', () => selectFilter('unrated'))");
+    // old independent-toggle behavior is gone
+    expect(indexSrc).not.toContain('state[key] = !state[key]');
   });
 
   test('popular list pages with a load more button', () => {

--- a/tests/toast.test.js
+++ b/tests/toast.test.js
@@ -73,6 +73,13 @@ describe('actions give feedback via ppToast', () => {
     expect(src).toContain('window.ppToast?.error');
   });
 
+  test('admin and profile actions use toasts, not alert()', () => {
+    expect(read('js/admin/main.js')).not.toContain('alert(');
+    expect(read('js/admin/components/userDetail.js')).not.toContain('alert(');
+    expect(read('js/profile/main.js')).toContain('window.ppToast?.success(msg)');
+    expect(read('js/auth/main.js')).toContain('window.ppToast?.error');
+  });
+
   test('toast.js is in the gh-pages manifest', () => {
     expect(read('gh-pages-manifest.txt')).toContain('js/lib/toast.js');
   });

--- a/tests/toast.test.js
+++ b/tests/toast.test.js
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment jest-environment-jsdom
+ */
+const fs = require('fs');
+const path = require('path');
+
+beforeAll(() => {
+  const src = fs.readFileSync(path.join(__dirname, '..', 'js', 'lib', 'toast.js'), 'utf8');
+  window.eval(src); // toast.js is a classic IIFE that sets window.ppToast
+});
+
+describe('ppToast', () => {
+  beforeEach(() => { document.body.innerHTML = ''; });
+
+  test('exposes window.ppToast with success/error/info helpers', () => {
+    expect(typeof window.ppToast).toBe('function');
+    expect(typeof window.ppToast.success).toBe('function');
+    expect(typeof window.ppToast.error).toBe('function');
+    expect(typeof window.ppToast.info).toBe('function');
+  });
+
+  test('renders a toast with the message and the type class', () => {
+    window.ppToast.success('Saved');
+    const t = document.querySelector('.pp-toast');
+    expect(t).toBeTruthy();
+    expect(t.classList.contains('pp-toast--success')).toBe(true);
+    expect(t.querySelector('.pp-toast-msg').textContent).toBe('Saved');
+  });
+
+  test('error toasts announce via role=alert', () => {
+    window.ppToast.error('Boom');
+    expect(document.querySelector('.pp-toast--error').getAttribute('role')).toBe('alert');
+  });
+
+  test('the close button dismisses the toast', () => {
+    window.ppToast('hi');
+    const t = document.querySelector('.pp-toast');
+    t.querySelector('.pp-toast-close').click();
+    expect(t.classList.contains('pp-toast--out')).toBe(true);
+  });
+
+  test('multiple toasts stack inside one container', () => {
+    window.ppToast('a');
+    window.ppToast('b');
+    expect(document.querySelectorAll('#pp-toast-container .pp-toast').length).toBe(2);
+  });
+});
+
+describe('actions give feedback via ppToast', () => {
+  const read = (p) => fs.readFileSync(path.join(__dirname, '..', p), 'utf8');
+
+  test('flag report toasts on success and failure', () => {
+    const src = read('js/app/components/game-page.js');
+    expect(src).toContain("window.ppToast?.success('Report flagged for review");
+    expect(src).toContain('window.ppToast?.error(\'Could not flag the report');
+  });
+
+  test('submit report toasts on success and failure', () => {
+    const src = read('js/submit/main.js');
+    expect(src).toContain('window.ppToast?.success(');
+    expect(src).toContain('window.ppToast?.error(');
+  });
+
+  test('admin moderation actions toast on success and failure', () => {
+    const src = read('js/admin/main.js');
+    expect(src).toContain('window.ppToast?.success(doneMsg)');
+    expect(src).toContain('window.ppToast?.error(`Action failed');
+    expect(src).toContain("window.ppToast?.success('Flag entry deleted.')");
+  });
+
+  test('vote failures surface a toast', () => {
+    const src = read('js/app/api/votes.js');
+    expect(src).toContain('window.ppToast?.error');
+  });
+
+  test('toast.js is in the gh-pages manifest', () => {
+    expect(read('gh-pages-manifest.txt')).toContain('js/lib/toast.js');
+  });
+});


### PR DESCRIPTION
Batch reviewed on staging. User-facing feedback and a few UI fixes.

Action feedback (closes #65)
- New shared toast utility (js/lib/toast.js, window.ppToast) loaded on every page
- Wired into submit/edit report, flag, vote, all admin moderation (flag actions, status, ban/unban, add/remove admin, banned phrases, user-detail), profile report actions, and Steam sign-in
- Every alert() removed. Pattern: button shows in-progress, toast confirms the result, no duplicate inline text

Submit / edit
- After editing a report from your profile, you return to the profile (return= param, sanitized to same-origin .html), not the game page
- Dropped the inline "Saved!" text now that the toast covers success

Homepage
- Rated / Not Rated pills are now mutually exclusive (either-or), exactly one active

UI fixes
- Topbar username no longer truncated on desktop (it was a JS 10-char slice plus a CSS cap; both fixed)
- My Reports action buttons fit on one row (Rating column was hogging the fixed-layout table)
- Removed the "Your report: Published" badge on game pages

No new DB migrations in this batch. Full JS suite green (512 tests).