### PR TITLE
Staging batch: view controls, toast system, hardware edit, avatar fix

### DIFF
--- a/.github/workflows/discord-issues.yml
+++ b/.github/workflows/discord-issues.yml
@@ -1,0 +1,48 @@
+name: Discord Issues
+
+on:
+  issues:
+    types: [opened, closed, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to Discord
+        env:
+          WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_ISSUES }}
+        run: |
+          ACTION="${{ github.event.action }}"
+          case "$ACTION" in
+            opened)   COLOR=5763719 ;;
+            closed)   COLOR=15548997 ;;
+            reopened) COLOR=16776796 ;;
+            *)        COLOR=9807270 ;;
+          esac
+
+          TITLE=$(echo '${{ github.event.issue.title }}' | jq -Rs '.')
+          BODY=$(cat <<'ENDJQ'
+          {
+            "embeds": [{
+              "title": "Issue ACTIONPLACEHOLDER: #NUMPLACEHOLDER",
+              "description": TITLEPLACEHOLDER,
+              "url": "URLPLACEHOLDER",
+              "color": COLORPLACEHOLDER,
+              "footer": { "text": "USERPLACEHOLDER" }
+            }]
+          }
+          ENDJQ
+          )
+
+          BODY=$(echo "$BODY" | sed \
+            -e "s|ACTIONPLACEHOLDER|$ACTION|" \
+            -e "s|NUMPLACEHOLDER|${{ github.event.issue.number }}|" \
+            -e "s|TITLEPLACEHOLDER|$TITLE|" \
+            -e "s|URLPLACEHOLDER|${{ github.event.issue.html_url }}|" \
+            -e "s|COLORPLACEHOLDER|$COLOR|" \
+            -e "s|USERPLACEHOLDER|${{ github.event.sender.login }}|")
+
+          curl -s -H "Content-Type: application/json" -d "$BODY" "$WEBHOOK_URL"

--- a/.github/workflows/discord-pull-requests.yml
+++ b/.github/workflows/discord-pull-requests.yml
@@ -1,0 +1,57 @@
+name: Discord Pull Requests
+
+on:
+  pull_request:
+    types: [opened, closed, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to Discord
+        env:
+          WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_PULL_REQUESTS }}
+        run: |
+          ACTION="${{ github.event.action }}"
+          MERGED="${{ github.event.pull_request.merged }}"
+
+          if [ "$MERGED" = "true" ]; then
+            COLOR=10181046
+            LABEL="merged"
+          elif [ "$ACTION" = "opened" ]; then
+            COLOR=5763719
+            LABEL="opened"
+          elif [ "$ACTION" = "closed" ]; then
+            COLOR=15548997
+            LABEL="closed"
+          else
+            COLOR=16776796
+            LABEL="reopened"
+          fi
+
+          TITLE=$(echo '${{ github.event.pull_request.title }}' | jq -Rs '.')
+          BODY=$(cat <<'ENDJQ'
+          {
+            "embeds": [{
+              "title": "PR LABELPLACEHOLDER: #NUMPLACEHOLDER",
+              "description": TITLEPLACEHOLDER,
+              "url": "URLPLACEHOLDER",
+              "color": COLORPLACEHOLDER,
+              "footer": { "text": "USERPLACEHOLDER" }
+            }]
+          }
+          ENDJQ
+          )
+
+          BODY=$(echo "$BODY" | sed \
+            -e "s|LABELPLACEHOLDER|$LABEL|" \
+            -e "s|NUMPLACEHOLDER|${{ github.event.pull_request.number }}|" \
+            -e "s|TITLEPLACEHOLDER|$TITLE|" \
+            -e "s|URLPLACEHOLDER|${{ github.event.pull_request.html_url }}|" \
+            -e "s|COLORPLACEHOLDER|$COLOR|" \
+            -e "s|USERPLACEHOLDER|${{ github.event.sender.login }}|")
+
+          curl -s -H "Content-Type: application/json" -d "$BODY" "$WEBHOOK_URL"

--- a/.github/workflows/discord-releases.yml
+++ b/.github/workflows/discord-releases.yml
@@ -1,0 +1,39 @@
+name: Discord Releases
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to Discord
+        env:
+          WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_RELEASES }}
+        run: |
+          TAG=$(echo '${{ github.event.release.tag_name }}' | jq -Rs '.')
+          NAME=$(echo '${{ github.event.release.name }}' | jq -Rs '.')
+          BODY=$(cat <<'ENDJQ'
+          {
+            "embeds": [{
+              "title": "New release: TAGPLACEHOLDER",
+              "description": NAMEPLACEHOLDER,
+              "url": "URLPLACEHOLDER",
+              "color": 5763719,
+              "footer": { "text": "USERPLACEHOLDER" }
+            }]
+          }
+          ENDJQ
+          )
+
+          BODY=$(echo "$BODY" | sed \
+            -e "s|TAGPLACEHOLDER|${{ github.event.release.tag_name }}|" \
+            -e "s|NAMEPLACEHOLDER|$NAME|" \
+            -e "s|URLPLACEHOLDER|${{ github.event.release.html_url }}|" \
+            -e "s|USERPLACEHOLDER|${{ github.event.sender.login }}|")
+
+          curl -s -H "Content-Type: application/json" -d "$BODY" "$WEBHOOK_URL"

--- a/about.html
+++ b/about.html
@@ -12,7 +12,7 @@
 <meta property="og:description" content="What Proton Pulse is, how it compares to ProtonDB, and how the open data pipeline works.">
 <meta property="og:type" content="website">
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=54609d3c">
+<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
 <link rel="stylesheet" href="css/index/index.css?v=857e41cf">
 </head>
 <body>
@@ -192,6 +192,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/about/version.js?v=30fa403d"></script>
 </body>
 </html>

--- a/about.html
+++ b/about.html
@@ -12,7 +12,7 @@
 <meta property="og:description" content="What Proton Pulse is, how it compares to ProtonDB, and how the open data pipeline works.">
 <meta property="og:type" content="website">
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
+<link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
 <link rel="stylesheet" href="css/index/index.css?v=857e41cf">
 </head>
 <body>

--- a/about.html
+++ b/about.html
@@ -13,7 +13,7 @@
 <meta property="og:type" content="website">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
-<link rel="stylesheet" href="css/index/index.css?v=857e41cf">
+<link rel="stylesheet" href="css/index/index.css?v=0bdafa7e">
 </head>
 <body>
 

--- a/about.html
+++ b/about.html
@@ -191,7 +191,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/about/version.js?v=30fa403d"></script>
 </body>

--- a/admin.html
+++ b/admin.html
@@ -264,6 +264,6 @@
 <script src="js/lib/analytics.js?v=89bd7747"></script>
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/admin/main.js?v=97e00bd6"></script>
+<script type="module" src="js/admin/main.js?v=5bb293bb"></script>
 </body>
 </html>

--- a/admin.html
+++ b/admin.html
@@ -8,7 +8,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Admin — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
+<link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
 <link rel="stylesheet" href="css/admin/admin.css?v=ff268395">
 </head>
 <body>

--- a/admin.html
+++ b/admin.html
@@ -8,7 +8,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Admin — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=54609d3c">
+<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
 <link rel="stylesheet" href="css/admin/admin.css?v=ff268395">
 </head>
 <body>
@@ -263,6 +263,7 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/analytics.js?v=89bd7747"></script>
 <script src="js/lib/topbar.js?v=e210caf6"></script>
-<script type="module" src="js/admin/main.js?v=38cf6a5f"></script>
+<script src="js/lib/toast.js?v=7bb23014"></script>
+<script type="module" src="js/admin/main.js?v=97e00bd6"></script>
 </body>
 </html>

--- a/admin.html
+++ b/admin.html
@@ -262,7 +262,7 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/analytics.js?v=89bd7747"></script>
-<script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/admin/main.js?v=97e00bd6"></script>
 </body>

--- a/app.html
+++ b/app.html
@@ -13,7 +13,7 @@
 <meta property="og:type" content="website">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
-<link rel="stylesheet" href="css/app/app.css?v=27333665">
+<link rel="stylesheet" href="css/app/app.css?v=c7bfd836">
 </head>
 <body>
 
@@ -50,6 +50,6 @@
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=88b94c66"></script>
+<script type="module" src="js/app/main.js?v=89f78790"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -49,6 +49,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=e210caf6"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=42e28f80"></script>
+<script type="module" src="js/app/main.js?v=cf9177cc"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -13,7 +13,7 @@
 <meta property="og:type" content="website">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
-<link rel="stylesheet" href="css/app/app.css?v=6be7d31a">
+<link rel="stylesheet" href="css/app/app.css?v=ae4d65d4">
 </head>
 <body>
 
@@ -50,6 +50,6 @@
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=b3e446bc"></script>
+<script type="module" src="js/app/main.js?v=0b2f5622"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -50,6 +50,6 @@
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=b334f320"></script>
+<script type="module" src="js/app/main.js?v=30ea6172"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -13,7 +13,7 @@
 <meta property="og:type" content="website">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
-<link rel="stylesheet" href="css/app/app.css?v=2b4c5354">
+<link rel="stylesheet" href="css/app/app.css?v=6be7d31a">
 </head>
 <body>
 
@@ -50,6 +50,6 @@
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=f5e0002a"></script>
+<script type="module" src="js/app/main.js?v=b3e446bc"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -12,7 +12,7 @@
 <meta property="og:description" content="Browse merged ProtonDB community reports and hardware-scored Proton Pulse configs. Filter by GPU, driver, and Proton version. Searchable, filterable, and updated daily.">
 <meta property="og:type" content="website">
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=54609d3c">
+<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
 <link rel="stylesheet" href="css/app/app.css?v=2b4c5354">
 </head>
 <body>
@@ -48,7 +48,8 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=cf9177cc"></script>
+<script type="module" src="js/app/main.js?v=bf834cc8"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -13,7 +13,7 @@
 <meta property="og:type" content="website">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
-<link rel="stylesheet" href="css/app/app.css?v=ae4d65d4">
+<link rel="stylesheet" href="css/app/app.css?v=27333665">
 </head>
 <body>
 
@@ -50,6 +50,6 @@
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=8a9c5ca7"></script>
+<script type="module" src="js/app/main.js?v=b334f320"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -12,7 +12,7 @@
 <meta property="og:description" content="Browse merged ProtonDB community reports and hardware-scored Proton Pulse configs. Filter by GPU, driver, and Proton version. Searchable, filterable, and updated daily.">
 <meta property="og:type" content="website">
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
+<link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
 <link rel="stylesheet" href="css/app/app.css?v=2b4c5354">
 </head>
 <body>
@@ -50,6 +50,6 @@
 <script src="js/lib/topbar.js?v=e210caf6"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=bf834cc8"></script>
+<script type="module" src="js/app/main.js?v=a5b21752"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -50,6 +50,6 @@
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=4a5b4648"></script>
+<script type="module" src="js/app/main.js?v=f5e0002a"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -50,6 +50,6 @@
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=30ea6172"></script>
+<script type="module" src="js/app/main.js?v=bf1a17ca"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -50,6 +50,6 @@
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=bf1a17ca"></script>
+<script type="module" src="js/app/main.js?v=7a50791d"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -50,6 +50,6 @@
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=092b3942"></script>
+<script type="module" src="js/app/main.js?v=a55e9be4"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -50,6 +50,6 @@
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=0b2f5622"></script>
+<script type="module" src="js/app/main.js?v=502090b4"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -50,6 +50,6 @@
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=0d212e41"></script>
+<script type="module" src="js/app/main.js?v=88b94c66"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -50,6 +50,6 @@
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=502090b4"></script>
+<script type="module" src="js/app/main.js?v=8a9c5ca7"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -47,9 +47,9 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=a5b21752"></script>
+<script type="module" src="js/app/main.js?v=092b3942"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -50,6 +50,6 @@
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=a55e9be4"></script>
+<script type="module" src="js/app/main.js?v=4a5b4648"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -50,6 +50,6 @@
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=7a50791d"></script>
+<script type="module" src="js/app/main.js?v=0d212e41"></script>
 </body>
 </html>

--- a/auth.html
+++ b/auth.html
@@ -8,7 +8,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Sign In With Steam — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
+<link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/auth.html
+++ b/auth.html
@@ -68,6 +68,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script type="module" src="js/auth/main.js?v=0016214c"></script>
+<script src="js/lib/toast.js?v=7bb23014"></script>
+<script type="module" src="js/auth/main.js?v=461034e1"></script>
 </body>
 </html>

--- a/auth.html
+++ b/auth.html
@@ -8,7 +8,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Sign In With Steam — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=54609d3c">
+<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/confidence.html
+++ b/confidence.html
@@ -10,7 +10,7 @@
 <meta name="description" content="Per-report and per-game confidence breakdown showing exactly how Proton Pulse computed its trust score.">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
-<link rel="stylesheet" href="css/app/app.css?v=2b4c5354">
+<link rel="stylesheet" href="css/app/app.css?v=6be7d31a">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/confidence.html
+++ b/confidence.html
@@ -10,7 +10,7 @@
 <meta name="description" content="Per-report and per-game confidence breakdown showing exactly how Proton Pulse computed its trust score.">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
-<link rel="stylesheet" href="css/app/app.css?v=6be7d31a">
+<link rel="stylesheet" href="css/app/app.css?v=ae4d65d4">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/confidence.html
+++ b/confidence.html
@@ -10,7 +10,7 @@
 <meta name="description" content="Per-report and per-game confidence breakdown showing exactly how Proton Pulse computed its trust score.">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
-<link rel="stylesheet" href="css/app/app.css?v=27333665">
+<link rel="stylesheet" href="css/app/app.css?v=c7bfd836">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/confidence.html
+++ b/confidence.html
@@ -9,7 +9,7 @@
 <title>Confidence Breakdown - Proton Pulse</title>
 <meta name="description" content="Per-report and per-game confidence breakdown showing exactly how Proton Pulse computed its trust score.">
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=54609d3c">
+<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
 <link rel="stylesheet" href="css/app/app.css?v=2b4c5354">
 <style>
 h1 {
@@ -197,6 +197,7 @@ h1 {
 </head>
 <body>
 <script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">
 

--- a/confidence.html
+++ b/confidence.html
@@ -9,7 +9,7 @@
 <title>Confidence Breakdown - Proton Pulse</title>
 <meta name="description" content="Per-report and per-game confidence breakdown showing exactly how Proton Pulse computed its trust score.">
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
+<link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
 <link rel="stylesheet" href="css/app/app.css?v=2b4c5354">
 <style>
 h1 {

--- a/confidence.html
+++ b/confidence.html
@@ -10,7 +10,7 @@
 <meta name="description" content="Per-report and per-game confidence breakdown showing exactly how Proton Pulse computed its trust score.">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
-<link rel="stylesheet" href="css/app/app.css?v=ae4d65d4">
+<link rel="stylesheet" href="css/app/app.css?v=27333665">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/confidence.html
+++ b/confidence.html
@@ -196,7 +196,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/css/app/app.css
+++ b/css/app/app.css
@@ -1411,6 +1411,7 @@ a.card:active { transform: translateY(1px); }
 .vote-btn:hover { color: var(--text); border-color: var(--accent); }
 .vote-btn.vote-up.active { color: var(--accent); border-color: var(--accent); }
 .vote-btn.vote-dn.active { color: #c85050; border-color: #c85050; }
+.vote-btn:disabled { opacity: 0.35; cursor: default; pointer-events: none; }
 
 .tier-badge {
   flex-shrink: 0;

--- a/css/app/app.css
+++ b/css/app/app.css
@@ -2054,8 +2054,10 @@ a.card:active { transform: translateY(1px); }
   border-radius: 4px;
   transition: background .1s, color .1s, border-color .1s;
 }
-.home-size-btn:hover { background: var(--s2); color: var(--text); }
+.home-size-btn:hover:not(:disabled) { background: var(--s2); color: var(--text); }
 .home-size-btn.active { color: var(--accent); border-color: var(--accent); background: rgba(74,159,208,0.08); }
+.home-size-btn:disabled { opacity: 0.4; cursor: default; }
+.home-size-toggle--disabled { opacity: 0.6; }
 
 /* Card size preference. Medium matches the default desktop row; small is
    denser, large is roomier. Title/sub scale with the boxart. The size class

--- a/css/app/app.css
+++ b/css/app/app.css
@@ -1362,7 +1362,8 @@ a.card:active { transform: translateY(1px); }
   flex-direction: column;
   align-items: flex-end;
   gap: 5px;
-  min-width: 72px;
+  /* Wide enough to keep "Confidence: 100%" + the rating badge on one line. */
+  min-width: 150px;
   flex-shrink: 0;
 }
 /* Home feed activity cards: always-row pg-card-style layout */
@@ -1375,7 +1376,7 @@ a.card:active { transform: translateY(1px); }
 .activity-badge { flex-shrink: 0; font-size: 0.7rem; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; padding: 4px 10px; border-radius: 999px; white-space: nowrap; align-self: center; }
 /* card-rating-row now shows confidence pill (left) and rating badge (right)
    side-by-side in a horizontal row. Matches the plugin's "78% GOLD" layout */
-.card-rating-row { display: flex; flex-direction: row; align-items: center; gap: 6px; margin-top: 4px; flex-wrap: wrap; justify-content: flex-end; }
+.card-rating-row { display: flex; flex-direction: row; align-items: center; gap: 6px; margin-top: 4px; flex-wrap: nowrap; justify-content: flex-end; }
 /* Per-report confidence pill - square corners to match the rating badge
    alongside it. Round corners read like a status pill, square reads like a
    "fact" tile which is what confidence is */

--- a/css/app/app.css
+++ b/css/app/app.css
@@ -2037,6 +2037,41 @@ a.card:active { transform: translateY(1px); }
 }
 .home-layout-btn:hover { background: var(--s2); color: var(--text); }
 .home-layout-btn.active { color: var(--accent); border-color: var(--accent); background: rgba(74,159,208,0.08); }
+
+/* View controls row: card-size (S/M/L) + grid/list toggles together. */
+.home-view-controls { display: flex; align-items: center; gap: 10px; }
+.home-size-toggle { display: flex; gap: 4px; }
+.home-size-btn {
+  width: 28px;
+  padding: 5px 0;
+  background: var(--s1);
+  border: 1px solid var(--border2);
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  font-family: inherit;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background .1s, color .1s, border-color .1s;
+}
+.home-size-btn:hover { background: var(--s2); color: var(--text); }
+.home-size-btn.active { color: var(--accent); border-color: var(--accent); background: rgba(74,159,208,0.08); }
+
+/* Card size preference. Medium matches the default desktop row; small is
+   denser, large is roomier. Title/sub scale with the boxart. The size class
+   lives on the .cards container and overrides the responsive default. */
+.cards--sm .game-card-thumb { width: 100px; height: 47px; }
+.cards--md .game-card-thumb { width: 138px; height: 64px; }
+.cards--lg .game-card-thumb { width: 200px; height: 93px; }
+.cards--sm .game-card { gap: 12px; padding: 8px 12px 8px 8px; }
+.cards--lg .game-card { gap: 20px; padding: 14px 20px 14px 12px; }
+.cards--sm .game-card-title { font-size: 0.92rem; }
+.cards--lg .game-card-title { font-size: 1.12rem; }
+.cards--lg .game-card-sub { font-size: 0.85rem; }
+@media (max-width: 560px) {
+  /* Keep large from overwhelming small screens. */
+  .cards--lg .game-card-thumb { width: 150px; height: 70px; }
+}
 .home-tier-chips { display: flex; gap: 5px; flex-wrap: wrap; margin-bottom: 12px; }
 .home-tier-chip {
   padding: 4px 11px;

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -342,6 +342,96 @@
   background: rgba(10,12,16,0.22);
   color: #0a0c10;
 }
+/* View controls: S/M/L size + Grid/List toggle */
+.pg-view-controls { display: flex; align-items: center; gap: 10px; margin-left: auto; }
+.pg-size-toggle { display: flex; gap: 4px; }
+.pg-size-btn {
+  padding: 4px 9px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: border-color 0.12s, color 0.12s, background 0.12s;
+}
+.pg-size-btn:hover:not(:disabled) { background: var(--s2); color: var(--text); }
+.pg-size-btn.active { color: var(--accent); border-color: var(--accent); background: rgba(74,159,208,0.08); }
+.pg-size-btn:disabled { opacity: 0.4; cursor: default; }
+.pg-size-toggle--disabled { opacity: 0.6; }
+.pg-layout-toggle { display: flex; gap: 4px; }
+.pg-layout-btn {
+  padding: 4px 10px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: border-color 0.12s, color 0.12s, background 0.12s;
+}
+.pg-layout-btn:hover { background: var(--s2); color: var(--text); }
+.pg-layout-btn.active { color: var(--accent); border-color: var(--accent); background: rgba(74,159,208,0.08); }
+
+/* S/M/L card sizes */
+.pg-list--sm .pg-thumb { width: 68px; height: 32px; }
+.pg-list--sm .pg-card { gap: 10px; padding: 6px 10px 6px 6px; }
+.pg-list--sm .pg-title { font-size: 0.85rem; }
+.pg-list--md .pg-thumb { width: 92px; height: 43px; }
+.pg-list--lg .pg-thumb { width: 130px; height: 61px; }
+.pg-list--lg .pg-card { gap: 18px; padding: 10px 16px 10px 10px; }
+.pg-list--lg .pg-title { font-size: 1.05rem; }
+.pg-list--lg .pg-sub { font-size: 0.82rem; }
+@media (max-width: 600px) {
+  .pg-list--lg .pg-thumb { width: 100px; height: 47px; }
+}
+
+/* List mode */
+.pg-list--list-mode { gap: 2px !important; }
+.pg-list--list-mode .pg-card { display: none; }
+.pg-list-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  background: var(--s1);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  text-decoration: none;
+  color: var(--text);
+  transition: background .1s;
+  overflow: hidden;
+}
+.pg-list-row:hover { background: var(--s2); }
+.pg-list-tier {
+  flex-shrink: 0;
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 3px 8px;
+  border-radius: 3px;
+  min-width: 56px;
+  text-align: center;
+}
+.pg-list-title {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 0.9rem;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.pg-list-meta {
+  flex-shrink: 0;
+  font-size: 0.72rem;
+  color: var(--muted);
+  font-family: var(--mono);
+}
+
 .pg-empty {
   padding: 24px 14px;
   color: var(--muted);
@@ -634,4 +724,6 @@
   .explore-grid { grid-template-columns: 1fr; }
   .quick-actions { flex-direction: column; }
   .qa-link { justify-content: center; }
+  .pg-head { gap: 8px; }
+  .pg-view-controls { margin-left: 0; width: 100%; justify-content: flex-end; }
 }

--- a/css/profile/profile.css
+++ b/css/profile/profile.css
@@ -566,6 +566,12 @@
   font-weight: 600;
 }
 .profile-configs-table tbody tr:last-child td { border-bottom: none; }
+/* Rating values are short (gold / platinum / dash), so cap the column small.
+   The table is table-layout:fixed, so a wide Rating column was starving the
+   actions column and wrapping the View/Publish/Edit/Delete buttons onto two
+   rows. A narrow Rating column gives the actions room to stay on one line. */
+.profile-configs-table th:nth-child(2),
+.profile-configs-table td:nth-child(2) { width: 92px; }
 .profile-configs-table td.col-action,
 .profile-configs-table th.col-action {
   text-align: right;

--- a/css/profile/profile.css
+++ b/css/profile/profile.css
@@ -394,14 +394,11 @@
 }
 .profile-systems-table tbody tr:last-child td { border-bottom: none; }
 .profile-systems-table td.col-default,
-.profile-systems-table td.col-delete,
-.profile-systems-table td.col-edit,
+.profile-systems-table td.col-action,
 .profile-systems-table th.col-default,
-.profile-systems-table th.col-delete,
-.profile-systems-table th.col-edit {
+.profile-systems-table th.col-action {
   text-align: center;
   vertical-align: middle;
-  width: 80px;
 }
 /* Default column needs more room since the toggle now reserves space for
    the "Default" text whether or not the row is the current default (so the
@@ -434,42 +431,6 @@
   font-size: 0.72rem;
   color: var(--muted);
   line-height: 1.45;
-}
-.profile-systems-view-btn {
-  padding: 2px 8px;
-  background: none;
-  border: 1px solid var(--border2);
-  color: var(--muted);
-  font-size: 0.68rem;
-  font-family: inherit;
-  cursor: pointer;
-}
-.profile-systems-view-btn:hover {
-  color: var(--accent);
-  border-color: var(--accent);
-}
-.profile-systems-trash {
-  background: none;
-  border: none;
-  color: var(--muted);
-  font-size: 1rem;
-  cursor: pointer;
-  padding: 2px 6px;
-}
-.profile-systems-trash:hover { color: #c85050; }
-.profile-systems-edit-btn {
-  padding: 2px 8px;
-  background: none;
-  border: 1px solid var(--border2);
-  color: var(--muted);
-  font-size: 0.68rem;
-  font-family: inherit;
-  cursor: pointer;
-  border-radius: 3px;
-}
-.profile-systems-edit-btn:hover {
-  color: var(--accent);
-  border-color: var(--accent);
 }
 .profile-systems-default-toggle {
   display: inline-flex;

--- a/css/profile/profile.css
+++ b/css/profile/profile.css
@@ -394,18 +394,15 @@
 }
 .profile-systems-table tbody tr:last-child td { border-bottom: none; }
 .profile-systems-table td.col-default,
-.profile-systems-table td.col-action,
-.profile-systems-table th.col-default,
-.profile-systems-table th.col-action {
+.profile-systems-table th.col-default {
   text-align: center;
   vertical-align: middle;
-}
-/* Default column needs more room since the toggle now reserves space for
-   the "Default" text whether or not the row is the current default (so the
-   switches in every row line up vertically at the same x position) */
-.profile-systems-table td.col-default,
-.profile-systems-table th.col-default {
   width: 110px;
+}
+.profile-systems-table td.col-action,
+.profile-systems-table th.col-action {
+  vertical-align: middle;
+  white-space: nowrap;
 }
 .profile-systems-label-input {
   background: transparent;

--- a/css/profile/profile.css
+++ b/css/profile/profile.css
@@ -395,8 +395,10 @@
 .profile-systems-table tbody tr:last-child td { border-bottom: none; }
 .profile-systems-table td.col-default,
 .profile-systems-table td.col-delete,
+.profile-systems-table td.col-edit,
 .profile-systems-table th.col-default,
-.profile-systems-table th.col-delete {
+.profile-systems-table th.col-delete,
+.profile-systems-table th.col-edit {
   text-align: center;
   vertical-align: middle;
   width: 80px;
@@ -455,6 +457,20 @@
   padding: 2px 6px;
 }
 .profile-systems-trash:hover { color: #c85050; }
+.profile-systems-edit-btn {
+  padding: 2px 8px;
+  background: none;
+  border: 1px solid var(--border2);
+  color: var(--muted);
+  font-size: 0.68rem;
+  font-family: inherit;
+  cursor: pointer;
+  border-radius: 3px;
+}
+.profile-systems-edit-btn:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
 .profile-systems-default-toggle {
   display: inline-flex;
   align-items: center;

--- a/css/shared/site.css
+++ b/css/shared/site.css
@@ -1342,9 +1342,9 @@ html[data-motion="off"] .banner-atoms {
   white-space: nowrap;
   font-weight: 500;
 }
-@media (min-width: 1100px) { .auth-username { max-width: 220px; } }
-@media (min-width: 1400px) { .auth-username { max-width: 320px; } }
-@media (min-width: 1700px) { .auth-username { max-width: none; } }
+/* On desktop there's plenty of room in the topbar, so show the full username
+   instead of truncating it. */
+@media (min-width: 1024px) { .auth-username { max-width: none; overflow: visible; } }
 
 .auth-admin-navlink {
   color: #e88a8a !important;

--- a/css/shared/site.css
+++ b/css/shared/site.css
@@ -1729,3 +1729,56 @@ html[data-motion="off"] .banner-atoms {
   z-index: 10;
 }
 .copy-tooltip--show { opacity: 1; }
+
+/* ---- Toasts (js/lib/toast.js) -------------------------------------------
+   Transient action feedback. Stacks bottom-right, slides in/out, auto-dismiss.
+   Sits above modals/overlays. */
+.pp-toast-container {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  z-index: 100000;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: min(360px, calc(100vw - 32px));
+  pointer-events: none;
+}
+.pp-toast {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 11px 12px 11px 14px;
+  border-radius: 8px;
+  background: var(--s2);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--muted);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+  font-size: 0.88rem;
+  line-height: 1.4;
+  pointer-events: auto;
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+.pp-toast--in { opacity: 1; transform: translateY(0); }
+.pp-toast--out { opacity: 0; transform: translateY(8px); }
+.pp-toast--success { border-left-color: var(--green); }
+.pp-toast--error { border-left-color: var(--red); }
+.pp-toast--info { border-left-color: var(--accent); }
+.pp-toast-msg { flex: 1 1 auto; min-width: 0; word-wrap: break-word; }
+.pp-toast-close {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--muted);
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 2px;
+}
+.pp-toast-close:hover { color: var(--fg); }
+@media (max-width: 480px) {
+  .pp-toast-container { right: 10px; left: 10px; bottom: 10px; max-width: none; }
+}

--- a/game-stats.html
+++ b/game-stats.html
@@ -10,7 +10,7 @@
 <meta name="description" content="Per-game Proton compatibility analysis with confidence breakdown, monthly report trends, working status, version success rates, and proven launch options.">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
-<link rel="stylesheet" href="css/app/app.css?v=ae4d65d4">
+<link rel="stylesheet" href="css/app/app.css?v=27333665">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/game-stats.html
+++ b/game-stats.html
@@ -9,7 +9,7 @@
 <title>Game Stats - Proton Pulse</title>
 <meta name="description" content="Per-game Proton compatibility analysis with confidence breakdown, monthly report trends, working status, version success rates, and proven launch options.">
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
+<link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
 <link rel="stylesheet" href="css/app/app.css?v=2b4c5354">
 <style>
 h1 {

--- a/game-stats.html
+++ b/game-stats.html
@@ -10,7 +10,7 @@
 <meta name="description" content="Per-game Proton compatibility analysis with confidence breakdown, monthly report trends, working status, version success rates, and proven launch options.">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
-<link rel="stylesheet" href="css/app/app.css?v=27333665">
+<link rel="stylesheet" href="css/app/app.css?v=c7bfd836">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/game-stats.html
+++ b/game-stats.html
@@ -9,7 +9,7 @@
 <title>Game Stats - Proton Pulse</title>
 <meta name="description" content="Per-game Proton compatibility analysis with confidence breakdown, monthly report trends, working status, version success rates, and proven launch options.">
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=54609d3c">
+<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
 <link rel="stylesheet" href="css/app/app.css?v=2b4c5354">
 <style>
 h1 {
@@ -303,6 +303,7 @@ h1 {
 </head>
 <body>
 <script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">
 

--- a/game-stats.html
+++ b/game-stats.html
@@ -10,7 +10,7 @@
 <meta name="description" content="Per-game Proton compatibility analysis with confidence breakdown, monthly report trends, working status, version success rates, and proven launch options.">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
-<link rel="stylesheet" href="css/app/app.css?v=6be7d31a">
+<link rel="stylesheet" href="css/app/app.css?v=ae4d65d4">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/game-stats.html
+++ b/game-stats.html
@@ -10,7 +10,7 @@
 <meta name="description" content="Per-game Proton compatibility analysis with confidence breakdown, monthly report trends, working status, version success rates, and proven launch options.">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
-<link rel="stylesheet" href="css/app/app.css?v=2b4c5354">
+<link rel="stylesheet" href="css/app/app.css?v=6be7d31a">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/game-stats.html
+++ b/game-stats.html
@@ -302,7 +302,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/gh-pages-manifest.txt
+++ b/gh-pages-manifest.txt
@@ -85,6 +85,7 @@ js/lib/gpu-arch-detector.js
 js/lib/supabase-client.js
 js/lib/analytics.js
 js/lib/topbar.js
+js/lib/toast.js
 js/lib/gh-gist.js
 js/lib/gh-auth.js
 js/lib/scoring/gameStats.js

--- a/gh-pages-manifest.txt
+++ b/gh-pages-manifest.txt
@@ -104,3 +104,5 @@ gh-pages-exclude-manifest.txt
 js/about/version.js
 js/app/lib/card.js
 js/app/lib/steam-img.js
+system-edit.html
+js/profile/system-edit.js

--- a/index.html
+++ b/index.html
@@ -188,6 +188,6 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=e210caf6"></script>
-<script type="module" src="js/index/main.js?v=84692ed0"></script>
+<script type="module" src="js/index/main.js?v=76eff07f"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 <meta property="og:description" content="Stop copying and pasting launch flags. View weighted ProtonDB hardware scores, filter compatibility reports by your GPU and driver, and apply Proton launch options directly to your Steam Deck library.">
 <meta property="og:type" content="website">
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=54609d3c">
+<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
 <link rel="stylesheet" href="css/index/index.css?v=857e41cf">
 </head>
 <body>
@@ -188,6 +188,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/index/main.js?v=76eff07f"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 <meta property="og:type" content="website">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
-<link rel="stylesheet" href="css/index/index.css?v=857e41cf">
+<link rel="stylesheet" href="css/index/index.css?v=0bdafa7e">
 </head>
 <body>
 
@@ -168,6 +168,17 @@
           <button class="pg-filter pg-filter--active" id="pg-filter-rated" type="button" aria-pressed="true">Rated <span class="pg-filter-count" id="pg-rated-count">0</span></button>
           <button class="pg-filter" id="pg-filter-unrated" type="button" aria-pressed="false">Not Rated <span class="pg-filter-count" id="pg-unrated-count">0</span></button>
         </div>
+        <div class="pg-view-controls">
+          <div class="pg-size-toggle" id="pg-size-toggle" title="Card size">
+            <button class="pg-size-btn" data-size="sm" type="button" title="Small cards">S</button>
+            <button class="pg-size-btn" data-size="md" type="button" title="Medium cards">M</button>
+            <button class="pg-size-btn" data-size="lg" type="button" title="Large cards">L</button>
+          </div>
+          <div class="pg-layout-toggle">
+            <button class="pg-layout-btn active" data-layout="grid" title="Grid view">Grid</button>
+            <button class="pg-layout-btn" data-layout="list" title="List view">List</button>
+          </div>
+        </div>
       </div>
       <p class="popular-games-sub">Steam's most-played games and how they run on Linux through Proton.</p>
       <div class="pg-list" id="pg-list"></div>
@@ -189,6 +200,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/index/main.js?v=76eff07f"></script>
+<script type="module" src="js/index/main.js?v=ade17f5b"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 <meta property="og:description" content="Stop copying and pasting launch flags. View weighted ProtonDB hardware scores, filter compatibility reports by your GPU and driver, and apply Proton launch options directly to your Steam Deck library.">
 <meta property="og:type" content="website">
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
+<link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
 <link rel="stylesheet" href="css/index/index.css?v=857e41cf">
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -187,7 +187,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/index/main.js?v=76eff07f"></script>
 </body>

--- a/js/admin/components/userDetail.js
+++ b/js/admin/components/userDetail.js
@@ -249,9 +249,10 @@ export function renderUserDetail(user, reports, authEvents, { session, onBack, o
         btn.closest('tr').remove();
         const remaining = reportsWrap.querySelectorAll('tbody tr').length;
         el.querySelector('.user-detail-section:last-of-type .user-detail-count').textContent = `(${remaining})`;
+        window.ppToast?.success('Report deleted.');
       } catch (err) {
         btn.disabled = false;
-        alert(err.message);
+        window.ppToast?.error(err.message);
       }
     }
 
@@ -272,8 +273,9 @@ export function renderUserDetail(user, reports, authEvents, { session, onBack, o
             existing.remove();
           }
         }
+        window.ppToast?.success(hide ? 'Report hidden.' : 'Report restored.');
       } catch (err) {
-        alert(err.message);
+        window.ppToast?.error(err.message);
       } finally {
         btn.disabled = false;
       }
@@ -322,8 +324,9 @@ export function renderUserDetail(user, reports, authEvents, { session, onBack, o
       }
       editModal.hidden = true;
       editingId = null;
+      window.ppToast?.success('Report updated.');
     } catch (err) {
-      alert(err.message);
+      window.ppToast?.error(err.message);
     } finally {
       saveBtn.disabled = false;
     }

--- a/js/admin/main.js
+++ b/js/admin/main.js
@@ -446,10 +446,11 @@ function wireEvents() {
         if (target) target.status = newStatus;
         btn.disabled = false;
         btn.textContent = origText;
+        window.ppToast?.success(`Status set to ${STATUS_LABELS[newStatus] || newStatus}.`);
       } catch (err) {
         btn.disabled = false;
         btn.textContent = origText;
-        alert(`Error: ${err.message}`);
+        window.ppToast?.error(`Could not update status: ${err.message}`);
       }
     }
 
@@ -462,10 +463,11 @@ function wireEvents() {
         await deleteFlaggedReport(currentSession, id);
         flaggedRows = flaggedRows.filter(r => String(r.id) !== id);
         activateTab('flagged');
+        window.ppToast?.success('Flag entry deleted.');
       } catch (err) {
         btn.disabled = false;
         btn.textContent = 'Delete';
-        alert(`Error: ${err.message}`);
+        window.ppToast?.error(`Could not delete flag: ${err.message}`);
       }
     }
 
@@ -506,10 +508,16 @@ function wireEvents() {
         // flips to Un-shadow ban) instead of bouncing back to the list. Only the
         // Back button / browser back should leave this screen.
         await loadFlagDetail(target || flag);
+        const doneMsg = {
+          'flag-shadowban': 'Report shadow banned.',
+          'flag-release': 'Report released and made visible.',
+          'flag-delete-report': 'Report deleted.',
+        }[action];
+        window.ppToast?.success(doneMsg);
       } catch (err) {
         btn.disabled = false;
         btn.textContent = origText;
-        alert(`Error: ${err.message}`);
+        window.ppToast?.error(`Action failed: ${err.message}`);
       }
     }
   });

--- a/js/admin/main.js
+++ b/js/admin/main.js
@@ -13,7 +13,7 @@ import { fetchBannedPhrases, addBannedPhrase, removeBannedPhrase, toggleBannedPh
 import { renderPhrases } from './components/phrases.js?v=79051c31';
 import { loadWordlist, checkAgainstWordlist } from './api/wordlist.js?v=51c55965';
 import { fetchUserReports, fetchUserActivity } from './api/userDetail.js?v=916aedfc';
-import { renderUserDetail } from './components/userDetail.js?v=7025c758';
+import { renderUserDetail } from './components/userDetail.js?v=74450110';
 import { fetchAnalytics } from './api/analytics.js?v=1b3f4599';
 import { renderAnalytics } from './components/analytics.js?v=7d29939b';
 import { renderCacheStatus } from './components/cache-status.js?v=764c4d18';
@@ -551,11 +551,12 @@ function wireEvents() {
       btn.textContent = '...';
       try {
         await unbanUser(currentSession, btn.dataset.banId, { protonPulseUserId: btn.dataset.userid, clientId: btn.dataset.clientid });
+        window.ppToast?.success('User unbanned. Their reports are visible again.');
         loadUsers();
       } catch (err) {
         btn.disabled = false;
         btn.textContent = 'Unban';
-        alert(`Error: ${err.message}`);
+        window.ppToast?.error(err.message);
       }
     }
     if (action === 'view-user-detail') {
@@ -563,7 +564,7 @@ function wireEvents() {
       try {
         user = JSON.parse(btn.dataset.userobj);
       } catch (_) {
-        alert('Could not parse user data.');
+        window.ppToast?.error('Could not parse user data.');
         return;
       }
       loadUserDetail(user);
@@ -587,11 +588,12 @@ function wireEvents() {
       btn.textContent = '...';
       try {
         await unbanUser(currentSession, btn.dataset.banId, { protonPulseUserId: btn.dataset.userid, clientId: btn.dataset.clientid });
+        window.ppToast?.success('User unbanned.');
         activateTab('users');
       } catch (err) {
         btn.disabled = false;
         btn.textContent = 'Unban';
-        alert(`Error: ${err.message}`);
+        window.ppToast?.error(err.message);
       }
     }
   });
@@ -606,10 +608,11 @@ function wireEvents() {
     try {
       await unbanUser(currentSession, btn.dataset.banId, { protonPulseUserId: btn.dataset.userId, clientId: btn.dataset.clientId });
       btn.closest('tr').remove();
+      window.ppToast?.success('User unbanned.');
     } catch (err) {
       btn.disabled = false;
       btn.textContent = 'Unban';
-      alert(`Error: ${err.message}`);
+      window.ppToast?.error(err.message);
     }
   });
 
@@ -635,10 +638,11 @@ function wireEvents() {
         reason,
       });
       closeBanModal();
+      window.ppToast?.success(`Banned ${pendingBan.username || 'user'}.`);
       // Refresh the users list so the newly banned user shows Unban.
       loadUsers();
     } catch (err) {
-      alert(`Error: ${err.message}`);
+      window.ppToast?.error(err.message);
       confirmBtn.disabled = false;
       confirmBtn.textContent = 'Ban';
     }
@@ -667,8 +671,8 @@ function wireEvents() {
     const permissions = newAdminRole === 'super_admin' ? presetFor('super_admin') : newAdminPerms;
     try {
       await addAdmin(currentSession, { uuid, username, role, permissions });
-      status.textContent = `Added ${username}.`;
-      status.style.color = 'var(--green)';
+      window.ppToast?.success(`Added ${username} as admin.`);
+      status.textContent = '';
       document.getElementById('new-admin-uuid').value = '';
       document.getElementById('new-admin-username').value = '';
       newAdminRole = 'moderator';
@@ -676,8 +680,7 @@ function wireEvents() {
       syncNewAdminForm();
       loadAdmins();
     } catch (e) {
-      status.textContent = e.message;
-      status.style.color = 'var(--red)';
+      window.ppToast?.error(e.message);
     }
   });
 
@@ -704,7 +707,7 @@ function wireEvents() {
         await applyAdminChange(uuid, resolveRoleLabel('moderator', perms), perms);
       }
     } catch (err) {
-      alert(`Error: ${err.message}`);
+      window.ppToast?.error(err.message);
       if (uuid !== 'new') loadAdmins();
     }
   });
@@ -718,17 +721,18 @@ function wireEvents() {
       btn.disabled = true; btn.textContent = '...';
       try {
         await removeAdmin(currentSession, uuid);
+        window.ppToast?.success(`Removed ${btn.dataset.name} as admin.`);
         loadAdmins();
       } catch (err) {
         btn.disabled = false; btn.textContent = 'Remove';
-        alert(`Error: ${err.message}`);
+        window.ppToast?.error(err.message);
       }
     } else if (action === 'remove-perm') {
       try {
         const perms = removePermission(currentRowPerms(uuid), btn.dataset.perm);
         await applyAdminChange(uuid, resolveRoleLabel('moderator', perms), perms);
       } catch (err) {
-        alert(`Error: ${err.message}`);
+        window.ppToast?.error(err.message);
         if (uuid !== 'new') loadAdmins();
       }
     }
@@ -807,9 +811,10 @@ function wireEvents() {
       try {
         await removeBannedPhrase(currentSession, id);
         btn.closest('tr').remove();
+        window.ppToast?.success('Banned phrase removed.');
       } catch (err) {
         btn.disabled = false; btn.textContent = 'Remove';
-        alert(`Error: ${err.message}`);
+        window.ppToast?.error(err.message);
       }
     }
 
@@ -818,10 +823,11 @@ function wireEvents() {
       btn.disabled = true; btn.textContent = '...';
       try {
         await toggleBannedPhrase(currentSession, id, enabled);
+        window.ppToast?.success(enabled ? 'Phrase enabled.' : 'Phrase disabled.');
         loadPhrases();
       } catch (err) {
         btn.disabled = false;
-        alert(`Error: ${err.message}`);
+        window.ppToast?.error(err.message);
       }
     }
   });

--- a/js/app/api/supabase.js
+++ b/js/app/api/supabase.js
@@ -43,7 +43,7 @@ export async function fetchSupabase(appId) {
 export async function fetchNativeReports(appId) {
   try {
     const r = await fetch(
-      `${SB_URL}/user_configs?app_id=eq.${appId}&is_flagged=neq.true&select=id,client_id,app_id,title,cpu,gpu,gpu_driver,gpu_vendor,gpu_architecture,ram,os,kernel,proton_version,rating,duration,duration_minutes,notes,vram_mb,form_responses,config_key,game_owned,created_at,updated_at,source,is_flagged&order=created_at.desc`,
+      `${SB_URL}/user_configs?app_id=eq.${appId}&is_flagged=neq.true&select=id,client_id,proton_pulse_user_id,app_id,title,cpu,gpu,gpu_driver,gpu_vendor,gpu_architecture,ram,os,kernel,proton_version,rating,duration,duration_minutes,notes,vram_mb,form_responses,config_key,game_owned,created_at,updated_at,source,is_flagged&order=created_at.desc`,
       { headers: { apikey: SB_KEY, Authorization: `Bearer ${SB_KEY}` } }
     );
     if (!r.ok) return [];
@@ -59,6 +59,7 @@ export async function fetchNativeReports(appId) {
       reportId:          row.id ?? null,
       appId:             row.app_id,
       clientId:          row.client_id || '',
+      protonPulseUserId: row.proton_pulse_user_id || null,
       title:             row.title || `App ${row.app_id}`,
       cpu:               row.cpu || '',
       gpu:               row.gpu || '',

--- a/js/app/api/votes.js
+++ b/js/app/api/votes.js
@@ -57,7 +57,7 @@ export async function castVote(appId, rKey, vote, upBtn, dnBtn) {
         method: 'DELETE',
         headers: { apikey: SB_KEY, Authorization: `Bearer ${SB_KEY}`, Prefer: 'return=minimal' },
       });
-    } catch { /* silently fail */ }
+    } catch { window.ppToast?.error('Could not update your vote. Check your connection.'); }
     return;
   }
 
@@ -86,7 +86,7 @@ export async function castVote(appId, rKey, vote, upBtn, dnBtn) {
         body: JSON.stringify({ vote }),
       });
     }
-  } catch { /* silently fail */ }
+  } catch { window.ppToast?.error('Could not save your vote. Check your connection.'); }
 }
 
 // - Helpers ------------------------------------------

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=d090b376';
+import { route } from '../router.js?v=48d9a5a6';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=eb8a974f';
+import { route } from '../router.js?v=efa84dd6';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=a8b12479';
+import { route } from '../router.js?v=c4509374';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=9b2de161';
+import { route } from '../router.js?v=fd3a77b4';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=57139a22';
+import { route } from '../router.js?v=a9034569';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=a9034569';
+import { route } from '../router.js?v=d090b376';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=500a6d93';
+import { route } from '../router.js?v=33e6030c';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=3ac9633a';
+import { route } from '../router.js?v=e6408adc';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=24b3f49e';
+import { route } from '../router.js?v=500a6d93';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=48d9a5a6';
+import { route } from '../router.js?v=10be3483';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=c4509374';
+import { route } from '../router.js?v=eb8a974f';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=33e6030c';
+import { route } from '../router.js?v=7a1c5216';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=f3272608';
+import { route } from '../router.js?v=24b3f49e';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=8a580fa7';
+import { route } from '../router.js?v=9b2de161';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=7a1c5216';
+import { route } from '../router.js?v=57139a22';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=10be3483';
+import { route } from '../router.js?v=8a580fa7';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=efa84dd6';
+import { route } from '../router.js?v=3ac9633a';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=e6408adc';
+import { route } from '../router.js?v=f3272608';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -6,12 +6,12 @@ import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.js?v=64d7ee9d';
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=0ed723fb';
-import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=f85fdd11';
-import { enhanceAuthorBlocks } from './author.js?v=16bb1a46';
+import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=6d4d6884';
+import { enhanceAuthorBlocks } from './author.js?v=b8542834';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=a44b0b02';
-import { loadSearchIndex, searchIndex } from './search.js?v=55c4c279';
+import { renderCard } from './report-card.js?v=a955b4e0';
+import { loadSearchIndex, searchIndex } from './search.js?v=8f0d7c0f';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';
@@ -103,9 +103,11 @@ function _showFlagModal(btn) {
       btn.classList.add('flagged');
       btn.title = 'Flagged for review';
       modal.remove();
+      window.ppToast?.success('Report flagged for review. Thanks for the heads-up.');
     } else {
       submitEl.textContent = 'Failed - try again';
       submitEl.disabled = false;
+      window.ppToast?.error('Could not flag the report. Please try again.');
     }
   });
 }

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=0ed723fb';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=6d4d6884';
-import { enhanceAuthorBlocks } from './author.js?v=a3d8d81d';
+import { enhanceAuthorBlocks } from './author.js?v=09a3a8a3';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=99bea4ed';
-import { loadSearchIndex, searchIndex } from './search.js?v=dc0b704a';
+import { renderCard } from './report-card.js?v=8199849f';
+import { loadSearchIndex, searchIndex } from './search.js?v=91907ef7';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=0ed723fb';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=6d4d6884';
-import { enhanceAuthorBlocks } from './author.js?v=7ae63ced';
+import { enhanceAuthorBlocks } from './author.js?v=8a41019a';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=cb535d24';
-import { loadSearchIndex, searchIndex } from './search.js?v=92201e95';
+import { renderCard } from './report-card.js?v=21833112';
+import { loadSearchIndex, searchIndex } from './search.js?v=2674bffb';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=0ed723fb';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=f85fdd11';
-import { enhanceAuthorBlocks } from './author.js?v=1934bbfc';
+import { enhanceAuthorBlocks } from './author.js?v=16bb1a46';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=36dd2fd4';
-import { loadSearchIndex, searchIndex } from './search.js?v=ba3209c7';
+import { renderCard } from './report-card.js?v=a44b0b02';
+import { loadSearchIndex, searchIndex } from './search.js?v=55c4c279';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=0ed723fb';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=6d4d6884';
-import { enhanceAuthorBlocks } from './author.js?v=2aa15c2c';
+import { enhanceAuthorBlocks } from './author.js?v=c1bcd966';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=1300535b';
-import { loadSearchIndex, searchIndex } from './search.js?v=15a61f4c';
+import { renderCard } from './report-card.js?v=9e2ba078';
+import { loadSearchIndex, searchIndex } from './search.js?v=0250842f';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=0ed723fb';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=6d4d6884';
-import { enhanceAuthorBlocks } from './author.js?v=b8542834';
+import { enhanceAuthorBlocks } from './author.js?v=e0dee311';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=a955b4e0';
-import { loadSearchIndex, searchIndex } from './search.js?v=8f0d7c0f';
+import { renderCard } from './report-card.js?v=fc17ded0';
+import { loadSearchIndex, searchIndex } from './search.js?v=d2abd0b4';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=0ed723fb';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=6d4d6884';
-import { enhanceAuthorBlocks } from './author.js?v=5bbd039b';
+import { enhanceAuthorBlocks } from './author.js?v=7ae63ced';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=09d02d61';
-import { loadSearchIndex, searchIndex } from './search.js?v=7f526e87';
+import { renderCard } from './report-card.js?v=cb535d24';
+import { loadSearchIndex, searchIndex } from './search.js?v=92201e95';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=0ed723fb';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=6d4d6884';
-import { enhanceAuthorBlocks } from './author.js?v=660ccd06';
+import { enhanceAuthorBlocks } from './author.js?v=9e8624e0';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=d6ffc6dd';
-import { loadSearchIndex, searchIndex } from './search.js?v=b05fe84a';
+import { renderCard } from './report-card.js?v=5033a425';
+import { loadSearchIndex, searchIndex } from './search.js?v=78b89e87';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=0ed723fb';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=6d4d6884';
-import { enhanceAuthorBlocks } from './author.js?v=9e8624e0';
+import { enhanceAuthorBlocks } from './author.js?v=8a3708ef';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=5033a425';
-import { loadSearchIndex, searchIndex } from './search.js?v=78b89e87';
+import { renderCard } from './report-card.js?v=73316ec5';
+import { loadSearchIndex, searchIndex } from './search.js?v=d808f5db';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=0ed723fb';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=6d4d6884';
-import { enhanceAuthorBlocks } from './author.js?v=660687a9';
+import { enhanceAuthorBlocks } from './author.js?v=a649ee85';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=fe7c60bd';
-import { loadSearchIndex, searchIndex } from './search.js?v=13827ba1';
+import { renderCard } from './report-card.js?v=08c806fb';
+import { loadSearchIndex, searchIndex } from './search.js?v=7d01b525';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';
@@ -492,17 +492,6 @@ export async function renderGamePage(appId) {
         </button>
       </div>`;
 
-    // Show a banner if the signed-in client already has a public report on this
-    // game (matched via client id on user_configs). No draft concept: upload means publish.
-    const myCid = getWebClientId();
-    const myPublished = nativeReports.find(r => r.clientId && r.clientId === myCid);
-    const myStatusBadge = myPublished ? `
-      <div class="my-config-banner my-config-banner--published" title="Your report for this game">
-        <span class="my-config-banner-dot"></span>
-        <span class="my-config-banner-label">Your report:</span>
-        <span class="my-config-banner-status">Published</span>
-      </div>` : '';
-
     el.innerHTML = `
       <div class="game-header">
         <div class="game-header-main">
@@ -515,7 +504,6 @@ export async function renderGamePage(appId) {
               &nbsp;/&nbsp; <strong>${configs.length}</strong> Pulse config${configs.length !== 1 ? 's' : ''}
               ${totalCommunityMinutes > 0 ? `&nbsp;/&nbsp; <strong>${fmtMinutes(totalCommunityMinutes)}</strong> community playtime (${totalSessionCount} session${totalSessionCount !== 1 ? 's' : ''})` : ''}
             </div>
-            ${myStatusBadge}
           </div>
           <img src="${STEAM_IMG(appId)}" data-appid="${appId}" alt="" onerror="window.__steamImgLoad(this)">
         </div>

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=0ed723fb';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=6d4d6884';
-import { enhanceAuthorBlocks } from './author.js?v=8a41019a';
+import { enhanceAuthorBlocks } from './author.js?v=2aa15c2c';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=21833112';
-import { loadSearchIndex, searchIndex } from './search.js?v=2674bffb';
+import { renderCard } from './report-card.js?v=1300535b';
+import { loadSearchIndex, searchIndex } from './search.js?v=15a61f4c';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=0ed723fb';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=6d4d6884';
-import { enhanceAuthorBlocks } from './author.js?v=09a3a8a3';
+import { enhanceAuthorBlocks } from './author.js?v=660ccd06';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=8199849f';
-import { loadSearchIndex, searchIndex } from './search.js?v=91907ef7';
+import { renderCard } from './report-card.js?v=d6ffc6dd';
+import { loadSearchIndex, searchIndex } from './search.js?v=b05fe84a';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=621c68c5';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=6d4d6884';
-import { enhanceAuthorBlocks } from './author.js?v=1817c49a';
+import { enhanceAuthorBlocks } from './author.js?v=d1684398';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=f2beb91c';
-import { loadSearchIndex, searchIndex } from './search.js?v=1172debb';
+import { renderCard } from './report-card.js?v=b36c67c1';
+import { loadSearchIndex, searchIndex } from './search.js?v=ec18de56';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';
@@ -729,9 +729,20 @@ export async function renderGamePage(appId) {
         else if (b.dataset.reportJson) downloadJson(JSON.parse(b.dataset.reportJson), 'report');
       });
     });
+    const myClientId = getWebClientId();
+    el.querySelectorAll('.vote-btns').forEach(btns => {
+      const authorId = btns.dataset.authorId;
+      if (authorId && authorId === myClientId) {
+        btns.querySelectorAll('.vote-btn').forEach(b => {
+          b.disabled = true;
+          b.title = 'You cannot vote on your own report';
+        });
+      }
+    });
     el.querySelectorAll('.vote-btn').forEach(btn => {
       btn.addEventListener('click', e => {
         e.stopPropagation();
+        if (btn.disabled) return;
         const vote  = parseInt(btn.dataset.vote);
         const rKey  = btn.dataset.rkey;
         const aId   = btn.dataset.appid;

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=0ed723fb';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=6d4d6884';
-import { enhanceAuthorBlocks } from './author.js?v=c1bcd966';
+import { enhanceAuthorBlocks } from './author.js?v=d93b6467';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=9e2ba078';
-import { loadSearchIndex, searchIndex } from './search.js?v=0250842f';
+import { renderCard } from './report-card.js?v=dc7232d0';
+import { loadSearchIndex, searchIndex } from './search.js?v=e61e2ebb';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=0ed723fb';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=6d4d6884';
-import { enhanceAuthorBlocks } from './author.js?v=e0dee311';
+import { enhanceAuthorBlocks } from './author.js?v=660687a9';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=fc17ded0';
-import { loadSearchIndex, searchIndex } from './search.js?v=d2abd0b4';
+import { renderCard } from './report-card.js?v=fe7c60bd';
+import { loadSearchIndex, searchIndex } from './search.js?v=13827ba1';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=0ed723fb';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=6d4d6884';
-import { enhanceAuthorBlocks } from './author.js?v=8a3708ef';
+import { enhanceAuthorBlocks } from './author.js?v=5bbd039b';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=73316ec5';
-import { loadSearchIndex, searchIndex } from './search.js?v=d808f5db';
+import { renderCard } from './report-card.js?v=09d02d61';
+import { loadSearchIndex, searchIndex } from './search.js?v=7f526e87';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=0ed723fb';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=6d4d6884';
-import { enhanceAuthorBlocks } from './author.js?v=a649ee85';
+import { enhanceAuthorBlocks } from './author.js?v=a3d8d81d';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=08c806fb';
-import { loadSearchIndex, searchIndex } from './search.js?v=7d01b525';
+import { renderCard } from './report-card.js?v=99bea4ed';
+import { loadSearchIndex, searchIndex } from './search.js?v=dc0b704a';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -5,13 +5,13 @@ import { populateScoringTooltip, pulseTierFromReports, tierFromReports } from '.
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.js?v=64d7ee9d';
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
-import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=0ed723fb';
+import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=621c68c5';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=6d4d6884';
-import { enhanceAuthorBlocks } from './author.js?v=d93b6467';
+import { enhanceAuthorBlocks } from './author.js?v=1817c49a';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=dc7232d0';
-import { loadSearchIndex, searchIndex } from './search.js?v=e61e2ebb';
+import { renderCard } from './report-card.js?v=f2beb91c';
+import { loadSearchIndex, searchIndex } from './search.js?v=1172debb';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=55c4c279';
+import { loadSearchIndex, searchIndex } from './search.js?v=8f0d7c0f';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=1172debb';
+import { loadSearchIndex, searchIndex } from './search.js?v=ec18de56';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=8f0d7c0f';
+import { loadSearchIndex, searchIndex } from './search.js?v=d2abd0b4';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=ba3209c7';
+import { loadSearchIndex, searchIndex } from './search.js?v=55c4c279';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=15a61f4c';
+import { loadSearchIndex, searchIndex } from './search.js?v=0250842f';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=92201e95';
+import { loadSearchIndex, searchIndex } from './search.js?v=2674bffb';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=b05fe84a';
+import { loadSearchIndex, searchIndex } from './search.js?v=78b89e87';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';
@@ -256,21 +256,33 @@ export async function renderHomePage() {
       const loadMoreEl = document.getElementById('load-more-popular');
       if (!cardsEl) return;
       const initial = filtered.slice(0, PAGE_SIZE);
-      const newQueue = filtered.slice(PAGE_SIZE);
-      cardsEl.innerHTML = initial.map(g => renderGameCard({
-        href: `#/app/${g.appId}`, appId: g.appId, imgUrl: g.headerImage || undefined,
-        title: g.title,
-        sub: g.tier === 'pending' ? 'No reports yet · be the first' : _popularSub(g),
-        tier: g.tier || undefined, sourceLabel: 'Steam',
-      })).join('') || '<div class="state-box">No games match the current filters.</div>';
+      const queue = filtered.slice(PAGE_SIZE);
+      cardsEl.innerHTML = initial.map(_popularItemHtml).join('')
+        || '<div class="state-box">No games match the current filters.</div>';
       if (loadMoreEl) {
-        if (newQueue.length) {
+        if (queue.length) {
           loadMoreEl.innerHTML = _loadMoreBtn('popular');
-          loadMoreEl.querySelector('button').addEventListener('click', () => _appendCards('popular', newQueue));
+          loadMoreEl.querySelector('button').addEventListener('click', () => {
+            const batch = queue.splice(0, PAGE_SIZE);
+            cardsEl.insertAdjacentHTML('beforeend', batch.map(_popularItemHtml).join(''));
+            if (!queue.length) loadMoreEl.innerHTML = '';
+          });
         } else {
           loadMoreEl.innerHTML = initial.length ? _allShownNote(filtered.length) : '';
         }
       }
+    }
+
+    // Render a popular game honoring the current view type: a slim list row in
+    // List mode (same as recent reports), or a sized card in Grid mode.
+    function _popularItemHtml(g) {
+      if (currentLayout === 'list') return _listRowHtml(g);
+      return renderGameCard({
+        href: `#/app/${g.appId}`, appId: g.appId, imgUrl: g.headerImage || undefined,
+        title: g.title,
+        sub: g.tier === 'pending' ? 'No reports yet · be the first' : _popularSub(g),
+        tier: g.tier || undefined, sourceLabel: 'Steam',
+      });
     }
 
     function applyRecentFilters() {
@@ -348,14 +360,24 @@ export async function renderHomePage() {
       applyPopularFilters();
     });
 
+    // S/M/L only make sense for the card (grid) view; disable them in list mode.
+    function _setSizeEnabled(enabled) {
+      document.querySelectorAll('.home-size-btn').forEach(b => { b.disabled = !enabled; });
+      document.getElementById('home-size-toggle')?.classList.toggle('home-size-toggle--disabled', !enabled);
+    }
+
     document.querySelectorAll('.home-layout-btn').forEach(btn => {
       btn.addEventListener('click', () => {
         document.querySelectorAll('.home-layout-btn').forEach(b => b.classList.remove('active'));
         btn.classList.add('active');
         currentLayout = btn.dataset.layout;
-        const cardsEl = document.getElementById('cards-recent');
-        if (cardsEl) cardsEl.classList.toggle('home-cards-list', currentLayout === 'list');
+        const isList = currentLayout === 'list';
+        // List view applies to BOTH sections so they stay consistent.
+        document.getElementById('cards-recent')?.classList.toggle('home-cards-list', isList);
+        document.getElementById('cards-popular')?.classList.toggle('home-cards-list', isList);
+        _setSizeEnabled(!isList);
         applyRecentFilters();
+        applyPopularFilters();
       });
     });
 

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=78b89e87';
+import { loadSearchIndex, searchIndex } from './search.js?v=d808f5db';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';
@@ -104,26 +104,6 @@ function _loadMoreBtn(sectionId) {
 
 function _allShownNote(count) {
   return `<p class="home-results-note">Showing all ${count} result${count === 1 ? '' : 's'}</p>`;
-}
-
-function _appendCards(sectionId, queue) {
-  const cardsEl = document.getElementById(`cards-${sectionId}`);
-  const btnEl = document.getElementById(`load-more-${sectionId}`);
-  if (!cardsEl || !queue.length) { if (btnEl) btnEl.innerHTML = ''; return; }
-  const batch = queue.splice(0, PAGE_SIZE);
-  const html = sectionId === 'recent'
-    ? batch.map(_recentCardHtml).join('')
-    : batch.map(g => {
-        const tier = g.tier || String(g.rating || '').toLowerCase();
-        return renderGameCard({
-          href: `#/app/${g.appId}`, appId: g.appId, imgUrl: g.headerImage || undefined,
-          title: g.title,
-          sub: tier === 'pending' ? 'No reports yet · be the first' : _popularSub(g),
-          tier: tier || undefined, sourceLabel: 'Steam',
-        });
-      }).join('');
-  cardsEl.insertAdjacentHTML('beforeend', html);
-  if (!queue.length && btnEl) btnEl.innerHTML = '';
 }
 
 function _recentCardHtml(r) {
@@ -296,7 +276,12 @@ export async function renderHomePage() {
       if (loadMoreEl) {
         if (queue.length) {
           loadMoreEl.innerHTML = _loadMoreBtn('recent');
-          loadMoreEl.querySelector('button').addEventListener('click', () => _appendCards('recent', queue));
+          // Append with the same renderFn so load-more keeps the current view.
+          loadMoreEl.querySelector('button').addEventListener('click', () => {
+            const batch = queue.splice(0, PAGE_SIZE);
+            cardsEl.insertAdjacentHTML('beforeend', batch.map(renderFn).join(''));
+            if (!queue.length) loadMoreEl.innerHTML = '';
+          });
         } else {
           loadMoreEl.innerHTML = filtered.length ? _allShownNote(filtered.length) : '';
         }

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=7f526e87';
+import { loadSearchIndex, searchIndex } from './search.js?v=92201e95';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=2674bffb';
+import { loadSearchIndex, searchIndex } from './search.js?v=15a61f4c';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=dc0b704a';
+import { loadSearchIndex, searchIndex } from './search.js?v=91907ef7';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=13827ba1';
+import { loadSearchIndex, searchIndex } from './search.js?v=7d01b525';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=91907ef7';
+import { loadSearchIndex, searchIndex } from './search.js?v=b05fe84a';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';
@@ -198,9 +198,16 @@ export async function renderHomePage() {
             </div>
           </div>
         </div>
-        <div class="home-layout-toggle">
-          <button class="home-layout-btn active" data-layout="grid" title="Grid view">Grid</button>
-          <button class="home-layout-btn" data-layout="list" title="List view">List</button>
+        <div class="home-view-controls">
+          <div class="home-size-toggle" id="home-size-toggle" title="Card size">
+            <button class="home-size-btn" data-size="sm" type="button" title="Small cards">S</button>
+            <button class="home-size-btn" data-size="md" type="button" title="Medium cards">M</button>
+            <button class="home-size-btn" data-size="lg" type="button" title="Large cards">L</button>
+          </div>
+          <div class="home-layout-toggle">
+            <button class="home-layout-btn active" data-layout="grid" title="Grid view">Grid</button>
+            <button class="home-layout-btn" data-layout="list" title="List view">List</button>
+          </div>
         </div>
       </div>
       <p class="section-label" style="margin-bottom:10px">Recent Reports</p>
@@ -351,6 +358,29 @@ export async function renderHomePage() {
         applyRecentFilters();
       });
     });
+
+    // Card size (S/M/L) is a saved user preference. Applies the cards--<size>
+    // class to both card lists; default medium.
+    const SIZE_KEY = 'pp:grid-size';
+    const SIZES = ['sm', 'md', 'lg'];
+    function _savedSize() {
+      try { const s = localStorage.getItem(SIZE_KEY); return SIZES.includes(s) ? s : 'md'; } catch { return 'md'; }
+    }
+    function applyGridSize(size) {
+      ['cards-recent', 'cards-popular'].forEach(id => {
+        const el2 = document.getElementById(id);
+        if (el2) { SIZES.forEach(s => el2.classList.remove(`cards--${s}`)); el2.classList.add(`cards--${size}`); }
+      });
+      document.querySelectorAll('.home-size-btn').forEach(b => b.classList.toggle('active', b.dataset.size === size));
+    }
+    document.querySelectorAll('.home-size-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const size = btn.dataset.size;
+        try { localStorage.setItem(SIZE_KEY, size); } catch { /* ignore */ }
+        applyGridSize(size);
+      });
+    });
+    applyGridSize(_savedSize());
 
     applyRecentFilters();
     applyPopularFilters();

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=7d01b525';
+import { loadSearchIndex, searchIndex } from './search.js?v=dc0b704a';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=0250842f';
+import { loadSearchIndex, searchIndex } from './search.js?v=e61e2ebb';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=d2abd0b4';
+import { loadSearchIndex, searchIndex } from './search.js?v=13827ba1';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=e61e2ebb';
+import { loadSearchIndex, searchIndex } from './search.js?v=1172debb';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=d808f5db';
+import { loadSearchIndex, searchIndex } from './search.js?v=7f526e87';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';
@@ -351,16 +351,24 @@ export async function renderHomePage() {
       document.getElementById('home-size-toggle')?.classList.toggle('home-size-toggle--disabled', !enabled);
     }
 
+    // List/Grid is a saved user preference, like card size. Default grid.
+    const LAYOUT_KEY = 'pp:grid-layout';
+    function _savedLayout() {
+      try { const l = localStorage.getItem(LAYOUT_KEY); return (l === 'list' || l === 'grid') ? l : 'grid'; } catch { return 'grid'; }
+    }
+    function applyLayout(layout) {
+      currentLayout = layout;
+      const isList = layout === 'list';
+      document.querySelectorAll('.home-layout-btn').forEach(b => b.classList.toggle('active', b.dataset.layout === layout));
+      // List view applies to BOTH sections so they stay consistent.
+      document.getElementById('cards-recent')?.classList.toggle('home-cards-list', isList);
+      document.getElementById('cards-popular')?.classList.toggle('home-cards-list', isList);
+      _setSizeEnabled(!isList);
+    }
     document.querySelectorAll('.home-layout-btn').forEach(btn => {
       btn.addEventListener('click', () => {
-        document.querySelectorAll('.home-layout-btn').forEach(b => b.classList.remove('active'));
-        btn.classList.add('active');
-        currentLayout = btn.dataset.layout;
-        const isList = currentLayout === 'list';
-        // List view applies to BOTH sections so they stay consistent.
-        document.getElementById('cards-recent')?.classList.toggle('home-cards-list', isList);
-        document.getElementById('cards-popular')?.classList.toggle('home-cards-list', isList);
-        _setSizeEnabled(!isList);
+        try { localStorage.setItem(LAYOUT_KEY, btn.dataset.layout); } catch { /* ignore */ }
+        applyLayout(btn.dataset.layout);
         applyRecentFilters();
         applyPopularFilters();
       });
@@ -388,6 +396,7 @@ export async function renderHomePage() {
       });
     });
     applyGridSize(_savedSize());
+    applyLayout(_savedLayout()); // restore saved list/grid before first render
 
     applyRecentFilters();
     applyPopularFilters();

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=660687a9';
+import { renderAuthorBlock } from './author.js?v=a649ee85';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=1817c49a';
+import { renderAuthorBlock } from './author.js?v=d1684398';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';
@@ -66,7 +66,7 @@ export function renderCard(r, votes, userVotes = {}, configPlaytimeTotals = []) 
           <a class="confidence-pill conf-link" href="confidence.html?app=${r.appId}${r.reportId != null ? '&report=' + r.reportId : '&ts=' + (r.timestamp || '')}" onclick="event.stopPropagation()" title="See the factor-by-factor breakdown of how this confidence was computed" style="background:${confColor(confPct / 10)};color:${confTextColor(confPct / 10)}">Confidence: ${confPct}%</a>
           <span class="rating" style="background:${rc};color:${rt}">${r.rating || '?'}</span>
         </div>
-        <div class="vote-btns">
+        <div class="vote-btns" data-author-id="${esc(r.clientId || '')}">
           <button class="vote-btn vote-up${userVote === 1 ? ' active' : ''}" data-vote="1" data-rkey="${esc(rKey)}" data-appid="${r.appId}" title="Helpful"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M1 21h4V9H1v12zm22-11c0-1.1-.9-2-2-2h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 1 7.59 7.59C7.22 7.95 7 8.45 7 9v10c0 1.1.9 2 2 2h9c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-2z"/></svg><span class="vote-count">${v.up}</span></button>
           <button class="vote-btn vote-dn${userVote === -1 ? ' active' : ''}" data-vote="-1" data-rkey="${esc(rKey)}" data-appid="${r.appId}" title="Not helpful"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" style="transform:scaleY(-1)"><path d="M1 21h4V9H1v12zm22-11c0-1.1-.9-2-2-2h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 1 7.59 7.59C7.22 7.95 7 8.45 7 9v10c0 1.1.9 2 2 2h9c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-2z"/></svg><span class="vote-count">${v.down}</span></button>
         </div>

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=5bbd039b';
+import { renderAuthorBlock } from './author.js?v=7ae63ced';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=660ccd06';
+import { renderAuthorBlock } from './author.js?v=9e8624e0';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=a3d8d81d';
+import { renderAuthorBlock } from './author.js?v=09a3a8a3';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=b8542834';
+import { renderAuthorBlock } from './author.js?v=e0dee311';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=2aa15c2c';
+import { renderAuthorBlock } from './author.js?v=c1bcd966';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=9e8624e0';
+import { renderAuthorBlock } from './author.js?v=8a3708ef';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=09a3a8a3';
+import { renderAuthorBlock } from './author.js?v=660ccd06';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=16bb1a46';
+import { renderAuthorBlock } from './author.js?v=b8542834';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=7ae63ced';
+import { renderAuthorBlock } from './author.js?v=8a41019a';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=1934bbfc';
+import { renderAuthorBlock } from './author.js?v=16bb1a46';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=8a41019a';
+import { renderAuthorBlock } from './author.js?v=2aa15c2c';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=e0dee311';
+import { renderAuthorBlock } from './author.js?v=660687a9';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=d93b6467';
+import { renderAuthorBlock } from './author.js?v=1817c49a';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=a649ee85';
+import { renderAuthorBlock } from './author.js?v=a3d8d81d';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=8a3708ef';
+import { renderAuthorBlock } from './author.js?v=5bbd039b';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=c1bcd966';
+import { renderAuthorBlock } from './author.js?v=d93b6467';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=9fb38e4a';
+import { renderGamePage } from './game-page.js?v=3a30f855';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=01c3d072';
+import { renderGamePage } from './game-page.js?v=99649303';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=e677c617';
+import { renderGamePage } from './game-page.js?v=07bd2f5e';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=c02da1b5';
+import { renderGamePage } from './game-page.js?v=4cea7c51';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=3a30f855';
+import { renderGamePage } from './game-page.js?v=ee5b5152';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=99649303';
+import { renderGamePage } from './game-page.js?v=c02da1b5';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=072af6a7';
+import { renderGamePage } from './game-page.js?v=1078e992';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=ee5b5152';
+import { renderGamePage } from './game-page.js?v=f6f0a94f';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=6033169d';
+import { renderGamePage } from './game-page.js?v=072af6a7';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=6b684f75';
+import { renderGamePage } from './game-page.js?v=fa355a8f';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=e0078aca';
+import { renderGamePage } from './game-page.js?v=6033169d';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=1078e992';
+import { renderGamePage } from './game-page.js?v=90bfaf30';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=f6f0a94f';
+import { renderGamePage } from './game-page.js?v=d9f89b53';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=4cea7c51';
+import { renderGamePage } from './game-page.js?v=6b684f75';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=aa4f014b';
+import { renderGamePage } from './game-page.js?v=e677c617';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=fa355a8f';
+import { renderGamePage } from './game-page.js?v=e0078aca';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=d9f89b53';
+import { renderGamePage } from './game-page.js?v=aa4f014b';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=90bfaf30';
+import { renderGamePage } from './game-page.js?v=9fb38e4a';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=c4509374';
-import { wireSearch } from './components/search.js?v=8f0d7c0f';
+import { route } from './router.js?v=eb8a974f';
+import { wireSearch } from './components/search.js?v=d2abd0b4';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=eb8a974f';
-import { wireSearch } from './components/search.js?v=d2abd0b4';
+import { route } from './router.js?v=efa84dd6';
+import { wireSearch } from './components/search.js?v=13827ba1';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=f3272608';
-import { wireSearch } from './components/search.js?v=91907ef7';
+import { route } from './router.js?v=24b3f49e';
+import { wireSearch } from './components/search.js?v=b05fe84a';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=3ac9633a';
-import { wireSearch } from './components/search.js?v=7d01b525';
+import { route } from './router.js?v=e6408adc';
+import { wireSearch } from './components/search.js?v=dc0b704a';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=24b3f49e';
-import { wireSearch } from './components/search.js?v=b05fe84a';
+import { route } from './router.js?v=500a6d93';
+import { wireSearch } from './components/search.js?v=78b89e87';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=33e6030c';
-import { wireSearch } from './components/search.js?v=d808f5db';
+import { route } from './router.js?v=7a1c5216';
+import { wireSearch } from './components/search.js?v=7f526e87';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=a9034569';
-import { wireSearch } from './components/search.js?v=92bfd5c9';
+import { route } from './router.js?v=d090b376';
+import { wireSearch } from './components/search.js?v=7a168eb2';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=a8b12479';
-import { wireSearch } from './components/search.js?v=55c4c279';
+import { route } from './router.js?v=c4509374';
+import { wireSearch } from './components/search.js?v=8f0d7c0f';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=9b2de161';
-import { wireSearch } from './components/search.js?v=7ed73f95';
+import { route } from './router.js?v=fd3a77b4';
+import { wireSearch } from './components/search.js?v=bd52aea7';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=57139a22';
-import { wireSearch } from './components/search.js?v=92201e95';
+import { route } from './router.js?v=a9034569';
+import { wireSearch } from './components/search.js?v=92bfd5c9';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=d090b376';
-import { wireSearch } from './components/search.js?v=7a168eb2';
+import { route } from './router.js?v=48d9a5a6';
+import { wireSearch } from './components/search.js?v=0250842f';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=48d9a5a6';
-import { wireSearch } from './components/search.js?v=0250842f';
+import { route } from './router.js?v=10be3483';
+import { wireSearch } from './components/search.js?v=e61e2ebb';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=500a6d93';
-import { wireSearch } from './components/search.js?v=78b89e87';
+import { route } from './router.js?v=33e6030c';
+import { wireSearch } from './components/search.js?v=d808f5db';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=10be3483';
-import { wireSearch } from './components/search.js?v=e61e2ebb';
+import { route } from './router.js?v=8a580fa7';
+import { wireSearch } from './components/search.js?v=1172debb';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=efa84dd6';
-import { wireSearch } from './components/search.js?v=13827ba1';
+import { route } from './router.js?v=3ac9633a';
+import { wireSearch } from './components/search.js?v=7d01b525';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=8a580fa7';
-import { wireSearch } from './components/search.js?v=1172debb';
+import { route } from './router.js?v=9b2de161';
+import { wireSearch } from './components/search.js?v=7ed73f95';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=7a1c5216';
-import { wireSearch } from './components/search.js?v=7f526e87';
+import { route } from './router.js?v=57139a22';
+import { wireSearch } from './components/search.js?v=92201e95';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=e6408adc';
-import { wireSearch } from './components/search.js?v=dc0b704a';
+import { route } from './router.js?v=f3272608';
+import { wireSearch } from './components/search.js?v=91907ef7';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=e677c617';
-import { renderHomePage } from './components/home.js?v=dfe38326';
-import { renderSearchPage } from './components/search.js?v=7ed73f95';
+import { renderGamePage } from './components/game-page.js?v=07bd2f5e';
+import { renderHomePage } from './components/home.js?v=8c7fea01';
+import { renderSearchPage } from './components/search.js?v=bd52aea7';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=e0078aca';
-import { renderHomePage } from './components/home.js?v=07616ca3';
-import { renderSearchPage } from './components/search.js?v=91907ef7';
+import { renderGamePage } from './components/game-page.js?v=6033169d';
+import { renderHomePage } from './components/home.js?v=3ea431c7';
+import { renderSearchPage } from './components/search.js?v=b05fe84a';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=3a30f855';
-import { renderHomePage } from './components/home.js?v=5f4e4317';
-import { renderSearchPage } from './components/search.js?v=92bfd5c9';
+import { renderGamePage } from './components/game-page.js?v=ee5b5152';
+import { renderHomePage } from './components/home.js?v=e791c556';
+import { renderSearchPage } from './components/search.js?v=7a168eb2';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=6033169d';
-import { renderHomePage } from './components/home.js?v=3ea431c7';
-import { renderSearchPage } from './components/search.js?v=b05fe84a';
+import { renderGamePage } from './components/game-page.js?v=072af6a7';
+import { renderHomePage } from './components/home.js?v=92a6a03b';
+import { renderSearchPage } from './components/search.js?v=78b89e87';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=01c3d072';
-import { renderHomePage } from './components/home.js?v=eb98da03';
-import { renderSearchPage } from './components/search.js?v=55c4c279';
+import { renderGamePage } from './components/game-page.js?v=99649303';
+import { renderHomePage } from './components/home.js?v=b6a321cf';
+import { renderSearchPage } from './components/search.js?v=8f0d7c0f';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=6b684f75';
-import { renderHomePage } from './components/home.js?v=87d7b24a';
-import { renderSearchPage } from './components/search.js?v=7d01b525';
+import { renderGamePage } from './components/game-page.js?v=fa355a8f';
+import { renderHomePage } from './components/home.js?v=da5a38a8';
+import { renderSearchPage } from './components/search.js?v=dc0b704a';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=99649303';
-import { renderHomePage } from './components/home.js?v=b6a321cf';
-import { renderSearchPage } from './components/search.js?v=8f0d7c0f';
+import { renderGamePage } from './components/game-page.js?v=c02da1b5';
+import { renderHomePage } from './components/home.js?v=3a583a03';
+import { renderSearchPage } from './components/search.js?v=d2abd0b4';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=ee5b5152';
-import { renderHomePage } from './components/home.js?v=e791c556';
-import { renderSearchPage } from './components/search.js?v=7a168eb2';
+import { renderGamePage } from './components/game-page.js?v=f6f0a94f';
+import { renderHomePage } from './components/home.js?v=43662b41';
+import { renderSearchPage } from './components/search.js?v=0250842f';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=c02da1b5';
-import { renderHomePage } from './components/home.js?v=3a583a03';
-import { renderSearchPage } from './components/search.js?v=d2abd0b4';
+import { renderGamePage } from './components/game-page.js?v=4cea7c51';
+import { renderHomePage } from './components/home.js?v=7d3aa992';
+import { renderSearchPage } from './components/search.js?v=13827ba1';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=1078e992';
-import { renderHomePage } from './components/home.js?v=ddc68e04';
-import { renderSearchPage } from './components/search.js?v=d808f5db';
+import { renderGamePage } from './components/game-page.js?v=90bfaf30';
+import { renderHomePage } from './components/home.js?v=1d95e4f8';
+import { renderSearchPage } from './components/search.js?v=7f526e87';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=f6f0a94f';
-import { renderHomePage } from './components/home.js?v=43662b41';
-import { renderSearchPage } from './components/search.js?v=0250842f';
+import { renderGamePage } from './components/game-page.js?v=d9f89b53';
+import { renderHomePage } from './components/home.js?v=9bada050';
+import { renderSearchPage } from './components/search.js?v=e61e2ebb';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=9fb38e4a';
-import { renderHomePage } from './components/home.js?v=58198c76';
-import { renderSearchPage } from './components/search.js?v=92201e95';
+import { renderGamePage } from './components/game-page.js?v=3a30f855';
+import { renderHomePage } from './components/home.js?v=5f4e4317';
+import { renderSearchPage } from './components/search.js?v=92bfd5c9';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=072af6a7';
-import { renderHomePage } from './components/home.js?v=92a6a03b';
-import { renderSearchPage } from './components/search.js?v=78b89e87';
+import { renderGamePage } from './components/game-page.js?v=1078e992';
+import { renderHomePage } from './components/home.js?v=ddc68e04';
+import { renderSearchPage } from './components/search.js?v=d808f5db';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=90bfaf30';
-import { renderHomePage } from './components/home.js?v=1d95e4f8';
-import { renderSearchPage } from './components/search.js?v=7f526e87';
+import { renderGamePage } from './components/game-page.js?v=9fb38e4a';
+import { renderHomePage } from './components/home.js?v=58198c76';
+import { renderSearchPage } from './components/search.js?v=92201e95';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=fa355a8f';
-import { renderHomePage } from './components/home.js?v=da5a38a8';
-import { renderSearchPage } from './components/search.js?v=dc0b704a';
+import { renderGamePage } from './components/game-page.js?v=e0078aca';
+import { renderHomePage } from './components/home.js?v=07616ca3';
+import { renderSearchPage } from './components/search.js?v=91907ef7';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=4cea7c51';
-import { renderHomePage } from './components/home.js?v=7d3aa992';
-import { renderSearchPage } from './components/search.js?v=13827ba1';
+import { renderGamePage } from './components/game-page.js?v=6b684f75';
+import { renderHomePage } from './components/home.js?v=87d7b24a';
+import { renderSearchPage } from './components/search.js?v=7d01b525';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=d9f89b53';
-import { renderHomePage } from './components/home.js?v=9bada050';
-import { renderSearchPage } from './components/search.js?v=e61e2ebb';
+import { renderGamePage } from './components/game-page.js?v=aa4f014b';
+import { renderHomePage } from './components/home.js?v=99d53718';
+import { renderSearchPage } from './components/search.js?v=1172debb';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=aa4f014b';
-import { renderHomePage } from './components/home.js?v=99d53718';
-import { renderSearchPage } from './components/search.js?v=1172debb';
+import { renderGamePage } from './components/game-page.js?v=e677c617';
+import { renderHomePage } from './components/home.js?v=dfe38326';
+import { renderSearchPage } from './components/search.js?v=7ed73f95';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/auth/main.js
+++ b/js/auth/main.js
@@ -40,7 +40,7 @@ import { SupaAuth } from '../shared/config.js?v=f6f2c00a';
       console.error('[auth] login error:', error);
       continueBtn.disabled = false;
       continueBtn.classList.remove('is-loading');
-      window.alert('Could not start Steam sign-in. Please try again.');
+      window.ppToast?.error('Could not start Steam sign-in. Please try again.');
     }
   });
 })();

--- a/js/index/main.js
+++ b/js/index/main.js
@@ -94,7 +94,10 @@ import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=85cf419
   // pending, empty) is a title we list but have no reports for yet.
   const KNOWN_TIERS = new Set(['platinum', 'gold', 'silver', 'bronze', 'borked']);
 
+  let currentLayout = 'grid';
+
   function pgCardHtml(g) {
+    if (currentLayout === 'list') return pgListRowHtml(g);
     const img = `https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/${encodeURIComponent(g.appId)}/header.jpg`;
     const peak = fmtPeak(g.peak);
     const rating = String(g.rating || '').toLowerCase();
@@ -110,6 +113,18 @@ import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=85cf419
         </div>
         <span class="pg-badge ${badgeClass}">${rLabel}</span>
       </a>`;
+  }
+
+  function pgListRowHtml(g) {
+    const rating = String(g.rating || '').toLowerCase();
+    const rated = KNOWN_TIERS.has(rating);
+    const rLabel = rated ? RATING_LABEL[rating] : '?';
+    const peak = fmtPeak(g.peak);
+    return `<a class="pg-list-row" href="app.html#/app/${encodeURIComponent(g.appId)}">
+      <span class="pg-list-tier pg-badge ${rated ? `pg-${rating}` : 'pg-unrated'}">${rLabel}</span>
+      <span class="pg-list-title">${esc(g.title)}</span>
+      <span class="pg-list-meta">${peak ? peak + ' peak' : ''}</span>
+    </a>`;
   }
 
   try {
@@ -188,7 +203,51 @@ import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=85cf419
     }
     ratedBtn?.addEventListener('click', () => selectFilter('rated'));
     unratedBtn?.addEventListener('click', () => selectFilter('unrated'));
-    renderPopular();
+
+    // S/M/L card size (saved preference, shared key with app page)
+    const SIZE_KEY = 'pp:grid-size';
+    const SIZES = ['sm', 'md', 'lg'];
+    function savedSize() {
+      try { const s = localStorage.getItem(SIZE_KEY); return SIZES.includes(s) ? s : 'md'; } catch { return 'md'; }
+    }
+    function applySize(size) {
+      SIZES.forEach(s => list.classList.remove(`pg-list--${s}`));
+      list.classList.add(`pg-list--${size}`);
+      document.querySelectorAll('.pg-size-btn').forEach(b => b.classList.toggle('active', b.dataset.size === size));
+    }
+    function setSizeEnabled(enabled) {
+      document.querySelectorAll('.pg-size-btn').forEach(b => { b.disabled = !enabled; });
+      document.getElementById('pg-size-toggle')?.classList.toggle('pg-size-toggle--disabled', !enabled);
+    }
+    document.querySelectorAll('.pg-size-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        try { localStorage.setItem(SIZE_KEY, btn.dataset.size); } catch { /* ignore */ }
+        applySize(btn.dataset.size);
+      });
+    });
+
+    // Grid/List layout (saved preference, shared key with app page)
+    const LAYOUT_KEY = 'pp:grid-layout';
+    function savedLayout() {
+      try { const l = localStorage.getItem(LAYOUT_KEY); return (l === 'list' || l === 'grid') ? l : 'grid'; } catch { return 'grid'; }
+    }
+    function applyLayout(layout) {
+      currentLayout = layout;
+      const isList = layout === 'list';
+      list.classList.toggle('pg-list--list-mode', isList);
+      document.querySelectorAll('.pg-layout-btn').forEach(b => b.classList.toggle('active', b.dataset.layout === layout));
+      setSizeEnabled(!isList);
+      renderPopular();
+    }
+    document.querySelectorAll('.pg-layout-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        try { localStorage.setItem(LAYOUT_KEY, btn.dataset.layout); } catch { /* ignore */ }
+        applyLayout(btn.dataset.layout);
+      });
+    });
+
+    applySize(savedSize());
+    applyLayout(savedLayout());
   } catch (err) {
     console.debug('[popular-games] failed to load most_played.json', { error: String(err) });
     /* leave the section hidden */

--- a/js/index/main.js
+++ b/js/index/main.js
@@ -174,18 +174,20 @@ import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=85cf419
       }
     }
 
-    function wireFilter(btn, key) {
-      if (!btn) return;
-      btn.addEventListener('click', () => {
-        state[key] = !state[key];
-        btn.classList.toggle('pg-filter--active', state[key]);
-        btn.setAttribute('aria-pressed', String(state[key]));
-        shownCount = PAGE_SIZE; // restart paging when the filter changes
-        renderPopular();
-      });
+    // Rated / Not Rated are mutually exclusive (either-or): selecting one
+    // deselects the other, and exactly one is always active.
+    function selectFilter(key) {
+      state.rated = key === 'rated';
+      state.unrated = key === 'unrated';
+      ratedBtn?.classList.toggle('pg-filter--active', state.rated);
+      unratedBtn?.classList.toggle('pg-filter--active', state.unrated);
+      ratedBtn?.setAttribute('aria-pressed', String(state.rated));
+      unratedBtn?.setAttribute('aria-pressed', String(state.unrated));
+      shownCount = PAGE_SIZE; // restart paging when the filter changes
+      renderPopular();
     }
-    wireFilter(ratedBtn, 'rated');
-    wireFilter(unratedBtn, 'unrated');
+    ratedBtn?.addEventListener('click', () => selectFilter('rated'));
+    unratedBtn?.addEventListener('click', () => selectFilter('unrated'));
     renderPopular();
   } catch (err) {
     console.debug('[popular-games] failed to load most_played.json', { error: String(err) });

--- a/js/lib/toast.js
+++ b/js/lib/toast.js
@@ -1,0 +1,73 @@
+/**
+ * toast.js -- tiny shared feedback toasts for the web app.
+ *
+ * Loaded as a classic script on every page (after topbar.js), so both the ES
+ * module pages and the plain-script pages can call it the same way:
+ *
+ *   window.ppToast('Report submitted', { type: 'success' });
+ *   window.ppToast.success('Saved');
+ *   window.ppToast.error('Could not save -- try again');
+ *
+ * Toasts stack bottom-right, auto-dismiss, and can be closed manually. Errors
+ * stay up longer and use role="alert" so screen readers announce them.
+ */
+(function () {
+  const DEFAULT_TIMEOUT = 3500;
+  const ERROR_TIMEOUT = 6000;
+
+  function ensureContainer() {
+    let c = document.getElementById('pp-toast-container');
+    if (!c) {
+      c = document.createElement('div');
+      c.id = 'pp-toast-container';
+      c.className = 'pp-toast-container';
+      c.setAttribute('aria-live', 'polite');
+      document.body.appendChild(c);
+    }
+    return c;
+  }
+
+  function dismiss(el) {
+    if (!el || el._ppDismissed) return;
+    el._ppDismissed = true;
+    clearTimeout(el._ppTimer);
+    el.classList.remove('pp-toast--in');
+    el.classList.add('pp-toast--out');
+    setTimeout(() => el.remove(), 250);
+  }
+
+  function ppToast(message, opts) {
+    opts = opts || {};
+    const type = opts.type || 'info'; // 'success' | 'error' | 'info'
+    const timeout = opts.timeout != null ? opts.timeout : (type === 'error' ? ERROR_TIMEOUT : DEFAULT_TIMEOUT);
+    const container = ensureContainer();
+
+    const el = document.createElement('div');
+    el.className = `pp-toast pp-toast--${type}`;
+    el.setAttribute('role', type === 'error' ? 'alert' : 'status');
+
+    const msg = document.createElement('span');
+    msg.className = 'pp-toast-msg';
+    msg.textContent = String(message == null ? '' : message);
+    el.appendChild(msg);
+
+    const close = document.createElement('button');
+    close.type = 'button';
+    close.className = 'pp-toast-close';
+    close.setAttribute('aria-label', 'Dismiss');
+    close.innerHTML = '&times;';
+    close.addEventListener('click', () => dismiss(el));
+    el.appendChild(close);
+
+    container.appendChild(el);
+    requestAnimationFrame(() => el.classList.add('pp-toast--in'));
+    el._ppTimer = setTimeout(() => dismiss(el), timeout);
+    return el;
+  }
+
+  ppToast.success = (m, o) => ppToast(m, Object.assign({}, o, { type: 'success' }));
+  ppToast.error = (m, o) => ppToast(m, Object.assign({}, o, { type: 'error' }));
+  ppToast.info = (m, o) => ppToast(m, Object.assign({}, o, { type: 'info' }));
+
+  window.ppToast = ppToast;
+})();

--- a/js/lib/topbar.js
+++ b/js/lib/topbar.js
@@ -759,7 +759,9 @@
         if (avatarEl)  avatarEl.src = (user.user_metadata && user.user_metadata.avatar_url) || '';
         if (avatarEl)  avatarEl.alt = (user.user_metadata && user.user_metadata.name) || user.email || '';
         const rawName = (user.user_metadata && user.user_metadata.name) || user.email || '';
-        if (nameEl)    nameEl.textContent = rawName.length > 10 ? rawName.slice(0, 10) + '\u2026' : rawName;
+        // Set the full name; CSS (.auth-username) handles truncation, capping it
+        // on narrow viewports but showing it in full on desktop (>=1024px).
+        if (nameEl) { nameEl.textContent = rawName; nameEl.title = rawName; }
 
         // Show/hide the pre-rendered admin nav link based on admin status.
         checkIsAdmin(state.session).then(function (admin) {

--- a/js/profile/api/systems.js
+++ b/js/profile/api/systems.js
@@ -60,6 +60,18 @@ export async function updateSystemLabel(protonPulseUserId, deviceId, label, sess
   if (!r.ok) throw new Error(`Update label failed: HTTP ${r.status}`);
 }
 
+export async function updateSystem(protonPulseUserId, deviceId, fields, session) {
+  const url = supabaseUserSystemsUrl(
+    `proton_pulse_user_id=eq.${encodeURIComponent(protonPulseUserId)}&device_id=eq.${encodeURIComponent(deviceId)}`,
+  );
+  const r = await fetch(url, {
+    method: 'PATCH',
+    headers: supabaseHeaders(session, { Prefer: 'return=minimal' }),
+    body: JSON.stringify({ ...fields, updated_at: new Date().toISOString() }),
+  });
+  if (!r.ok) throw new Error(`Update failed: HTTP ${r.status}`);
+}
+
 export async function deleteSystem(protonPulseUserId, deviceId, session) {
   const url = supabaseUserSystemsUrl(
     `proton_pulse_user_id=eq.${encodeURIComponent(protonPulseUserId)}&device_id=eq.${encodeURIComponent(deviceId)}`,

--- a/js/profile/components/edit-modals.js
+++ b/js/profile/components/edit-modals.js
@@ -3,11 +3,13 @@
 // api layer; takes no closure state from main.
 import {
   escapeHtml, formatSystemUpdated, enabledVarsToText, textToEnabledVars,
+  parseUploadedSystem, isGenericSystemLabel, inferSystemLabel,
 } from '../utils.js?v=2324dd84';
 import {
   fetchCloudConfig, patchCloudConfig, fetchFullUserConfig,
   fetchReportHistory, patchUserConfig,
 } from '../api/configs.js?v=a51234ab';
+import { updateSystem } from '../api/systems.js?v=8c9eb2f2';
 
 export let _cloudEditModal = null;
 export function getCloudEditModal() {
@@ -217,6 +219,249 @@ export async function showEditReportModal(reportId, session, onSaved) {
     } catch (e) {
       status.textContent = e.message || 'Save failed';
       console.warn('[profile] showEditReportModal: save failed', { reportId, error: String(e) });
+    } finally {
+      saveBtn.textContent = 'Save Changes';
+      saveBtn.disabled = false;
+    }
+  };
+}
+
+export let _systemAddModal = null;
+export function getSystemAddModal() {
+  if (_systemAddModal) return _systemAddModal;
+  _systemAddModal = document.createElement('dialog');
+  _systemAddModal.className = 'edit-report-modal';
+  _systemAddModal.innerHTML = `
+    <h2 class="edit-report-title">Add System</h2>
+    <div class="edit-report-fields">
+      <label class="edit-report-label">Label
+        <input class="edit-report-input" type="text" name="label" placeholder="e.g. Desktop RTX 4070" maxlength="80">
+      </label>
+      <label class="edit-report-label">CPU
+        <input class="edit-report-input" type="text" name="cpu" placeholder="e.g. AMD Ryzen 7 5800X3D" maxlength="120">
+      </label>
+      <label class="edit-report-label">GPU
+        <input class="edit-report-input" type="text" name="gpu" placeholder="e.g. NVIDIA GeForce RTX 4070" maxlength="120">
+      </label>
+      <label class="edit-report-label">GPU Vendor
+        <select class="edit-report-input" name="gpu_vendor">
+          <option value="">--</option>
+          <option value="nvidia">NVIDIA</option>
+          <option value="amd">AMD</option>
+          <option value="intel">Intel</option>
+        </select>
+      </label>
+      <label class="edit-report-label">GPU Driver
+        <input class="edit-report-input" type="text" name="gpu_driver" placeholder="e.g. Mesa 24.1.0" maxlength="80">
+      </label>
+      <label class="edit-report-label">RAM
+        <input class="edit-report-input" type="text" name="ram" placeholder="e.g. 32 GB" maxlength="20">
+      </label>
+      <label class="edit-report-label">VRAM (MB)
+        <input class="edit-report-input" type="number" name="vram" placeholder="e.g. 8192" min="0" max="262144">
+      </label>
+      <label class="edit-report-label">OS
+        <input class="edit-report-input" type="text" name="os" placeholder="e.g. Arch Linux" maxlength="60">
+      </label>
+      <label class="edit-report-label">Kernel
+        <input class="edit-report-input" type="text" name="kernel" placeholder="e.g. 6.8.0" maxlength="60">
+      </label>
+    </div>
+    <div class="edit-report-status"></div>
+    <div class="edit-report-actions">
+      <button type="button" class="edit-report-cancel">Cancel</button>
+      <button type="button" class="edit-report-save">Save System</button>
+    </div>
+  `;
+  document.body.appendChild(_systemAddModal);
+  _systemAddModal.querySelector('.edit-report-cancel').addEventListener('click', () => _systemAddModal.close());
+  return _systemAddModal;
+}
+
+export async function showAddSystemModal(protonPulseUserId, session, { supabaseUserSystemsUrl, supabaseHeaders, systemsCache }, onSaved) {
+  const modal = getSystemAddModal();
+  const status = modal.querySelector('.edit-report-status');
+  const saveBtn = modal.querySelector('.edit-report-save');
+  status.textContent = '';
+  saveBtn.disabled = false;
+  saveBtn.textContent = 'Save System';
+  modal.querySelectorAll('input, select, textarea').forEach(el => { el.value = ''; });
+  modal.showModal();
+
+  saveBtn.onclick = async () => {
+    const cpu = modal.querySelector('[name="cpu"]').value.trim();
+    const gpu = modal.querySelector('[name="gpu"]').value.trim();
+    if (!cpu && !gpu) {
+      status.textContent = 'At least CPU or GPU is needed';
+      status.style.color = 'var(--red)';
+      return;
+    }
+    saveBtn.textContent = 'Saving...';
+    saveBtn.disabled = true;
+    status.textContent = '';
+
+    const label = modal.querySelector('[name="label"]').value.trim() || 'Manual system';
+    const gpuDriver = modal.querySelector('[name="gpu_driver"]').value.trim();
+    const ram = modal.querySelector('[name="ram"]').value.trim();
+    const vram = modal.querySelector('[name="vram"]').value.trim();
+    const os = modal.querySelector('[name="os"]').value.trim();
+    const kernel = modal.querySelector('[name="kernel"]').value.trim();
+
+    const lines = [];
+    if (cpu) lines.push(`CPU Brand: ${cpu}`);
+    if (gpu) lines.push(`Video Card: ${gpu}`);
+    if (gpuDriver) lines.push(`Driver Version: ${gpuDriver}`);
+    if (ram) {
+      const gb = parseInt(ram.replace(/[^0-9]/g, ''), 10);
+      if (gb) lines.push(`RAM: ${gb * 1024} Mb`);
+    }
+    if (vram) lines.push(`VRAM: ${vram} Mb`);
+    if (os) lines.push(`OS Version: ${os}`);
+    if (kernel) lines.push(`Kernel Version: ${kernel}`);
+
+    const deviceId = 'web-' + crypto.randomUUID().slice(0, 12);
+    const isFirst = (systemsCache || []).length === 0;
+
+    try {
+      const resp = await fetch(supabaseUserSystemsUrl(), {
+        method: 'POST',
+        headers: supabaseHeaders(session, { Prefer: 'return=minimal' }),
+        body: JSON.stringify({
+          proton_pulse_user_id: protonPulseUserId,
+          device_id: deviceId,
+          label,
+          sysinfo_text: lines.join('\n'),
+          is_default: isFirst,
+          updated_at: new Date().toISOString(),
+        }),
+      });
+      if (!resp.ok) throw new Error(`Save failed: HTTP ${resp.status}`);
+      console.debug('[profile] showAddSystemModal: saved', { deviceId, label });
+      modal.close();
+      onSaved?.();
+    } catch (e) {
+      status.textContent = e.message || 'Save failed';
+      status.style.color = 'var(--red)';
+      console.warn('[profile] showAddSystemModal: save failed', { error: String(e) });
+    } finally {
+      saveBtn.textContent = 'Save System';
+      saveBtn.disabled = false;
+    }
+  };
+}
+
+export let _systemEditModal = null;
+export function getSystemEditModal() {
+  if (_systemEditModal) return _systemEditModal;
+  _systemEditModal = document.createElement('dialog');
+  _systemEditModal.className = 'edit-report-modal';
+  _systemEditModal.innerHTML = `
+    <h2 class="edit-report-title">Edit System</h2>
+    <div class="edit-report-fields">
+      <label class="edit-report-label">Label
+        <input class="edit-report-input" type="text" name="label" placeholder="e.g. Desktop RTX 4070" maxlength="80">
+      </label>
+      <label class="edit-report-label">CPU
+        <input class="edit-report-input" type="text" name="cpu" placeholder="e.g. AMD Ryzen 7 5800X3D" maxlength="120">
+      </label>
+      <label class="edit-report-label">GPU
+        <input class="edit-report-input" type="text" name="gpu" placeholder="e.g. NVIDIA GeForce RTX 4070" maxlength="120">
+      </label>
+      <label class="edit-report-label">GPU Vendor
+        <select class="edit-report-input" name="gpu_vendor">
+          <option value="">--</option>
+          <option value="nvidia">NVIDIA</option>
+          <option value="amd">AMD</option>
+          <option value="intel">Intel</option>
+        </select>
+      </label>
+      <label class="edit-report-label">GPU Driver
+        <input class="edit-report-input" type="text" name="gpu_driver" placeholder="e.g. Mesa 24.1.0" maxlength="80">
+      </label>
+      <label class="edit-report-label">RAM
+        <input class="edit-report-input" type="text" name="ram" placeholder="e.g. 32 GB" maxlength="20">
+      </label>
+      <label class="edit-report-label">VRAM (MB)
+        <input class="edit-report-input" type="number" name="vram" placeholder="e.g. 8192" min="0" max="262144">
+      </label>
+      <label class="edit-report-label">OS
+        <input class="edit-report-input" type="text" name="os" placeholder="e.g. Arch Linux" maxlength="60">
+      </label>
+      <label class="edit-report-label">Kernel
+        <input class="edit-report-input" type="text" name="kernel" placeholder="e.g. 6.8.0" maxlength="60">
+      </label>
+    </div>
+    <div class="edit-report-status"></div>
+    <div class="edit-report-actions">
+      <button type="button" class="edit-report-cancel">Cancel</button>
+      <button type="button" class="edit-report-save">Save Changes</button>
+    </div>
+  `;
+  document.body.appendChild(_systemEditModal);
+  _systemEditModal.querySelector('.edit-report-cancel').addEventListener('click', () => _systemEditModal.close());
+  return _systemEditModal;
+}
+
+export async function showEditSystemModal(row, protonPulseUserId, session, onSaved) {
+  const modal = getSystemEditModal();
+  const status = modal.querySelector('.edit-report-status');
+  const saveBtn = modal.querySelector('.edit-report-save');
+  status.textContent = '';
+  saveBtn.disabled = false;
+  saveBtn.textContent = 'Save Changes';
+  modal.showModal();
+
+  const parsed = parseUploadedSystem(row);
+  const displayLabel = isGenericSystemLabel(row.label) ? inferSystemLabel(row) : (row.label || '');
+  const ramGb = parsed.ram ? parseInt(parsed.ram.replace(/[^0-9]/g, ''), 10) || '' : '';
+
+  modal.querySelector('[name="label"]').value = displayLabel;
+  modal.querySelector('[name="cpu"]').value = parsed.cpu || '';
+  modal.querySelector('[name="gpu"]').value = parsed.gpu || '';
+  modal.querySelector('[name="gpu_vendor"]').value = parsed.gpuVendor || '';
+  modal.querySelector('[name="gpu_driver"]').value = parsed.gpuDriver || '';
+  modal.querySelector('[name="ram"]').value = ramGb ? `${ramGb} GB` : '';
+  modal.querySelector('[name="vram"]').value = parsed.vramMb || '';
+  modal.querySelector('[name="os"]').value = [parsed.os, parsed.osVersion].filter(Boolean).join(' ');
+  modal.querySelector('[name="kernel"]').value = parsed.kernel || '';
+
+  saveBtn.onclick = async () => {
+    saveBtn.textContent = 'Saving...';
+    saveBtn.disabled = true;
+    status.textContent = '';
+
+    const label = modal.querySelector('[name="label"]').value.trim() || displayLabel;
+    const cpu = modal.querySelector('[name="cpu"]').value.trim();
+    const gpu = modal.querySelector('[name="gpu"]').value.trim();
+    const gpuDriver = modal.querySelector('[name="gpu_driver"]').value.trim();
+    const ram = modal.querySelector('[name="ram"]').value.trim();
+    const vram = modal.querySelector('[name="vram"]').value.trim();
+    const os = modal.querySelector('[name="os"]').value.trim();
+    const kernel = modal.querySelector('[name="kernel"]').value.trim();
+
+    const lines = [];
+    if (cpu) lines.push(`CPU Brand: ${cpu}`);
+    if (gpu) lines.push(`Video Card: ${gpu}`);
+    if (gpuDriver) lines.push(`Driver Version: ${gpuDriver}`);
+    if (ram) {
+      const gb = parseInt(ram.replace(/[^0-9]/g, ''), 10);
+      if (gb) lines.push(`RAM: ${gb * 1024} Mb`);
+    }
+    if (vram) lines.push(`VRAM: ${vram} Mb`);
+    if (os) lines.push(`OS Version: ${os}`);
+    if (kernel) lines.push(`Kernel Version: ${kernel}`);
+
+    try {
+      await updateSystem(protonPulseUserId, row.device_id, {
+        label,
+        sysinfo_text: lines.join('\n'),
+      }, session);
+      console.debug('[profile] showEditSystemModal: saved', { deviceId: row.device_id });
+      modal.close();
+      onSaved?.();
+    } catch (e) {
+      status.textContent = e.message || 'Save failed';
+      console.warn('[profile] showEditSystemModal: save failed', { deviceId: row.device_id, error: String(e) });
     } finally {
       saveBtn.textContent = 'Save Changes';
       saveBtn.disabled = false;

--- a/js/profile/main.js
+++ b/js/profile/main.js
@@ -17,8 +17,8 @@ import {
 import { supabaseHeaders } from './api/supabase.js?v=bdf4b262';
 import {
   supabaseUserSystemsUrl, listUserSystems, setDefaultSystem,
-  clearDefaultSystem, updateSystemLabel, deleteSystem,
-} from './api/systems.js?v=fcfc95e6';
+  clearDefaultSystem, updateSystemLabel, updateSystem, deleteSystem,
+} from './api/systems.js?v=8c9eb2f2';
 import {
   fetchMyUserConfigs, fetchMyCloudConfigs, deleteMyReportsEverywhere,
   deleteAllMyData, fetchAllMyData, checkMyDataExists, unpublishReport,
@@ -689,12 +689,15 @@ import { showEditCloudConfigModal, showEditReportModal } from './components/edit
             <span class="profile-systems-default-text">Default</span>
           </label>
         </td>
+        <td class="col-edit">
+          <button type="button" class="profile-systems-edit-btn" data-role="edit" title="Edit">Edit</button>
+        </td>
         <td class="col-delete">
           <button type="button" class="profile-systems-trash" data-role="delete" title="Delete">x</button>
         </td>
       </tr>
       <tr class="profile-systems-details-row" data-details-for="${escapeHtml(r.device_id)}" hidden>
-        <td colspan="4">
+        <td colspan="5">
           <div class="profile-systems-details-card">
             <div class="profile-systems-details-grid">
               ${detailRows.map(([label, value]) => `
@@ -808,6 +811,11 @@ import { showEditCloudConfigModal, showEditReportModal } from './components/edit
         if (detailRow) detailRow.hidden = expanded;
         return;
       }
+      if (btn.dataset.role === 'edit') {
+        const row = systemsCache.find(r => r.device_id === deviceId);
+        if (row) openEditSystemForm(row, protonPulseUserId, s);
+        return;
+      }
       if (btn.dataset.role === 'delete') {
         if (!window.confirm('Delete this system? The plugin will re-create it next time you upload.')) return;
         await deleteSystem(protonPulseUserId, deviceId, s);
@@ -816,6 +824,96 @@ import { showEditCloudConfigModal, showEditReportModal } from './components/edit
     } catch (e) {
       showSystemsStatus(e.message || 'Action failed', false);
     }
+  }
+
+  function openEditSystemForm(row, protonPulseUserId, session) {
+    const existing = document.getElementById('edit-system-form');
+    if (existing) existing.remove();
+
+    const parsed = parseUploadedSystem(row);
+    const displayLabel = isGenericSystemLabel(row.label) ? inferSystemLabel(row) : (row.label || '');
+    const ramGb = parsed.ram ? parseInt(parsed.ram.replace(/[^0-9]/g, ''), 10) || '' : '';
+
+    const formHtml = `
+      <tr id="edit-system-form" data-editing="${escapeHtml(row.device_id)}">
+        <td colspan="5">
+          <div class="profile-prefill-source" style="margin:8px 0">
+            <div class="profile-prefill-source-title">Edit system</div>
+            <div style="display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px 12px;margin-top:10px">
+              <div><label class="profile-field-label">Label</label><input type="text" id="edit-sys-label" class="profile-select" value="${escapeHtml(displayLabel)}" maxlength="80" style="width:100%"></div>
+              <div><label class="profile-field-label">CPU</label><input type="text" id="edit-sys-cpu" class="profile-select" value="${escapeHtml(parsed.cpu || '')}" maxlength="120" style="width:100%"></div>
+              <div><label class="profile-field-label">GPU</label><input type="text" id="edit-sys-gpu" class="profile-select" value="${escapeHtml(parsed.gpu || '')}" maxlength="120" style="width:100%"></div>
+              <div><label class="profile-field-label">GPU Vendor</label>
+                <select id="edit-sys-gpu-vendor" class="profile-select" style="width:100%">
+                  <option value="">--</option>
+                  <option value="nvidia" ${parsed.gpuVendor === 'nvidia' ? 'selected' : ''}>NVIDIA</option>
+                  <option value="amd" ${parsed.gpuVendor === 'amd' ? 'selected' : ''}>AMD</option>
+                  <option value="intel" ${parsed.gpuVendor === 'intel' ? 'selected' : ''}>Intel</option>
+                </select>
+              </div>
+              <div><label class="profile-field-label">GPU Driver</label><input type="text" id="edit-sys-gpu-driver" class="profile-select" value="${escapeHtml(parsed.gpuDriver || '')}" maxlength="80" style="width:100%"></div>
+              <div><label class="profile-field-label">RAM</label><input type="text" id="edit-sys-ram" class="profile-select" value="${ramGb ? ramGb + ' GB' : ''}" maxlength="20" style="width:100%"></div>
+              <div><label class="profile-field-label">VRAM (MB)</label><input type="number" id="edit-sys-vram" class="profile-select" value="${parsed.vramMb || ''}" min="0" max="262144" style="width:100%"></div>
+              <div><label class="profile-field-label">OS</label><input type="text" id="edit-sys-os" class="profile-select" value="${escapeHtml([parsed.os, parsed.osVersion].filter(Boolean).join(' '))}" maxlength="60" style="width:100%"></div>
+              <div><label class="profile-field-label">Kernel</label><input type="text" id="edit-sys-kernel" class="profile-select" value="${escapeHtml(parsed.kernel || '')}" maxlength="60" style="width:100%"></div>
+            </div>
+            <div style="display:flex;gap:8px;margin-top:10px;align-items:center">
+              <button type="button" class="profile-parse-btn" id="edit-sys-save">Save</button>
+              <button type="button" class="profile-refresh-btn" id="edit-sys-cancel">Cancel</button>
+              <span id="edit-sys-status" style="font-size:0.76rem;color:var(--muted)"></span>
+            </div>
+          </div>
+        </td>
+      </tr>`;
+
+    const mainRow = systemsTbody.querySelector(`tr[data-device-id="${CSS.escape(row.device_id)}"]`);
+    if (!mainRow) return;
+    mainRow.insertAdjacentHTML('afterend', formHtml);
+
+    document.getElementById('edit-sys-cancel')?.addEventListener('click', () => {
+      document.getElementById('edit-system-form')?.remove();
+    });
+
+    document.getElementById('edit-sys-save')?.addEventListener('click', async () => {
+      const label = document.getElementById('edit-sys-label')?.value?.trim() || displayLabel;
+      const cpu = document.getElementById('edit-sys-cpu')?.value?.trim() || '';
+      const gpu = document.getElementById('edit-sys-gpu')?.value?.trim() || '';
+      const gpuDriver = document.getElementById('edit-sys-gpu-driver')?.value?.trim() || '';
+      const ram = document.getElementById('edit-sys-ram')?.value?.trim() || '';
+      const vram = document.getElementById('edit-sys-vram')?.value?.trim() || '';
+      const os = document.getElementById('edit-sys-os')?.value?.trim() || '';
+      const kernel = document.getElementById('edit-sys-kernel')?.value?.trim() || '';
+
+      const lines = [];
+      if (cpu) lines.push(`CPU Brand: ${cpu}`);
+      if (gpu) lines.push(`Video Card: ${gpu}`);
+      if (gpuDriver) lines.push(`Driver Version: ${gpuDriver}`);
+      if (ram) {
+        const gb = parseInt(ram.replace(/[^0-9]/g, ''), 10);
+        if (gb) lines.push(`RAM: ${gb * 1024} Mb`);
+      }
+      if (vram) lines.push(`VRAM: ${vram} Mb`);
+      if (os) lines.push(`OS Version: ${os}`);
+      if (kernel) lines.push(`Kernel Version: ${kernel}`);
+
+      const saveBtn = document.getElementById('edit-sys-save');
+      const statusEl = document.getElementById('edit-sys-status');
+      try {
+        saveBtn.disabled = true;
+        saveBtn.textContent = 'Saving...';
+        await updateSystem(protonPulseUserId, row.device_id, {
+          label,
+          sysinfo_text: lines.join('\n'),
+        }, session);
+        document.getElementById('edit-system-form')?.remove();
+        showSystemsStatus('System updated', true);
+        void refreshSystems();
+      } catch (e) {
+        saveBtn.disabled = false;
+        saveBtn.textContent = 'Save';
+        if (statusEl) { statusEl.textContent = e.message || 'Save failed'; statusEl.style.color = 'var(--red)'; }
+      }
+    });
   }
 
   // Label saves on blur. Using focusout so it bubbles through the table

--- a/js/profile/main.js
+++ b/js/profile/main.js
@@ -17,7 +17,7 @@ import {
 import { supabaseHeaders } from './api/supabase.js?v=bdf4b262';
 import {
   supabaseUserSystemsUrl, listUserSystems, setDefaultSystem,
-  clearDefaultSystem, updateSystemLabel, updateSystem, deleteSystem,
+  clearDefaultSystem, updateSystemLabel, deleteSystem,
 } from './api/systems.js?v=8c9eb2f2';
 import {
   fetchMyUserConfigs, fetchMyCloudConfigs, deleteMyReportsEverywhere,
@@ -26,7 +26,7 @@ import {
 import {
   listLinkedPlugins, completePluginLink, removePluginLink,
 } from './api/plugin-links.js?v=59c9f51e';
-import { showEditCloudConfigModal, showEditReportModal } from './components/edit-modals.js?v=d0e0780c';
+import { showEditCloudConfigModal, showEditReportModal, showEditSystemModal, showAddSystemModal } from './components/edit-modals.js?v=27767f46';
 
 (async function () {
   const signedIn  = document.getElementById('profile-signed-in');
@@ -678,7 +678,6 @@ import { showEditCloudConfigModal, showEditReportModal } from './components/edit
             <input type="text" class="profile-systems-label-input"
               data-role="label" value="${escapeHtml(displayLabel)}" maxlength="80">
             <div class="profile-systems-summary">${escapeHtml(summary)}</div>
-            <button type="button" class="profile-systems-view-btn" data-role="toggle-details" aria-expanded="false">View hardware</button>
           </div>
         </td>
         <td>${escapeHtml(formatSystemUpdated(r.updated_at))}</td>
@@ -689,15 +688,16 @@ import { showEditCloudConfigModal, showEditReportModal } from './components/edit
             <span class="profile-systems-default-text">Default</span>
           </label>
         </td>
-        <td class="col-edit">
-          <button type="button" class="profile-systems-edit-btn" data-role="edit" title="Edit">Edit</button>
-        </td>
-        <td class="col-delete">
-          <button type="button" class="profile-systems-trash" data-role="delete" title="Delete">x</button>
+        <td class="col-action">
+          <div class="profile-configs-actions">
+            <button type="button" class="profile-configs-action profile-configs-view-link" data-role="toggle-details" aria-expanded="false">View</button>
+            <button type="button" class="profile-configs-action profile-configs-edit-btn" data-role="edit">Edit</button>
+            <button type="button" class="profile-configs-action profile-configs-delete-btn" data-role="delete">Delete</button>
+          </div>
         </td>
       </tr>
       <tr class="profile-systems-details-row" data-details-for="${escapeHtml(r.device_id)}" hidden>
-        <td colspan="5">
+        <td colspan="4">
           <div class="profile-systems-details-card">
             <div class="profile-systems-details-grid">
               ${detailRows.map(([label, value]) => `
@@ -807,13 +807,13 @@ import { showEditCloudConfigModal, showEditReportModal } from './components/edit
           .find((row) => row.getAttribute('data-details-for') === deviceId);
         const expanded = btn.getAttribute('aria-expanded') === 'true';
         btn.setAttribute('aria-expanded', expanded ? 'false' : 'true');
-        btn.textContent = expanded ? 'View hardware' : 'Hide hardware';
+        btn.textContent = expanded ? 'View' : 'Hide';
         if (detailRow) detailRow.hidden = expanded;
         return;
       }
       if (btn.dataset.role === 'edit') {
         const row = systemsCache.find(r => r.device_id === deviceId);
-        if (row) openEditSystemForm(row, protonPulseUserId, s);
+        if (row) showEditSystemModal(row, protonPulseUserId, s, () => { void refreshSystems(); });
         return;
       }
       if (btn.dataset.role === 'delete') {
@@ -824,96 +824,6 @@ import { showEditCloudConfigModal, showEditReportModal } from './components/edit
     } catch (e) {
       showSystemsStatus(e.message || 'Action failed', false);
     }
-  }
-
-  function openEditSystemForm(row, protonPulseUserId, session) {
-    const existing = document.getElementById('edit-system-form');
-    if (existing) existing.remove();
-
-    const parsed = parseUploadedSystem(row);
-    const displayLabel = isGenericSystemLabel(row.label) ? inferSystemLabel(row) : (row.label || '');
-    const ramGb = parsed.ram ? parseInt(parsed.ram.replace(/[^0-9]/g, ''), 10) || '' : '';
-
-    const formHtml = `
-      <tr id="edit-system-form" data-editing="${escapeHtml(row.device_id)}">
-        <td colspan="5">
-          <div class="profile-prefill-source" style="margin:8px 0">
-            <div class="profile-prefill-source-title">Edit system</div>
-            <div style="display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px 12px;margin-top:10px">
-              <div><label class="profile-field-label">Label</label><input type="text" id="edit-sys-label" class="profile-select" value="${escapeHtml(displayLabel)}" maxlength="80" style="width:100%"></div>
-              <div><label class="profile-field-label">CPU</label><input type="text" id="edit-sys-cpu" class="profile-select" value="${escapeHtml(parsed.cpu || '')}" maxlength="120" style="width:100%"></div>
-              <div><label class="profile-field-label">GPU</label><input type="text" id="edit-sys-gpu" class="profile-select" value="${escapeHtml(parsed.gpu || '')}" maxlength="120" style="width:100%"></div>
-              <div><label class="profile-field-label">GPU Vendor</label>
-                <select id="edit-sys-gpu-vendor" class="profile-select" style="width:100%">
-                  <option value="">--</option>
-                  <option value="nvidia" ${parsed.gpuVendor === 'nvidia' ? 'selected' : ''}>NVIDIA</option>
-                  <option value="amd" ${parsed.gpuVendor === 'amd' ? 'selected' : ''}>AMD</option>
-                  <option value="intel" ${parsed.gpuVendor === 'intel' ? 'selected' : ''}>Intel</option>
-                </select>
-              </div>
-              <div><label class="profile-field-label">GPU Driver</label><input type="text" id="edit-sys-gpu-driver" class="profile-select" value="${escapeHtml(parsed.gpuDriver || '')}" maxlength="80" style="width:100%"></div>
-              <div><label class="profile-field-label">RAM</label><input type="text" id="edit-sys-ram" class="profile-select" value="${ramGb ? ramGb + ' GB' : ''}" maxlength="20" style="width:100%"></div>
-              <div><label class="profile-field-label">VRAM (MB)</label><input type="number" id="edit-sys-vram" class="profile-select" value="${parsed.vramMb || ''}" min="0" max="262144" style="width:100%"></div>
-              <div><label class="profile-field-label">OS</label><input type="text" id="edit-sys-os" class="profile-select" value="${escapeHtml([parsed.os, parsed.osVersion].filter(Boolean).join(' '))}" maxlength="60" style="width:100%"></div>
-              <div><label class="profile-field-label">Kernel</label><input type="text" id="edit-sys-kernel" class="profile-select" value="${escapeHtml(parsed.kernel || '')}" maxlength="60" style="width:100%"></div>
-            </div>
-            <div style="display:flex;gap:8px;margin-top:10px;align-items:center">
-              <button type="button" class="profile-parse-btn" id="edit-sys-save">Save</button>
-              <button type="button" class="profile-refresh-btn" id="edit-sys-cancel">Cancel</button>
-              <span id="edit-sys-status" style="font-size:0.76rem;color:var(--muted)"></span>
-            </div>
-          </div>
-        </td>
-      </tr>`;
-
-    const mainRow = systemsTbody.querySelector(`tr[data-device-id="${CSS.escape(row.device_id)}"]`);
-    if (!mainRow) return;
-    mainRow.insertAdjacentHTML('afterend', formHtml);
-
-    document.getElementById('edit-sys-cancel')?.addEventListener('click', () => {
-      document.getElementById('edit-system-form')?.remove();
-    });
-
-    document.getElementById('edit-sys-save')?.addEventListener('click', async () => {
-      const label = document.getElementById('edit-sys-label')?.value?.trim() || displayLabel;
-      const cpu = document.getElementById('edit-sys-cpu')?.value?.trim() || '';
-      const gpu = document.getElementById('edit-sys-gpu')?.value?.trim() || '';
-      const gpuDriver = document.getElementById('edit-sys-gpu-driver')?.value?.trim() || '';
-      const ram = document.getElementById('edit-sys-ram')?.value?.trim() || '';
-      const vram = document.getElementById('edit-sys-vram')?.value?.trim() || '';
-      const os = document.getElementById('edit-sys-os')?.value?.trim() || '';
-      const kernel = document.getElementById('edit-sys-kernel')?.value?.trim() || '';
-
-      const lines = [];
-      if (cpu) lines.push(`CPU Brand: ${cpu}`);
-      if (gpu) lines.push(`Video Card: ${gpu}`);
-      if (gpuDriver) lines.push(`Driver Version: ${gpuDriver}`);
-      if (ram) {
-        const gb = parseInt(ram.replace(/[^0-9]/g, ''), 10);
-        if (gb) lines.push(`RAM: ${gb * 1024} Mb`);
-      }
-      if (vram) lines.push(`VRAM: ${vram} Mb`);
-      if (os) lines.push(`OS Version: ${os}`);
-      if (kernel) lines.push(`Kernel Version: ${kernel}`);
-
-      const saveBtn = document.getElementById('edit-sys-save');
-      const statusEl = document.getElementById('edit-sys-status');
-      try {
-        saveBtn.disabled = true;
-        saveBtn.textContent = 'Saving...';
-        await updateSystem(protonPulseUserId, row.device_id, {
-          label,
-          sysinfo_text: lines.join('\n'),
-        }, session);
-        document.getElementById('edit-system-form')?.remove();
-        showSystemsStatus('System updated', true);
-        void refreshSystems();
-      } catch (e) {
-        saveBtn.disabled = false;
-        saveBtn.textContent = 'Save';
-        if (statusEl) { statusEl.textContent = e.message || 'Save failed'; statusEl.style.color = 'var(--red)'; }
-      }
-    });
   }
 
   // Label saves on blur. Using focusout so it bubbles through the table
@@ -941,97 +851,19 @@ import { showEditCloudConfigModal, showEditReportModal } from './components/edit
   systemsTable?.addEventListener('focusout', handleSystemsLabelBlur);
   systemsRefresh?.addEventListener('click', () => { void refreshSystems(); });
 
-  // manual system add form
+  // Add system button opens modal
   const addSysBtn = document.getElementById('add-system-btn');
-  const addSysForm = document.getElementById('add-system-form');
-  const addSysSubmit = document.getElementById('add-sys-submit');
-  const addSysCancel = document.getElementById('add-sys-cancel');
-  const addSysStatus = document.getElementById('add-sys-status');
-  if (addSysBtn && addSysForm) {
-    addSysBtn.addEventListener('click', () => {
-      addSysForm.hidden = !addSysForm.hidden;
-      addSysBtn.textContent = addSysForm.hidden ? '+ Add system' : '- Cancel';
-    });
-  }
-
-  if (addSysCancel && addSysForm && addSysBtn) {
-    addSysCancel.addEventListener('click', () => {
-      addSysForm.hidden = true;
-      addSysBtn.textContent = '+ Add system';
-    });
-  }
-
-  addSysSubmit?.addEventListener('click', async () => {
-    const label = document.getElementById('add-sys-label')?.value?.trim() || 'Manual system';
-    const cpu = document.getElementById('add-sys-cpu')?.value?.trim() || '';
-    const gpu = document.getElementById('add-sys-gpu')?.value?.trim() || '';
-    const gpuVendor = document.getElementById('add-sys-gpu-vendor')?.value || '';
-    const gpuDriver = document.getElementById('add-sys-gpu-driver')?.value?.trim() || '';
-    const ram = document.getElementById('add-sys-ram')?.value?.trim() || '';
-    const vram = document.getElementById('add-sys-vram')?.value?.trim() || '';
-    const os = document.getElementById('add-sys-os')?.value?.trim() || '';
-    const kernel = document.getElementById('add-sys-kernel')?.value?.trim() || '';
-
-    if (!cpu && !gpu) {
-      if (addSysStatus) { addSysStatus.textContent = 'At least CPU or GPU is needed'; addSysStatus.style.color = 'var(--red)'; }
-      return;
-    }
-
-    // build a sysinfo_text blob that parseSteamSystemInfo can read back
-    const lines = [];
-    if (cpu) lines.push(`CPU Brand: ${cpu}`);
-    if (gpu) lines.push(`Video Card: ${gpu}`);
-    if (gpuDriver) lines.push(`Driver Version: ${gpuDriver}`);
-    // convert user-entered GB to the MB format parseSteamSystemInfo expects
-    if (ram) {
-      const gb = parseInt(ram.replace(/[^0-9]/g, ''), 10);
-      lines.push(`RAM: ${gb * 1024} Mb`);
-    }
-    if (vram) lines.push(`VRAM: ${vram} Mb`);
-    if (os) lines.push(`OS Version: ${os}`);
-    if (kernel) lines.push(`Kernel Version: ${kernel}`);
-    const sysinfoText = lines.join('\n');
-
-    // generate a device_id for web-created systems so they dont collide
-    const deviceId = 'web-' + crypto.randomUUID().slice(0, 12);
-
-    try {
-      addSysSubmit.disabled = true;
-      addSysSubmit.textContent = 'Saving...';
+  if (addSysBtn) {
+    addSysBtn.addEventListener('click', async () => {
       const s = await SupaAuth.getSession();
       const protonPulseUserId = getProtonPulseUserIdFromSession(s);
-      if (!protonPulseUserId) throw new Error('Not signed in');
-
-      const isFirst = systemsCache.length === 0;
-
-      const resp = await fetch(supabaseUserSystemsUrl(), {
-        method: 'POST',
-        headers: supabaseHeaders(s, { Prefer: 'return=minimal' }),
-        body: JSON.stringify({
-          proton_pulse_user_id: protonPulseUserId,
-          device_id: deviceId,
-          label,
-          sysinfo_text: sysinfoText,
-          is_default: isFirst,
-          updated_at: new Date().toISOString(),
-        }),
+      if (!protonPulseUserId) return;
+      showAddSystemModal(protonPulseUserId, s, { supabaseUserSystemsUrl, supabaseHeaders, systemsCache }, () => {
+        showSystemsStatus('System added', true);
+        void refreshSystems();
       });
-      if (!resp.ok) throw new Error(`Save failed: HTTP ${resp.status}`);
-
-      addSysForm.hidden = true;
-      addSysBtn.textContent = '+ Add system';
-      // clear the form inputs
-      ['add-sys-label','add-sys-cpu','add-sys-gpu','add-sys-gpu-vendor','add-sys-gpu-driver','add-sys-ram','add-sys-vram','add-sys-os','add-sys-kernel']
-        .forEach(id => { const el = document.getElementById(id); if (el) el.value = ''; });
-      showSystemsStatus('System added', true);
-      void refreshSystems();
-    } catch (e) {
-      if (addSysStatus) { addSysStatus.textContent = e.message || 'Failed'; addSysStatus.style.color = 'var(--red)'; }
-    } finally {
-      addSysSubmit.disabled = false;
-      addSysSubmit.textContent = 'Save system';
-    }
-  });
+    });
+  }
 
   // Initial fetch so the table populates on page load
   void refreshSystems();

--- a/js/profile/main.js
+++ b/js/profile/main.js
@@ -685,7 +685,6 @@ import { showEditCloudConfigModal, showEditReportModal, showEditSystemModal, sho
           <label class="profile-systems-default-toggle" title="Set as default">
             <input type="checkbox" data-role="default" ${r.is_default ? 'checked' : ''}>
             <span class="profile-systems-default-switch" aria-hidden="true"></span>
-            <span class="profile-systems-default-text">Default</span>
           </label>
         </td>
         <td class="col-action">

--- a/js/profile/main.js
+++ b/js/profile/main.js
@@ -979,10 +979,9 @@ import { showEditCloudConfigModal, showEditReportModal } from './components/edit
   const myConfigsRefresh  = document.getElementById('my-configs-refresh-btn');
 
   function showMyConfigsStatus(msg, ok) {
-    if (!myConfigsStatus) return;
-    myConfigsStatus.textContent = msg;
-    myConfigsStatus.style.color = ok ? 'var(--green)' : 'var(--red)';
-    setTimeout(() => { myConfigsStatus.textContent = ''; }, 3000);
+    // Surface report actions (publish/unpublish/delete/update) through the
+    // shared toast so feedback is consistent with the rest of the site.
+    if (ok) window.ppToast?.success(msg); else window.ppToast?.error(msg);
   }
 
   function renderMyConfigs(rows) {

--- a/js/profile/main.js
+++ b/js/profile/main.js
@@ -26,7 +26,7 @@ import {
 import {
   listLinkedPlugins, completePluginLink, removePluginLink,
 } from './api/plugin-links.js?v=59c9f51e';
-import { showEditCloudConfigModal, showEditReportModal, showEditSystemModal, showAddSystemModal } from './components/edit-modals.js?v=27767f46';
+import { showEditCloudConfigModal, showEditReportModal } from './components/edit-modals.js?v=27767f46';
 
 (async function () {
   const signedIn  = document.getElementById('profile-signed-in');
@@ -690,7 +690,7 @@ import { showEditCloudConfigModal, showEditReportModal, showEditSystemModal, sho
         <td class="col-action">
           <div class="profile-configs-actions">
             <button type="button" class="profile-configs-action profile-configs-view-link" data-role="toggle-details" aria-expanded="false">View</button>
-            <button type="button" class="profile-configs-action profile-configs-edit-btn" data-role="edit">Edit</button>
+            <a href="system-edit.html?device=${encodeURIComponent(r.device_id)}" class="profile-configs-action profile-configs-edit-btn">Edit</a>
             <button type="button" class="profile-configs-action profile-configs-delete-btn" data-role="delete">Delete</button>
           </div>
         </td>
@@ -810,11 +810,6 @@ import { showEditCloudConfigModal, showEditReportModal, showEditSystemModal, sho
         if (detailRow) detailRow.hidden = expanded;
         return;
       }
-      if (btn.dataset.role === 'edit') {
-        const row = systemsCache.find(r => r.device_id === deviceId);
-        if (row) showEditSystemModal(row, protonPulseUserId, s, () => { void refreshSystems(); });
-        return;
-      }
       if (btn.dataset.role === 'delete') {
         if (!window.confirm('Delete this system? The plugin will re-create it next time you upload.')) return;
         await deleteSystem(protonPulseUserId, deviceId, s);
@@ -850,17 +845,11 @@ import { showEditCloudConfigModal, showEditReportModal, showEditSystemModal, sho
   systemsTable?.addEventListener('focusout', handleSystemsLabelBlur);
   systemsRefresh?.addEventListener('click', () => { void refreshSystems(); });
 
-  // Add system button opens modal
+  // Add system navigates to system-edit page
   const addSysBtn = document.getElementById('add-system-btn');
   if (addSysBtn) {
-    addSysBtn.addEventListener('click', async () => {
-      const s = await SupaAuth.getSession();
-      const protonPulseUserId = getProtonPulseUserIdFromSession(s);
-      if (!protonPulseUserId) return;
-      showAddSystemModal(protonPulseUserId, s, { supabaseUserSystemsUrl, supabaseHeaders, systemsCache }, () => {
-        showSystemsStatus('System added', true);
-        void refreshSystems();
-      });
+    addSysBtn.addEventListener('click', () => {
+      window.location.href = 'system-edit.html';
     });
   }
 

--- a/js/profile/main.js
+++ b/js/profile/main.js
@@ -1021,7 +1021,7 @@ import { showEditCloudConfigModal, showEditReportModal } from './components/edit
         // already have (proton version, launch options, hardware) and
         // validation enforces the rest before save
         row.cloud && row.unpublished
-          ? `<a class="profile-configs-action profile-configs-publish-btn" href="submit.html?app=${escapeHtml(String(row.app_id))}&fromCloud=1" target="_blank" rel="noopener">Publish</a>`
+          ? `<a class="profile-configs-action profile-configs-publish-btn" href="submit.html?app=${escapeHtml(String(row.app_id))}&fromCloud=1&return=profile.html" target="_blank" rel="noopener">Publish</a>`
           : '',
         row.published_id
           ? `<button type="button" class="profile-configs-action profile-configs-unpublish-btn" data-published-id="${escapeHtml(String(row.published_id))}">Unpublish</button>`
@@ -1030,9 +1030,9 @@ import { showEditCloudConfigModal, showEditReportModal } from './components/edit
         // pre-fill from user_configs). Cloud-only rows go to submit.html?fromCloud=1
         // where a Save button lets them update the draft without publishing.
         row.published_id
-          ? `<a class="profile-configs-action profile-configs-edit-btn" href="submit.html?app=${escapeHtml(String(row.app_id))}&edit=${escapeHtml(String(row.published_id))}" target="_blank" rel="noopener">Edit</a>`
+          ? `<a class="profile-configs-action profile-configs-edit-btn" href="submit.html?app=${escapeHtml(String(row.app_id))}&edit=${escapeHtml(String(row.published_id))}&return=profile.html" target="_blank" rel="noopener">Edit</a>`
           : row.cloud
-            ? `<a class="profile-configs-action profile-configs-edit-btn" href="submit.html?app=${escapeHtml(String(row.app_id))}&fromCloud=1" target="_blank" rel="noopener">Edit</a>`
+            ? `<a class="profile-configs-action profile-configs-edit-btn" href="submit.html?app=${escapeHtml(String(row.app_id))}&fromCloud=1&return=profile.html" target="_blank" rel="noopener">Edit</a>`
             : '',
         `<button type="button" class="profile-configs-action profile-configs-delete-btn" data-app-id="${escapeHtml(String(row.app_id))}">Delete</button>`,
       ].filter(Boolean).join('');

--- a/js/profile/system-edit.js
+++ b/js/profile/system-edit.js
@@ -1,0 +1,133 @@
+import { SUPABASE_URL, SUPABASE_ANON_KEY, SupaAuth } from './config.js?v=87cd0f3d';
+import {
+  getProtonPulseUserIdFromSession, parseSteamSystemInfo, inferGpuVendor,
+  parseUploadedSystem, isGenericSystemLabel, inferSystemLabel, escapeHtml,
+} from './utils.js?v=2324dd84';
+import { supabaseHeaders } from './api/supabase.js?v=bdf4b262';
+import { supabaseUserSystemsUrl, listUserSystems, updateSystem } from './api/systems.js?v=8c9eb2f2';
+
+(async function () {
+  const params = new URLSearchParams(window.location.search);
+  const deviceId = params.get('device');
+  const isAdd = !deviceId;
+
+  const titleEl = document.getElementById('page-title');
+  const eyebrowEl = document.getElementById('page-eyebrow');
+  const formEl = document.getElementById('system-form');
+  const authGate = document.getElementById('auth-gate');
+  const saveBtn = document.getElementById('save-btn');
+  const statusEl = document.getElementById('form-status');
+
+  if (isAdd) {
+    eyebrowEl.textContent = 'Add System';
+    titleEl.textContent = 'New System';
+    document.title = 'Add System — Proton Pulse';
+  } else {
+    eyebrowEl.textContent = 'Edit System';
+    titleEl.textContent = 'Loading...';
+  }
+
+  const session = await SupaAuth.getSession();
+  const protonPulseUserId = getProtonPulseUserIdFromSession(session);
+  if (!protonPulseUserId) {
+    titleEl.textContent = 'Sign in required';
+    authGate.hidden = false;
+    document.getElementById('login-btn')?.addEventListener('click', () => SupaAuth.signIn());
+    return;
+  }
+
+  formEl.hidden = false;
+
+  if (!isAdd) {
+    const rows = await listUserSystems(protonPulseUserId, session);
+    const row = rows.find(r => r.device_id === deviceId);
+    if (!row) {
+      titleEl.textContent = 'System not found';
+      formEl.hidden = true;
+      return;
+    }
+    const parsed = parseUploadedSystem(row);
+    const displayLabel = isGenericSystemLabel(row.label) ? inferSystemLabel(row) : (row.label || '');
+    titleEl.textContent = displayLabel;
+
+    document.getElementById('sys-label').value = displayLabel;
+    document.getElementById('sys-cpu').value = parsed.cpu || '';
+    document.getElementById('sys-gpu').value = parsed.gpu || '';
+    document.getElementById('sys-gpu-vendor').value = parsed.gpuVendor || '';
+    document.getElementById('sys-gpu-driver').value = parsed.gpuDriver || '';
+    const ramGb = parsed.ram ? parseInt(parsed.ram.replace(/[^0-9]/g, ''), 10) || '' : '';
+    document.getElementById('sys-ram').value = ramGb ? `${ramGb} GB` : '';
+    document.getElementById('sys-vram').value = parsed.vramMb || '';
+    document.getElementById('sys-os').value = [parsed.os, parsed.osVersion].filter(Boolean).join(' ');
+    document.getElementById('sys-kernel').value = parsed.kernel || '';
+  } else {
+    titleEl.textContent = 'New System';
+    saveBtn.textContent = 'Save System';
+  }
+
+  formEl.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const label = document.getElementById('sys-label').value.trim() || 'Manual system';
+    const cpu = document.getElementById('sys-cpu').value.trim();
+    const gpu = document.getElementById('sys-gpu').value.trim();
+    const gpuDriver = document.getElementById('sys-gpu-driver').value.trim();
+    const ram = document.getElementById('sys-ram').value.trim();
+    const vram = document.getElementById('sys-vram').value.trim();
+    const os = document.getElementById('sys-os').value.trim();
+    const kernel = document.getElementById('sys-kernel').value.trim();
+
+    if (!cpu && !gpu) {
+      statusEl.textContent = 'At least CPU or GPU is needed';
+      statusEl.style.color = 'var(--red)';
+      return;
+    }
+
+    const lines = [];
+    if (cpu) lines.push(`CPU Brand: ${cpu}`);
+    if (gpu) lines.push(`Video Card: ${gpu}`);
+    if (gpuDriver) lines.push(`Driver Version: ${gpuDriver}`);
+    if (ram) {
+      const gb = parseInt(ram.replace(/[^0-9]/g, ''), 10);
+      if (gb) lines.push(`RAM: ${gb * 1024} Mb`);
+    }
+    if (vram) lines.push(`VRAM: ${vram} Mb`);
+    if (os) lines.push(`OS Version: ${os}`);
+    if (kernel) lines.push(`Kernel Version: ${kernel}`);
+
+    saveBtn.disabled = true;
+    saveBtn.textContent = 'Saving...';
+    statusEl.textContent = '';
+
+    try {
+      if (isAdd) {
+        const newDeviceId = 'web-' + crypto.randomUUID().slice(0, 12);
+        const rows = await listUserSystems(protonPulseUserId, session);
+        const isFirst = rows.length === 0;
+        const resp = await fetch(supabaseUserSystemsUrl(), {
+          method: 'POST',
+          headers: supabaseHeaders(session, { Prefer: 'return=minimal' }),
+          body: JSON.stringify({
+            proton_pulse_user_id: protonPulseUserId,
+            device_id: newDeviceId,
+            label,
+            sysinfo_text: lines.join('\n'),
+            is_default: isFirst,
+            updated_at: new Date().toISOString(),
+          }),
+        });
+        if (!resp.ok) throw new Error(`Save failed: HTTP ${resp.status}`);
+      } else {
+        await updateSystem(protonPulseUserId, deviceId, {
+          label,
+          sysinfo_text: lines.join('\n'),
+        }, session);
+      }
+      window.location.href = 'profile.html';
+    } catch (err) {
+      statusEl.textContent = err.message || 'Save failed';
+      statusEl.style.color = 'var(--red)';
+      saveBtn.disabled = false;
+      saveBtn.textContent = isAdd ? 'Save System' : 'Save Changes';
+    }
+  });
+})();

--- a/js/submit/main.js
+++ b/js/submit/main.js
@@ -345,15 +345,18 @@ import { SupaAuth } from '../shared/config.js?v=f6f2c00a';
         }
         if (result.ok) {
           if (statusEl) { statusEl.textContent = savedText; statusEl.style.color = 'var(--green)'; }
+          window.ppToast?.success(isEdit ? 'Changes saved.' : 'Report submitted. Thanks!');
           if (typeof window.ppTrack === 'function') window.ppTrack('report_submit', { app_id: String(appId), is_edit: isEdit });
           setTimeout(() => { window.location.href = `app.html#/app/${appId}`; }, 1200);
         } else {
           if (statusEl) { statusEl.textContent = result.error || 'Failed'; statusEl.style.color = 'var(--red)'; }
+          window.ppToast?.error(result.error || (isEdit ? 'Could not save changes.' : 'Could not submit the report.'));
           if (submitBtn) { submitBtn.disabled = false; submitBtn.textContent = isEdit ? 'Save Changes' : 'Submit'; }
         }
       } catch (err) {
         console.error('[submit] save failed:', err);
         if (statusEl) { statusEl.textContent = err.message || 'Failed'; statusEl.style.color = 'var(--red)'; }
+        window.ppToast?.error(`Submit failed: ${err.message || err}`);
         if (submitBtn) { submitBtn.disabled = false; submitBtn.textContent = isEdit ? 'Save Changes' : 'Submit'; }
       }
     });

--- a/js/submit/main.js
+++ b/js/submit/main.js
@@ -17,6 +17,13 @@ import { SupaAuth } from '../shared/config.js?v=f6f2c00a';
   // user_configs with form_responses)
   const fromCloud = !isEdit && params.get('fromCloud') === '1';
 
+  // Where to go after a successful save. Defaults to the game page, but the
+  // profile page passes return=profile.html so an edit returns to where the
+  // user came from. Sanitized to a same-origin relative .html path to avoid an
+  // open-redirect: no protocol, no //, must end in .html.
+  const returnRaw = params.get('return') || '';
+  const returnTo = /^[a-z0-9._-]+\.html(?:[?#].*)?$/i.test(returnRaw) ? returnRaw : null;
+
   if (!appId) {
     document.getElementById('game-title').textContent = 'No app ID provided';
     document.getElementById('submit-form-content').innerHTML =
@@ -293,7 +300,6 @@ import { SupaAuth } from '../shared/config.js?v=f6f2c00a';
       const statusEl = el.querySelector('#submit-status');
       const submitBtn = form.querySelector('button[type="submit"]');
       const savingText = isEdit ? 'Saving...' : 'Submitting...';
-      const savedText  = isEdit ? 'Saved! Redirecting...' : 'Report submitted! Redirecting...';
 
       el.querySelectorAll('.sf-question.sf-needs-answer, .sf-row.sf-needs-answer').forEach(q => q.classList.remove('sf-needs-answer'));
       const state = form._formState || {};
@@ -344,10 +350,11 @@ import { SupaAuth } from '../shared/config.js?v=f6f2c00a';
           result = await submitReport(appId, title, form);
         }
         if (result.ok) {
-          if (statusEl) { statusEl.textContent = savedText; statusEl.style.color = 'var(--green)'; }
+          // Toast is the single success confirmation now; no duplicate inline text.
           window.ppToast?.success(isEdit ? 'Changes saved.' : 'Report submitted. Thanks!');
           if (typeof window.ppTrack === 'function') window.ppTrack('report_submit', { app_id: String(appId), is_edit: isEdit });
-          setTimeout(() => { window.location.href = `app.html#/app/${appId}`; }, 1200);
+          const dest = returnTo || `app.html#/app/${appId}`;
+          setTimeout(() => { window.location.href = dest; }, 900);
         } else {
           if (statusEl) { statusEl.textContent = result.error || 'Failed'; statusEl.style.color = 'var(--red)'; }
           window.ppToast?.error(result.error || (isEdit ? 'Could not save changes.' : 'Could not submit the report.'));

--- a/options.html
+++ b/options.html
@@ -9,7 +9,7 @@
 <title>Site Options | Proton Pulse</title>
 <meta name="description" content="Browser-local display preferences for Proton Pulse, including an animations on/off toggle.">
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
+<link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
 <link rel="stylesheet" href="css/options/options.css?v=1df0e588">
 </head>
 <body>

--- a/options.html
+++ b/options.html
@@ -9,7 +9,7 @@
 <title>Site Options | Proton Pulse</title>
 <meta name="description" content="Browser-local display preferences for Proton Pulse, including an animations on/off toggle.">
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=54609d3c">
+<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
 <link rel="stylesheet" href="css/options/options.css?v=1df0e588">
 </head>
 <body>
@@ -57,6 +57,7 @@
 </footer>
 
 <script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/options/main.js?v=c4413624"></script>
 </body>
 </html>

--- a/options.html
+++ b/options.html
@@ -56,7 +56,7 @@
   <a href="terms.html">Terms</a>
 </footer>
 
-<script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/options/main.js?v=c4413624"></script>
 </body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -8,7 +8,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Link Decky Plugin — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=54609d3c">
+<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -8,7 +8,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Link Decky Plugin — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
+<link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/privacy.html
+++ b/privacy.html
@@ -8,7 +8,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Privacy Policy - Proton Pulse</title>
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
+<link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
 <link rel="stylesheet" href="css/index/index.css?v=857e41cf">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }

--- a/privacy.html
+++ b/privacy.html
@@ -8,7 +8,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Privacy Policy - Proton Pulse</title>
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=54609d3c">
+<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
 <link rel="stylesheet" href="css/index/index.css?v=857e41cf">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
@@ -85,5 +85,6 @@
 </div>
 
 <script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -9,7 +9,7 @@
 <title>Privacy Policy - Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
-<link rel="stylesheet" href="css/index/index.css?v=857e41cf">
+<link rel="stylesheet" href="css/index/index.css?v=0bdafa7e">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/privacy.html
+++ b/privacy.html
@@ -84,7 +84,7 @@
 </div>
 </div>
 
-<script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -9,7 +9,7 @@
 <title>My Account — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
-<link rel="stylesheet" href="css/profile/profile.css?v=da401332">
+<link rel="stylesheet" href="css/profile/profile.css?v=43f18079">
 </head>
 <body>
 
@@ -209,31 +209,6 @@
               <button type="button" class="profile-refresh-btn" id="add-system-btn" style="border-color:var(--accent);color:var(--accent)">+ Add system</button>
               <button type="button" class="profile-refresh-btn" id="systems-refresh-btn">Refresh</button>
             </div>
-
-            <!-- inline form for manually adding a system, hidden by default -->
-            <div id="add-system-form" class="profile-prefill-source" hidden style="margin-bottom:12px">
-              <div class="profile-prefill-source-title">Add a system manually</div>
-              <div style="display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px 12px;margin-top:10px">
-                <div><label class="profile-field-label">Label</label><input type="text" id="add-sys-label" class="profile-select" placeholder="e.g. Desktop RTX 4070" maxlength="80" style="width:100%"></div>
-                <div><label class="profile-field-label">CPU</label><input type="text" id="add-sys-cpu" class="profile-select" placeholder="e.g. AMD Ryzen 7 5800X3D" maxlength="120" style="width:100%"></div>
-                <div><label class="profile-field-label">GPU</label><input type="text" id="add-sys-gpu" class="profile-select" placeholder="e.g. NVIDIA GeForce RTX 4070" maxlength="120" style="width:100%"></div>
-                <div><label class="profile-field-label">GPU Vendor</label>
-                  <select id="add-sys-gpu-vendor" class="profile-select" style="width:100%">
-                    <option value="">--</option><option value="nvidia">NVIDIA</option><option value="amd">AMD</option><option value="intel">Intel</option>
-                  </select>
-                </div>
-                <div><label class="profile-field-label">GPU Driver</label><input type="text" id="add-sys-gpu-driver" class="profile-select" placeholder="e.g. Mesa 24.1.0" maxlength="80" style="width:100%"></div>
-                <div><label class="profile-field-label">RAM</label><input type="text" id="add-sys-ram" class="profile-select" placeholder="e.g. 32 GB" maxlength="20" style="width:100%"></div>
-                <div><label class="profile-field-label">VRAM (MB)</label><input type="number" id="add-sys-vram" class="profile-select" placeholder="e.g. 8192" min="0" max="262144" style="width:100%"></div>
-                <div><label class="profile-field-label">OS</label><input type="text" id="add-sys-os" class="profile-select" placeholder="e.g. Arch Linux" maxlength="60" style="width:100%"></div>
-                <div><label class="profile-field-label">Kernel</label><input type="text" id="add-sys-kernel" class="profile-select" placeholder="e.g. 6.8.0" maxlength="60" style="width:100%"></div>
-              </div>
-              <div style="display:flex;gap:8px;margin-top:10px;align-items:center">
-                <button type="button" class="profile-parse-btn" id="add-sys-submit">Save system</button>
-                <button type="button" class="profile-refresh-btn" id="add-sys-cancel">Cancel</button>
-                <span id="add-sys-status" style="font-size:0.76rem;color:var(--muted)"></span>
-              </div>
-            </div>
             <div id="systems-empty" class="profile-field-hint" hidden>
               Open Pulse on your Steam Deck and press <strong>Upload to Pulse</strong> in the plugin settings. Your systems will show up here.
             </div>
@@ -244,8 +219,7 @@
                   <th>Label</th>
                   <th>Updated</th>
                   <th class="col-default">Default</th>
-                  <th class="col-edit"></th>
-                  <th class="col-delete"></th>
+                  <th class="col-action"></th>
                 </tr>
               </thead>
               <tbody id="systems-tbody"></tbody>
@@ -310,6 +284,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/profile/main.js?v=e94d36c6"></script>
+<script type="module" src="js/profile/main.js?v=cc06c649"></script>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -309,6 +309,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/profile/main.js?v=b7dc83bd"></script>
+<script type="module" src="js/profile/main.js?v=e87a73e0"></script>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -9,7 +9,7 @@
 <title>My Account — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
-<link rel="stylesheet" href="css/profile/profile.css?v=43f18079">
+<link rel="stylesheet" href="css/profile/profile.css?v=ebafcea9">
 </head>
 <body>
 
@@ -284,6 +284,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/profile/main.js?v=cc06c649"></script>
+<script type="module" src="js/profile/main.js?v=bea77de8"></script>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -8,8 +8,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>My Account — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
-<link rel="stylesheet" href="css/profile/profile.css?v=f806abc2">
+<link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
+<link rel="stylesheet" href="css/profile/profile.css?v=b62240da">
 </head>
 <body>
 

--- a/profile.html
+++ b/profile.html
@@ -9,7 +9,7 @@
 <title>My Account — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
-<link rel="stylesheet" href="css/profile/profile.css?v=b62240da">
+<link rel="stylesheet" href="css/profile/profile.css?v=da401332">
 </head>
 <body>
 
@@ -244,6 +244,7 @@
                   <th>Label</th>
                   <th>Updated</th>
                   <th class="col-default">Default</th>
+                  <th class="col-edit"></th>
                   <th class="col-delete"></th>
                 </tr>
               </thead>
@@ -309,6 +310,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/profile/main.js?v=e87a73e0"></script>
+<script type="module" src="js/profile/main.js?v=e94d36c6"></script>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -8,7 +8,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>My Account — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=54609d3c">
+<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
 <link rel="stylesheet" href="css/profile/profile.css?v=f806abc2">
 </head>
 <body>
@@ -308,6 +308,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/profile/main.js?v=462abf9f"></script>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -284,6 +284,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/profile/main.js?v=bea77de8"></script>
+<script type="module" src="js/profile/main.js?v=267ea616"></script>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -309,6 +309,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/profile/main.js?v=462abf9f"></script>
+<script type="module" src="js/profile/main.js?v=b7dc83bd"></script>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -307,7 +307,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/profile/main.js?v=462abf9f"></script>
 </body>

--- a/scoring.html
+++ b/scoring.html
@@ -9,7 +9,7 @@
 <title>How Scoring Works - Proton Pulse</title>
 <meta name="description" content="Transparent explanation of how Proton Pulse scores compatibility reports against your hardware. Identical algorithm to the Decky Loader plugin - one canonical source of truth, no hidden magic.">
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
+<link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/scoring.html
+++ b/scoring.html
@@ -9,7 +9,7 @@
 <title>How Scoring Works - Proton Pulse</title>
 <meta name="description" content="Transparent explanation of how Proton Pulse scores compatibility reports against your hardware. Identical algorithm to the Decky Loader plugin - one canonical source of truth, no hidden magic.">
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=54609d3c">
+<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
 <style>
 h1 {
   font-family: var(--font-display);
@@ -488,6 +488,7 @@ h2 small {
 </head>
 <body>
 <script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">
 

--- a/scoring.html
+++ b/scoring.html
@@ -487,7 +487,7 @@ h2 small {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/stats.html
+++ b/stats.html
@@ -9,7 +9,7 @@
 <title>Stats - Proton Pulse</title>
 <meta name="description" content="Aggregate compatibility stats for Steam on Linux: ratings, GPU and CPU breakdowns, OS distribution, Proton version share, and top-reported games. Filter by hardware to drill in.">
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
+<link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/stats.html
+++ b/stats.html
@@ -9,7 +9,7 @@
 <title>Stats - Proton Pulse</title>
 <meta name="description" content="Aggregate compatibility stats for Steam on Linux: ratings, GPU and CPU breakdowns, OS distribution, Proton version share, and top-reported games. Filter by hardware to drill in.">
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=54609d3c">
+<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
 <style>
 h1 {
   font-family: var(--font-display);
@@ -707,6 +707,7 @@ h2 {
 </head>
 <body>
 <script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">
 

--- a/stats.html
+++ b/stats.html
@@ -706,7 +706,7 @@ h2 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/submit.html
+++ b/submit.html
@@ -8,7 +8,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Submit Report — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
+<link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
 <link rel="stylesheet" href="css/app/app.css?v=2b4c5354">
 </head>
 <body>

--- a/submit.html
+++ b/submit.html
@@ -9,7 +9,7 @@
 <title>Submit Report — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
-<link rel="stylesheet" href="css/app/app.css?v=27333665">
+<link rel="stylesheet" href="css/app/app.css?v=c7bfd836">
 </head>
 <body>
 

--- a/submit.html
+++ b/submit.html
@@ -9,7 +9,7 @@
 <title>Submit Report — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
-<link rel="stylesheet" href="css/app/app.css?v=ae4d65d4">
+<link rel="stylesheet" href="css/app/app.css?v=27333665">
 </head>
 <body>
 

--- a/submit.html
+++ b/submit.html
@@ -9,7 +9,7 @@
 <title>Submit Report — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
-<link rel="stylesheet" href="css/app/app.css?v=6be7d31a">
+<link rel="stylesheet" href="css/app/app.css?v=ae4d65d4">
 </head>
 <body>
 

--- a/submit.html
+++ b/submit.html
@@ -9,7 +9,7 @@
 <title>Submit Report — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
-<link rel="stylesheet" href="css/app/app.css?v=2b4c5354">
+<link rel="stylesheet" href="css/app/app.css?v=6be7d31a">
 </head>
 <body>
 

--- a/submit.html
+++ b/submit.html
@@ -8,7 +8,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Submit Report — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=54609d3c">
+<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
 <link rel="stylesheet" href="css/app/app.css?v=2b4c5354">
 </head>
 <body>
@@ -16,6 +16,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">
   <div class="main-inner" style="max-width:860px">
@@ -46,6 +47,6 @@
   </div>
 </div>
 
-<script type="module" src="js/submit/main.js?v=5a30fc22"></script>
+<script type="module" src="js/submit/main.js?v=f8125fc1"></script>
 </body>
 </html>

--- a/submit.html
+++ b/submit.html
@@ -15,7 +15,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/submit.html
+++ b/submit.html
@@ -47,6 +47,6 @@
   </div>
 </div>
 
-<script type="module" src="js/submit/main.js?v=f8125fc1"></script>
+<script type="module" src="js/submit/main.js?v=ff057316"></script>
 </body>
 </html>

--- a/system-edit.html
+++ b/system-edit.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+<meta http-equiv="Pragma" content="no-cache">
+<meta http-equiv="Expires" content="0">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Edit System — Proton Pulse</title>
+<meta name="color-scheme" content="dark">
+<link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
+<link rel="stylesheet" href="css/profile/profile.css?v=ebafcea9">
+</head>
+<body>
+
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
+<script src="js/lib/supabase-client.js?v=04813aa1"></script>
+<script src="js/lib/topbar.js?v=38d23fe3"></script>
+<script src="js/lib/toast.js?v=7bb23014"></script>
+
+<div class="main-content">
+  <div class="main-inner" style="max-width:640px">
+
+    <div style="display:flex;align-items:center;gap:14px;margin-bottom:24px">
+      <a href="profile.html" class="hub-link" style="flex-shrink:0">
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" style="vertical-align:-2px"><path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/></svg>
+        Back to profile
+      </a>
+    </div>
+
+    <div class="page-header" style="margin-bottom:20px">
+      <div class="eyebrow" id="page-eyebrow">Edit System</div>
+      <div class="page-title" id="page-title">Loading...</div>
+    </div>
+
+    <div id="auth-gate" hidden>
+      <div style="padding:32px;background:var(--s1);border:1px solid var(--border);text-align:center">
+        <p style="color:var(--muted);margin-bottom:14px">Sign in with Steam to edit your system</p>
+        <button class="gh-login-btn" id="login-btn" style="margin:0 auto">
+          <span class="gh-login-btn__badge"><img class="gh-login-btn__icon" src="assets/steam-logo-glyph.png" alt=""></span>
+          <span class="gh-login-btn__label">Login with Steam</span>
+        </button>
+      </div>
+    </div>
+
+    <form id="system-form" class="profile-section" hidden>
+      <div class="profile-section-title" id="form-section-title">System details</div>
+      <div class="profile-field">
+        <label class="profile-field-label" for="sys-label">Label</label>
+        <input type="text" id="sys-label" class="profile-select" style="width:100%" maxlength="80" placeholder="e.g. Desktop RTX 4070">
+      </div>
+      <div class="profile-field">
+        <label class="profile-field-label" for="sys-cpu">CPU</label>
+        <input type="text" id="sys-cpu" class="profile-select" style="width:100%" maxlength="120" placeholder="e.g. AMD Ryzen 7 5800X3D">
+      </div>
+      <div class="profile-field">
+        <label class="profile-field-label" for="sys-gpu">GPU</label>
+        <input type="text" id="sys-gpu" class="profile-select" style="width:100%" maxlength="120" placeholder="e.g. NVIDIA GeForce RTX 4070">
+      </div>
+      <div class="profile-field">
+        <label class="profile-field-label" for="sys-gpu-vendor">GPU Vendor</label>
+        <select id="sys-gpu-vendor" class="profile-select" style="width:100%">
+          <option value="">--</option>
+          <option value="nvidia">NVIDIA</option>
+          <option value="amd">AMD</option>
+          <option value="intel">Intel</option>
+        </select>
+      </div>
+      <div class="profile-field">
+        <label class="profile-field-label" for="sys-gpu-driver">GPU Driver</label>
+        <input type="text" id="sys-gpu-driver" class="profile-select" style="width:100%" maxlength="80" placeholder="e.g. Mesa 24.1.0">
+      </div>
+      <div class="profile-field">
+        <label class="profile-field-label" for="sys-ram">RAM</label>
+        <input type="text" id="sys-ram" class="profile-select" style="width:100%" maxlength="20" placeholder="e.g. 32 GB">
+      </div>
+      <div class="profile-field">
+        <label class="profile-field-label" for="sys-vram">VRAM (MB)</label>
+        <input type="number" id="sys-vram" class="profile-select" style="width:100%" min="0" max="262144" placeholder="e.g. 8192">
+      </div>
+      <div class="profile-field">
+        <label class="profile-field-label" for="sys-os">OS</label>
+        <input type="text" id="sys-os" class="profile-select" style="width:100%" maxlength="60" placeholder="e.g. Arch Linux">
+      </div>
+      <div class="profile-field">
+        <label class="profile-field-label" for="sys-kernel">Kernel</label>
+        <input type="text" id="sys-kernel" class="profile-select" style="width:100%" maxlength="60" placeholder="e.g. 6.8.0">
+      </div>
+      <div class="profile-field" style="display:flex;gap:10px;align-items:center">
+        <button type="submit" class="profile-parse-btn" id="save-btn">Save Changes</button>
+        <a href="profile.html" class="profile-refresh-btn" style="text-decoration:none">Cancel</a>
+        <span id="form-status" style="font-size:0.76rem"></span>
+      </div>
+    </form>
+
+  </div>
+</div>
+
+<script type="module" src="js/profile/system-edit.js?v=95998027"></script>
+</body>
+</html>

--- a/terms.html
+++ b/terms.html
@@ -8,7 +8,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Terms of Service - Proton Pulse</title>
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
+<link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
 <link rel="stylesheet" href="css/index/index.css?v=857e41cf">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }

--- a/terms.html
+++ b/terms.html
@@ -9,7 +9,7 @@
 <title>Terms of Service - Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/site.css?v=aa1f96c6">
-<link rel="stylesheet" href="css/index/index.css?v=857e41cf">
+<link rel="stylesheet" href="css/index/index.css?v=0bdafa7e">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/terms.html
+++ b/terms.html
@@ -8,7 +8,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Terms of Service - Proton Pulse</title>
 <meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="css/shared/site.css?v=54609d3c">
+<link rel="stylesheet" href="css/shared/site.css?v=912ea88e">
 <link rel="stylesheet" href="css/index/index.css?v=857e41cf">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
@@ -87,5 +87,6 @@
 </div>
 
 <script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -86,7 +86,7 @@
 </div>
 </div>
 
-<script src="js/lib/topbar.js?v=e210caf6"></script>
+<script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/tests/editReturn.test.js
+++ b/tests/editReturn.test.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+const read = (p) => fs.readFileSync(path.join(__dirname, '..', p), 'utf8');
+
+describe('edit/submit return-to-origin and toast-only success', () => {
+  const submitSrc = read('js/submit/main.js');
+  const profileSrc = read('js/profile/main.js');
+
+  test('profile edit/publish links pass return=profile.html', () => {
+    expect(profileSrc).toContain('&edit=${escapeHtml(String(row.published_id))}&return=profile.html');
+    expect(profileSrc).toContain('&fromCloud=1&return=profile.html');
+  });
+
+  test('submit reads and sanitizes the return param (no open redirect)', () => {
+    expect(submitSrc).toContain("const returnRaw = params.get('return') || ''");
+    // must be a same-origin relative .html path
+    expect(submitSrc).toContain('\\.html(?:[?#].*)?$/i.test(returnRaw)');
+  });
+
+  test('redirect prefers returnTo, falls back to the game page', () => {
+    expect(submitSrc).toContain('const dest = returnTo || `app.html#/app/${appId}`');
+    expect(submitSrc).toContain('window.location.href = dest');
+  });
+
+  test('success is shown only via toast, not a duplicate inline status', () => {
+    expect(submitSrc).toContain("window.ppToast?.success(isEdit ? 'Changes saved.'");
+    expect(submitSrc).not.toContain('savedText');
+  });
+});

--- a/tests/gridSize.test.js
+++ b/tests/gridSize.test.js
@@ -44,4 +44,12 @@ describe('configurable card size (S/M/L)', () => {
     expect(homeSrc).toContain('function _popularItemHtml(g)');
     expect(homeSrc).toContain("if (currentLayout === 'list') return _listRowHtml(g)");
   });
+
+  test('load more keeps the current view in both sections', () => {
+    // recent appends with the layout-aware renderFn, popular with _popularItemHtml
+    expect(homeSrc).toContain('batch.map(renderFn).join(\'\')');
+    expect(homeSrc).toContain('batch.map(_popularItemHtml).join(\'\')');
+    // the old layout-blind _appendCards helper is gone
+    expect(homeSrc).not.toContain('function _appendCards');
+  });
 });

--- a/tests/gridSize.test.js
+++ b/tests/gridSize.test.js
@@ -30,4 +30,18 @@ describe('configurable card size (S/M/L)', () => {
     expect(cssSrc).toContain('.cards--md .game-card-thumb');
     expect(cssSrc).toContain('.cards--lg .game-card-thumb');
   });
+
+  test('S/M/L are disabled in list mode', () => {
+    expect(homeSrc).toContain('function _setSizeEnabled(enabled)');
+    expect(homeSrc).toContain('b.disabled = !enabled');
+    expect(homeSrc).toContain('_setSizeEnabled(!isList)');
+    expect(cssSrc).toContain('.home-size-btn:disabled');
+  });
+
+  test('list view applies to both Recent and Popular sections', () => {
+    expect(homeSrc).toContain("document.getElementById('cards-popular')?.classList.toggle('home-cards-list', isList)");
+    // popular renders a slim list row in list mode, a sized card otherwise
+    expect(homeSrc).toContain('function _popularItemHtml(g)');
+    expect(homeSrc).toContain("if (currentLayout === 'list') return _listRowHtml(g)");
+  });
 });

--- a/tests/gridSize.test.js
+++ b/tests/gridSize.test.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+const read = (p) => fs.readFileSync(path.join(__dirname, '..', p), 'utf8');
+
+describe('configurable card size (S/M/L)', () => {
+  const homeSrc = read('js/app/components/home.js');
+  const cssSrc = read('css/app/app.css');
+
+  test('renders an S/M/L size toggle', () => {
+    expect(homeSrc).toContain('id="home-size-toggle"');
+    expect(homeSrc).toContain('data-size="sm"');
+    expect(homeSrc).toContain('data-size="md"');
+    expect(homeSrc).toContain('data-size="lg"');
+  });
+
+  test('size is a saved user preference defaulting to medium', () => {
+    expect(homeSrc).toContain("const SIZE_KEY = 'pp:grid-size'");
+    expect(homeSrc).toContain('localStorage.setItem(SIZE_KEY, size)');
+    expect(homeSrc).toContain("return SIZES.includes(s) ? s : 'md'");
+    expect(homeSrc).toContain('applyGridSize(_savedSize())');
+  });
+
+  test('size class is applied to both card lists', () => {
+    expect(homeSrc).toContain("['cards-recent', 'cards-popular'].forEach");
+    expect(homeSrc).toContain('el2.classList.add(`cards--${size}`)');
+  });
+
+  test('CSS defines the three card sizes', () => {
+    expect(cssSrc).toContain('.cards--sm .game-card-thumb');
+    expect(cssSrc).toContain('.cards--md .game-card-thumb');
+    expect(cssSrc).toContain('.cards--lg .game-card-thumb');
+  });
+});

--- a/tests/gridSize.test.js
+++ b/tests/gridSize.test.js
@@ -20,6 +20,12 @@ describe('configurable card size (S/M/L)', () => {
     expect(homeSrc).toContain('applyGridSize(_savedSize())');
   });
 
+  test('list/grid layout is also a saved preference, restored on load', () => {
+    expect(homeSrc).toContain("const LAYOUT_KEY = 'pp:grid-layout'");
+    expect(homeSrc).toContain('localStorage.setItem(LAYOUT_KEY, btn.dataset.layout)');
+    expect(homeSrc).toContain('applyLayout(_savedLayout())');
+  });
+
   test('size class is applied to both card lists', () => {
     expect(homeSrc).toContain("['cards-recent', 'cards-popular'].forEach");
     expect(homeSrc).toContain('el2.classList.add(`cards--${size}`)');

--- a/tests/indexPopularFilters.test.js
+++ b/tests/indexPopularFilters.test.js
@@ -35,20 +35,18 @@ describe('index page popular games rating filters', () => {
     expect(indexSrc).toContain('const state = { rated: true, unrated: false }');
   });
 
-  test('render combines the two filters and supports any combination', () => {
+  test('render shows whichever single filter is active', () => {
     expect(indexSrc).toContain('...(state.rated ? ratedGames : [])');
     expect(indexSrc).toContain('...(state.unrated ? unratedGames : [])');
   });
 
-  test('each button toggles its own state independently', () => {
-    expect(indexSrc).toContain("state[key] = !state[key]");
-    expect(indexSrc).toContain("btn.classList.toggle('pg-filter--active', state[key])");
-    expect(indexSrc).toContain("wireFilter(ratedBtn, 'rated')");
-    expect(indexSrc).toContain("wireFilter(unratedBtn, 'unrated')");
-  });
-
-  test('shows an empty state when both filters are off', () => {
-    expect(indexSrc).toContain("class=\"pg-empty\"");
+  test('Rated / Not Rated are mutually exclusive (selecting one deselects the other)', () => {
+    expect(indexSrc).toContain("state.rated = key === 'rated'");
+    expect(indexSrc).toContain("state.unrated = key === 'unrated'");
+    expect(indexSrc).toContain("ratedBtn?.addEventListener('click', () => selectFilter('rated'))");
+    expect(indexSrc).toContain("unratedBtn?.addEventListener('click', () => selectFilter('unrated'))");
+    // old independent-toggle behavior is gone
+    expect(indexSrc).not.toContain('state[key] = !state[key]');
   });
 
   test('popular list pages with a load more button', () => {

--- a/tests/toast.test.js
+++ b/tests/toast.test.js
@@ -73,6 +73,13 @@ describe('actions give feedback via ppToast', () => {
     expect(src).toContain('window.ppToast?.error');
   });
 
+  test('admin and profile actions use toasts, not alert()', () => {
+    expect(read('js/admin/main.js')).not.toContain('alert(');
+    expect(read('js/admin/components/userDetail.js')).not.toContain('alert(');
+    expect(read('js/profile/main.js')).toContain('window.ppToast?.success(msg)');
+    expect(read('js/auth/main.js')).toContain('window.ppToast?.error');
+  });
+
   test('toast.js is in the gh-pages manifest', () => {
     expect(read('gh-pages-manifest.txt')).toContain('js/lib/toast.js');
   });

--- a/tests/toast.test.js
+++ b/tests/toast.test.js
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment jest-environment-jsdom
+ */
+const fs = require('fs');
+const path = require('path');
+
+beforeAll(() => {
+  const src = fs.readFileSync(path.join(__dirname, '..', 'js', 'lib', 'toast.js'), 'utf8');
+  window.eval(src); // toast.js is a classic IIFE that sets window.ppToast
+});
+
+describe('ppToast', () => {
+  beforeEach(() => { document.body.innerHTML = ''; });
+
+  test('exposes window.ppToast with success/error/info helpers', () => {
+    expect(typeof window.ppToast).toBe('function');
+    expect(typeof window.ppToast.success).toBe('function');
+    expect(typeof window.ppToast.error).toBe('function');
+    expect(typeof window.ppToast.info).toBe('function');
+  });
+
+  test('renders a toast with the message and the type class', () => {
+    window.ppToast.success('Saved');
+    const t = document.querySelector('.pp-toast');
+    expect(t).toBeTruthy();
+    expect(t.classList.contains('pp-toast--success')).toBe(true);
+    expect(t.querySelector('.pp-toast-msg').textContent).toBe('Saved');
+  });
+
+  test('error toasts announce via role=alert', () => {
+    window.ppToast.error('Boom');
+    expect(document.querySelector('.pp-toast--error').getAttribute('role')).toBe('alert');
+  });
+
+  test('the close button dismisses the toast', () => {
+    window.ppToast('hi');
+    const t = document.querySelector('.pp-toast');
+    t.querySelector('.pp-toast-close').click();
+    expect(t.classList.contains('pp-toast--out')).toBe(true);
+  });
+
+  test('multiple toasts stack inside one container', () => {
+    window.ppToast('a');
+    window.ppToast('b');
+    expect(document.querySelectorAll('#pp-toast-container .pp-toast').length).toBe(2);
+  });
+});
+
+describe('actions give feedback via ppToast', () => {
+  const read = (p) => fs.readFileSync(path.join(__dirname, '..', p), 'utf8');
+
+  test('flag report toasts on success and failure', () => {
+    const src = read('js/app/components/game-page.js');
+    expect(src).toContain("window.ppToast?.success('Report flagged for review");
+    expect(src).toContain('window.ppToast?.error(\'Could not flag the report');
+  });
+
+  test('submit report toasts on success and failure', () => {
+    const src = read('js/submit/main.js');
+    expect(src).toContain('window.ppToast?.success(');
+    expect(src).toContain('window.ppToast?.error(');
+  });
+
+  test('admin moderation actions toast on success and failure', () => {
+    const src = read('js/admin/main.js');
+    expect(src).toContain('window.ppToast?.success(doneMsg)');
+    expect(src).toContain('window.ppToast?.error(`Action failed');
+    expect(src).toContain("window.ppToast?.success('Flag entry deleted.')");
+  });
+
+  test('vote failures surface a toast', () => {
+    const src = read('js/app/api/votes.js');
+    expect(src).toContain('window.ppToast?.error');
+  });
+
+  test('toast.js is in the gh-pages manifest', () => {
+    expect(read('gh-pages-manifest.txt')).toContain('js/lib/toast.js');
+  });
+});


### PR DESCRIPTION
## Summary

- Configurable card size (S/M/L) and Grid/List view toggle on both the browse page and the homepage popular games section. Preferences persist in localStorage and sync across pages.
- Toast notifications replace all alert() calls site-wide (submit, flag, vote, admin actions, auth).
- My Hardware: full-page edit/add form (system-edit.html), View/Edit/Delete buttons match My Reports style.
- Report cards now show Steam username + avatar for web-submitted reports (was showing "WEB USER" because proton_pulse_user_id was missing from the fetch query).
- Discord webhook workflows for issues, PRs, and releases (already on main).
- UI polish: full username in topbar on desktop, confidence/rating column width, rated/unrated mutually exclusive pills.

## Test plan

- [x] S/M/L and Grid/List verified on staging index and app pages
- [x] Toast notifications confirmed working across submit, flag, vote, admin flows
- [x] Hardware edit page loads pre-filled, saves, redirects back to profile
- [x] Steam username and avatar now display on web-submitted report cards
- [x] All tests pass (520/520)