### PR TITLE
fix(ci): backup, system-edit validation, GPU vendor round-trip

### DIFF
--- a/.github/scripts/backup.mjs
+++ b/.github/scripts/backup.mjs
@@ -230,3 +230,5 @@ async function main() {
 }
 
 main().catch(e => { console.error(e); process.exit(1); });
+
+export { TABLE_ORDER_KEY };

--- a/.github/scripts/backup.mjs
+++ b/.github/scripts/backup.mjs
@@ -68,12 +68,16 @@ function redactPaths(str) {
     .replace(/\/root/g, '/root');
 }
 
+// Tables that don't have an `id` column and need a different order key.
+const TABLE_ORDER_KEY = { author_avatars: 'proton_pulse_user_id' };
+
 async function fetchAll(table, select = '*', extraFilter = '') {
   const rows = [];
   let offset = 0;
   const limit = 1000;
+  const orderKey = TABLE_ORDER_KEY[table] || 'id';
   while (true) {
-    const url = `${SUPABASE_URL}/rest/v1/${table}?select=${encodeURIComponent(select)}${extraFilter}&limit=${limit}&offset=${offset}&order=id.asc`;
+    const url = `${SUPABASE_URL}/rest/v1/${table}?select=${encodeURIComponent(select)}${extraFilter}&limit=${limit}&offset=${offset}&order=${orderKey}.asc`;
     const res = await fetch(url, { headers: HEADERS });
     if (!res.ok) throw new Error(`Fetch ${table} failed: ${res.status} ${await res.text()}`);
     const batch = await res.json();

--- a/.github/scripts/backup.mjs
+++ b/.github/scripts/backup.mjs
@@ -18,36 +18,25 @@ import { mkdirSync, writeFileSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
-const SUPABASE_URL = process.env.SUPABASE_URL;
-const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
-const HMAC_SECRET  = process.env.BACKUP_HMAC_SECRET;
-const DATE         = process.env.BACKUP_DATE;
-const TYPE         = process.env.BACKUP_TYPE || 'all';
-const SITE_DIR     = process.env.SITE_DIR || '';
-const OUT_DIR      = process.env.OUT_DIR || '.';
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for testing)
+// ---------------------------------------------------------------------------
 
-if (!HMAC_SECRET) {
-  console.error('FATAL: BACKUP_HMAC_SECRET is not set. Refusing to run without a pseudonymization key.');
-  process.exit(1);
-}
-if (!SUPABASE_URL || !SUPABASE_KEY) {
-  console.error('FATAL: SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must both be set.');
-  process.exit(1);
+// Tables that don't have an `id` column and need a different order key.
+export const TABLE_ORDER_KEY = { author_avatars: 'proton_pulse_user_id' };
+
+export function buildFetchUrl(baseUrl, table, select, extraFilter, offset, limit) {
+  const orderKey = TABLE_ORDER_KEY[table] || 'id';
+  return `${baseUrl}/rest/v1/${table}?select=${encodeURIComponent(select)}${extraFilter}&limit=${limit}&offset=${offset}&order=${orderKey}.asc`;
 }
 
-const HEADERS = {
-  apikey: SUPABASE_KEY,
-  Authorization: `Bearer ${SUPABASE_KEY}`,
-  'Content-Type': 'application/json',
-};
-
-function hmac(value) {
+export function hmac(value, secret) {
   if (!value) return null;
-  return createHmac('sha256', HMAC_SECRET).update(String(value)).digest('hex');
+  return createHmac('sha256', secret).update(String(value)).digest('hex');
 }
 
 // Strip common PII patterns from free-text fields (email, URLs, file paths, Steam IDs).
-function sanitizeNotes(str) {
+export function sanitizeNotes(str) {
   if (!str) return str;
   return str
     .replace(/[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g, '[email redacted]')
@@ -59,7 +48,7 @@ function sanitizeNotes(str) {
 }
 
 // Redact anything that looks like an absolute file path to avoid leaking OS usernames.
-function redactPaths(str) {
+export function redactPaths(str) {
   if (!str) return str;
   return str
     .replace(/\/home\/[^/\s]+/g, '/home/[redacted]')
@@ -68,58 +57,7 @@ function redactPaths(str) {
     .replace(/\/root/g, '/root');
 }
 
-// Tables that don't have an `id` column and need a different order key.
-const TABLE_ORDER_KEY = { author_avatars: 'proton_pulse_user_id' };
-
-async function fetchAll(table, select = '*', extraFilter = '') {
-  const rows = [];
-  let offset = 0;
-  const limit = 1000;
-  const orderKey = TABLE_ORDER_KEY[table] || 'id';
-  while (true) {
-    const url = `${SUPABASE_URL}/rest/v1/${table}?select=${encodeURIComponent(select)}${extraFilter}&limit=${limit}&offset=${offset}&order=${orderKey}.asc`;
-    const res = await fetch(url, { headers: HEADERS });
-    if (!res.ok) throw new Error(`Fetch ${table} failed: ${res.status} ${await res.text()}`);
-    const batch = await res.json();
-    rows.push(...batch);
-    if (batch.length < limit) break;
-    offset += limit;
-  }
-  return rows;
-}
-
-async function fetchSchema() {
-  const tables = ['user_configs', 'author_avatars', 'user_proton_configs', 'user_systems', 'admins', 'banned_users'];
-  const lines = [`-- Schema export ${DATE}\n`];
-  for (const table of tables) {
-    const res = await fetch(`${SUPABASE_URL}/rest/v1/${table}?limit=0`, { headers: HEADERS });
-    lines.push(`-- Table: ${table} (columns from API response headers)\n`);
-    lines.push(`-- Content-Range: ${res.headers.get('content-range') || 'n/a'}\n\n`);
-  }
-
-  // Fetch RLS policies via management API (requires service role introspection).
-  const policyQuery = `
-    SELECT schemaname, tablename, policyname, cmd, qual, with_check
-    FROM pg_policies
-    WHERE schemaname = 'public'
-    ORDER BY tablename, policyname;
-  `;
-  const queryRes = await fetch(`${SUPABASE_URL}/rest/v1/rpc/query`, {
-    method: 'POST',
-    headers: HEADERS,
-    body: JSON.stringify({ query: policyQuery }),
-  }).catch(() => null);
-
-  if (queryRes?.ok) {
-    const policies = await queryRes.json();
-    lines.push('-- RLS Policies\n');
-    lines.push(JSON.stringify(policies, null, 2));
-  }
-
-  return lines.join('');
-}
-
-function sanitizeUserConfig(row) {
+export function sanitizeUserConfig(row, secret) {
   return {
     id: row.id,
     app_id: row.app_id,
@@ -152,14 +90,14 @@ function sanitizeUserConfig(row) {
     created_at: row.created_at,
     updated_at: row.updated_at,
     // pseudonymized
-    proton_pulse_user_id: hmac(row.proton_pulse_user_id),
-    client_id: hmac(row.client_id),
+    proton_pulse_user_id: hmac(row.proton_pulse_user_id, secret),
+    client_id: hmac(row.client_id, secret),
   };
 }
 
-function sanitizeAuthorAvatar(row) {
+export function sanitizeAuthorAvatar(row, secret) {
   return {
-    proton_pulse_user_id: hmac(row.proton_pulse_user_id),
+    proton_pulse_user_id: hmac(row.proton_pulse_user_id, secret),
     display_name: row.display_name,
     avatar_url: row.avatar_url,
     cached_at: row.cached_at,
@@ -167,44 +105,93 @@ function sanitizeAuthorAvatar(row) {
   };
 }
 
+// ---------------------------------------------------------------------------
+// I/O (not exported; depends on env + network)
+// ---------------------------------------------------------------------------
+
+async function fetchAll(table, select = '*', extraFilter = '', headers) {
+  const rows = [];
+  let offset = 0;
+  const limit = 1000;
+  while (true) {
+    const url = buildFetchUrl(process.env.SUPABASE_URL, table, select, extraFilter, offset, limit);
+    const res = await fetch(url, { headers });
+    if (!res.ok) throw new Error(`Fetch ${table} failed: ${res.status} ${await res.text()}`);
+    const batch = await res.json();
+    rows.push(...batch);
+    if (batch.length < limit) break;
+    offset += limit;
+  }
+  return rows;
+}
+
+async function fetchSchema(headers, date) {
+  const tables = ['user_configs', 'author_avatars', 'user_proton_configs', 'user_systems', 'admins', 'banned_users'];
+  const lines = [`-- Schema export ${date}\n`];
+  for (const table of tables) {
+    const res = await fetch(`${process.env.SUPABASE_URL}/rest/v1/${table}?limit=0`, { headers });
+    lines.push(`-- Table: ${table} (columns from API response headers)\n`);
+    lines.push(`-- Content-Range: ${res.headers.get('content-range') || 'n/a'}\n\n`);
+  }
+
+  const policyQuery = `
+    SELECT schemaname, tablename, policyname, cmd, qual, with_check
+    FROM pg_policies
+    WHERE schemaname = 'public'
+    ORDER BY tablename, policyname;
+  `;
+  const queryRes = await fetch(`${process.env.SUPABASE_URL}/rest/v1/rpc/query`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ query: policyQuery }),
+  }).catch(() => null);
+
+  if (queryRes?.ok) {
+    const policies = await queryRes.json();
+    lines.push('-- RLS Policies\n');
+    lines.push(JSON.stringify(policies, null, 2));
+  }
+
+  return lines.join('');
+}
+
 function makeTarball(srcDir, outPath) {
   execSync(`tar -czf "${outPath}" -C "${srcDir}" .`, { stdio: 'inherit' });
 }
 
-async function run(type) {
-  const workDir = join(tmpdir(), `backup-${DATE}-${type}`);
+async function run(type, { headers, date, outDir, siteDir, secret }) {
+  const workDir = join(tmpdir(), `backup-${date}-${type}`);
   mkdirSync(workDir, { recursive: true });
 
   console.log(`[${type}] exporting...`);
 
   if (type === 'schema') {
-    const schema = await fetchSchema();
-    writeFileSync(join(workDir, `schema-${DATE}.sql`), schema);
+    const schema = await fetchSchema(headers, date);
+    writeFileSync(join(workDir, `schema-${date}.sql`), schema);
   }
 
   if (type === 'user_configs') {
-    // Exclude hidden reports - they were hidden for a reason (flagged/banned).
-    const rows = await fetchAll('user_configs', '*', '&is_hidden=eq.false');
-    const sanitized = rows.map(sanitizeUserConfig);
-    writeFileSync(join(workDir, `user_configs-${DATE}.json`), JSON.stringify(sanitized, null, 2));
+    const rows = await fetchAll('user_configs', '*', '&is_hidden=eq.false', headers);
+    const sanitized = rows.map(r => sanitizeUserConfig(r, secret));
+    writeFileSync(join(workDir, `user_configs-${date}.json`), JSON.stringify(sanitized, null, 2));
     console.log(`[user_configs] exported ${sanitized.length} rows`);
   }
 
   if (type === 'author_avatars') {
-    const rows = await fetchAll('author_avatars', 'proton_pulse_user_id,display_name,avatar_url,cached_at');
-    const sanitized = rows.map(sanitizeAuthorAvatar);
-    writeFileSync(join(workDir, `author_avatars-${DATE}.json`), JSON.stringify(sanitized, null, 2));
+    const rows = await fetchAll('author_avatars', 'proton_pulse_user_id,display_name,avatar_url,cached_at', '', headers);
+    const sanitized = rows.map(r => sanitizeAuthorAvatar(r, secret));
+    writeFileSync(join(workDir, `author_avatars-${date}.json`), JSON.stringify(sanitized, null, 2));
     console.log(`[author_avatars] exported ${sanitized.length} rows`);
   }
 
   if (type === 'site') {
-    if (!SITE_DIR) throw new Error('SITE_DIR is required for site backup');
+    if (!siteDir) throw new Error('SITE_DIR is required for site backup');
     const siteOut = join(workDir, 'site');
     mkdirSync(siteOut, { recursive: true });
     const allowed = ['.html', '.js', '.css', '.svg', '.png', '.ico'];
-    for (const f of readdirSync(SITE_DIR)) {
+    for (const f of readdirSync(siteDir)) {
       if (allowed.some(ext => f.endsWith(ext))) {
-        const src = join(SITE_DIR, f);
+        const src = join(siteDir, f);
         if (statSync(src).isFile()) {
           execSync(`cp "${src}" "${siteOut}/"`);
         }
@@ -212,23 +199,47 @@ async function run(type) {
     }
   }
 
-  const outPath = join(OUT_DIR, `backup-${DATE}-${type}.tar.gz`);
+  const outPath = join(outDir, `backup-${date}-${type}.tar.gz`);
   makeTarball(workDir, outPath);
   console.log(`[${type}] wrote ${outPath}`);
   execSync(`rm -rf "${workDir}"`);
 }
 
 async function main() {
-  mkdirSync(OUT_DIR, { recursive: true });
-  const types = TYPE === 'all'
+  const secret = process.env.BACKUP_HMAC_SECRET;
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!secret) {
+    console.error('FATAL: BACKUP_HMAC_SECRET is not set. Refusing to run without a pseudonymization key.');
+    process.exit(1);
+  }
+  if (!supabaseUrl || !supabaseKey) {
+    console.error('FATAL: SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must both be set.');
+    process.exit(1);
+  }
+
+  const headers = {
+    apikey: supabaseKey,
+    Authorization: `Bearer ${supabaseKey}`,
+    'Content-Type': 'application/json',
+  };
+  const date = process.env.BACKUP_DATE;
+  const outDir = process.env.OUT_DIR || '.';
+  const siteDir = process.env.SITE_DIR || '';
+  const type = process.env.BACKUP_TYPE || 'all';
+
+  mkdirSync(outDir, { recursive: true });
+  const types = type === 'all'
     ? ['schema', 'user_configs', 'author_avatars', 'site']
-    : [TYPE];
+    : [type];
 
   for (const t of types) {
-    await run(t);
+    await run(t, { headers, date, outDir, siteDir, secret });
   }
 }
 
-main().catch(e => { console.error(e); process.exit(1); });
-
-export { TABLE_ORDER_KEY };
+// Only run as CLI entry point, not when imported by tests.
+if (process.argv[1]?.endsWith('backup.mjs')) {
+  main().catch(e => { console.error(e); process.exit(1); });
+}

--- a/tests/backup.test.js
+++ b/tests/backup.test.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const path = require('path');
+
+const backupSrc = fs.readFileSync(
+  path.join(__dirname, '..', '.github', 'scripts', 'backup.mjs'),
+  'utf8'
+);
+
+// Tables that the backup script fetches. Each must either have an `id` column
+// or an explicit entry in TABLE_ORDER_KEY. Adding a new table without one is
+// the bug that caused the June 2026 nightly backup failure.
+const FETCHED_TABLES = [
+  'user_configs',
+  'author_avatars',
+  'user_proton_configs',
+  'user_systems',
+  'admins',
+  'banned_users',
+];
+
+// Tables confirmed to lack an `id` column (use a named PK instead).
+const NO_ID_TABLES = ['author_avatars'];
+
+describe('backup script order key safety', () => {
+  test('TABLE_ORDER_KEY covers every table that lacks an id column', () => {
+    for (const table of NO_ID_TABLES) {
+      expect(backupSrc).toContain(`${table}:`);
+    }
+  });
+
+  test('fetchAll URL uses the table-specific order key, not always id', () => {
+    expect(backupSrc).toContain('TABLE_ORDER_KEY[table]');
+    expect(backupSrc).toContain("|| 'id'");
+    expect(backupSrc).toContain('order=${orderKey}.asc');
+  });
+
+  test('author_avatars backup selects only safe non-PII columns', () => {
+    expect(backupSrc).toContain("'author_avatars', 'proton_pulse_user_id,display_name,avatar_url,cached_at'");
+  });
+
+  test('all expected tables are present in the schema export list', () => {
+    for (const table of FETCHED_TABLES) {
+      expect(backupSrc).toContain(`'${table}'`);
+    }
+  });
+});

--- a/tests/backup.test.js
+++ b/tests/backup.test.js
@@ -1,46 +1,243 @@
-const fs = require('fs');
-const path = require('path');
+/**
+ * Unit tests for .github/scripts/backup.mjs pure helpers.
+ * These run without network access or env vars -- all I/O stays in main().
+ */
+const {
+  TABLE_ORDER_KEY,
+  buildFetchUrl,
+  hmac,
+  sanitizeNotes,
+  redactPaths,
+  sanitizeUserConfig,
+  sanitizeAuthorAvatar,
+} = require('../.github/scripts/backup.mjs');
 
-const backupSrc = fs.readFileSync(
-  path.join(__dirname, '..', '.github', 'scripts', 'backup.mjs'),
-  'utf8'
-);
+const SECRET = 'test-secret-key';
 
-// Tables that the backup script fetches. Each must either have an `id` column
-// or an explicit entry in TABLE_ORDER_KEY. Adding a new table without one is
-// the bug that caused the June 2026 nightly backup failure.
-const FETCHED_TABLES = [
-  'user_configs',
-  'author_avatars',
-  'user_proton_configs',
-  'user_systems',
-  'admins',
-  'banned_users',
-];
+// ---------------------------------------------------------------------------
+// TABLE_ORDER_KEY / buildFetchUrl
+// ---------------------------------------------------------------------------
 
-// Tables confirmed to lack an `id` column (use a named PK instead).
-const NO_ID_TABLES = ['author_avatars'];
-
-describe('backup script order key safety', () => {
-  test('TABLE_ORDER_KEY covers every table that lacks an id column', () => {
-    for (const table of NO_ID_TABLES) {
-      expect(backupSrc).toContain(`${table}:`);
-    }
+describe('buildFetchUrl', () => {
+  test('uses id order key for tables with a normal PK', () => {
+    const url = buildFetchUrl('https://example.supabase.co', 'user_configs', '*', '', 0, 1000);
+    expect(url).toContain('order=id.asc');
   });
 
-  test('fetchAll URL uses the table-specific order key, not always id', () => {
-    expect(backupSrc).toContain('TABLE_ORDER_KEY[table]');
-    expect(backupSrc).toContain("|| 'id'");
-    expect(backupSrc).toContain('order=${orderKey}.asc');
+  test('uses proton_pulse_user_id order key for author_avatars', () => {
+    const url = buildFetchUrl('https://example.supabase.co', 'author_avatars', '*', '', 0, 1000);
+    expect(url).toContain('order=proton_pulse_user_id.asc');
+    expect(url).not.toContain('order=id.asc');
   });
 
-  test('author_avatars backup selects only safe non-PII columns', () => {
-    expect(backupSrc).toContain("'author_avatars', 'proton_pulse_user_id,display_name,avatar_url,cached_at'");
+  test('encodes the select param', () => {
+    const url = buildFetchUrl('https://example.supabase.co', 'user_configs', 'id,app_id', '', 0, 1000);
+    expect(url).toContain('select=id%2Capp_id');
   });
 
-  test('all expected tables are present in the schema export list', () => {
-    for (const table of FETCHED_TABLES) {
-      expect(backupSrc).toContain(`'${table}'`);
-    }
+  test('applies offset and limit', () => {
+    const url = buildFetchUrl('https://example.supabase.co', 'user_configs', '*', '', 2000, 1000);
+    expect(url).toContain('offset=2000');
+    expect(url).toContain('limit=1000');
+  });
+
+  test('TABLE_ORDER_KEY covers all known tables that lack an id column', () => {
+    expect(TABLE_ORDER_KEY).toHaveProperty('author_avatars', 'proton_pulse_user_id');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hmac
+// ---------------------------------------------------------------------------
+
+describe('hmac', () => {
+  test('returns null for falsy values', () => {
+    expect(hmac(null, SECRET)).toBeNull();
+    expect(hmac('', SECRET)).toBeNull();
+    expect(hmac(undefined, SECRET)).toBeNull();
+  });
+
+  test('returns a hex string for a real value', () => {
+    const result = hmac('76561198000000001', SECRET);
+    expect(result).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test('same input + same secret = same hash (deterministic)', () => {
+    expect(hmac('abc', SECRET)).toBe(hmac('abc', SECRET));
+  });
+
+  test('different secrets produce different hashes', () => {
+    expect(hmac('abc', 'secret-a')).not.toBe(hmac('abc', 'secret-b'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeNotes
+// ---------------------------------------------------------------------------
+
+describe('sanitizeNotes', () => {
+  test('redacts email addresses', () => {
+    expect(sanitizeNotes('contact me at user@example.com please')).toContain('[email redacted]');
+    expect(sanitizeNotes('contact me at user@example.com please')).not.toContain('user@example.com');
+  });
+
+  test('redacts http and https URLs', () => {
+    expect(sanitizeNotes('see https://evil.com/steal')).toContain('[url redacted]');
+    expect(sanitizeNotes('see http://leak.io/path')).toContain('[url redacted]');
+  });
+
+  test('redacts Steam IDs (17-digit format starting with 7656119)', () => {
+    expect(sanitizeNotes('steam id is 76561198123456789')).toContain('[steamid redacted]');
+    expect(sanitizeNotes('steam id is 76561198123456789')).not.toContain('76561198123456789');
+  });
+
+  test('redacts Linux home paths', () => {
+    expect(sanitizeNotes('/home/mike/games/game.exe')).toContain('/home/[redacted]');
+  });
+
+  test('redacts macOS Users paths', () => {
+    expect(sanitizeNotes('/Users/mike/Library/stuff')).toContain('/Users/[redacted]');
+  });
+
+  test('redacts Windows user paths', () => {
+    expect(sanitizeNotes('C:\\Users\\mike\\AppData')).toContain('C:\\Users\\[redacted]');
+  });
+
+  test('returns null/undefined unchanged', () => {
+    expect(sanitizeNotes(null)).toBeNull();
+    expect(sanitizeNotes(undefined)).toBeUndefined();
+  });
+
+  test('leaves clean text untouched', () => {
+    const clean = 'Works great at high settings, no issues';
+    expect(sanitizeNotes(clean)).toBe(clean);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// redactPaths
+// ---------------------------------------------------------------------------
+
+describe('redactPaths', () => {
+  test('redacts Linux /home paths', () => {
+    expect(redactPaths('PROTON_LOG=/home/mike/proton.log')).toBe('PROTON_LOG=/home/[redacted]/proton.log');
+  });
+
+  test('redacts /Users paths', () => {
+    expect(redactPaths('/Users/mike/game')).toBe('/Users/[redacted]/game');
+  });
+
+  test('does not redact /home/[redacted] (already clean)', () => {
+    const already = '/home/[redacted]/game';
+    expect(redactPaths(already)).toBe(already);
+  });
+
+  test('returns null/undefined unchanged', () => {
+    expect(redactPaths(null)).toBeNull();
+    expect(redactPaths(undefined)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeUserConfig
+// ---------------------------------------------------------------------------
+
+describe('sanitizeUserConfig', () => {
+  const row = {
+    id: 'uuid-1',
+    app_id: 12345,
+    title: 'Some Game',
+    rating: 'gold',
+    proton_version: 'Proton 9.0',
+    launch_options: 'MANGOHUD=1 %command% /home/mike/script.sh',
+    cpu: 'AMD Ryzen 7',
+    gpu: 'RX 7900 XTX',
+    gpu_driver: 'Mesa 24.1',
+    gpu_vendor: 'amd',
+    ram: '32 GB',
+    vram_mb: 24576,
+    os: 'Arch Linux',
+    kernel: '6.9.0',
+    notes: 'email me at test@example.com',
+    form_responses: {},
+    duration: '1-10h',
+    duration_minutes: null,
+    game_owned: true,
+    config_key: 'key-abc',
+    source: 'pulse',
+    is_flagged: false,
+    is_hidden: false,
+    flagged_reason: 'wordlist:badword',
+    flagged_at: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    proton_pulse_user_id: 'user-uuid-real',
+    client_id: 'client-uuid-real',
+  };
+
+  let out;
+  beforeAll(() => { out = sanitizeUserConfig(row, SECRET); });
+
+  test('pseudonymizes proton_pulse_user_id', () => {
+    expect(out.proton_pulse_user_id).not.toBe('user-uuid-real');
+    expect(out.proton_pulse_user_id).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test('pseudonymizes client_id', () => {
+    expect(out.client_id).not.toBe('client-uuid-real');
+    expect(out.client_id).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test('redacts paths in launch_options', () => {
+    expect(out.launch_options).toContain('/home/[redacted]');
+    expect(out.launch_options).not.toContain('/home/mike');
+  });
+
+  test('redacts PII in notes', () => {
+    expect(out.notes).toContain('[email redacted]');
+    expect(out.notes).not.toContain('test@example.com');
+  });
+
+  test('strips matched term from flagged_reason, keeps category', () => {
+    expect(out.flagged_reason).toBe('wordlist:redacted');
+  });
+
+  test('preserves safe fields unchanged', () => {
+    expect(out.id).toBe('uuid-1');
+    expect(out.app_id).toBe(12345);
+    expect(out.rating).toBe('gold');
+    expect(out.gpu_vendor).toBe('amd');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeAuthorAvatar
+// ---------------------------------------------------------------------------
+
+describe('sanitizeAuthorAvatar', () => {
+  const row = {
+    proton_pulse_user_id: 'user-uuid-real',
+    display_name: 'CoolGamer42',
+    avatar_url: 'https://cdn.steam.com/avatar/abc.jpg',
+    cached_at: '2026-01-01T00:00:00Z',
+    steam_id: '76561198123456789',
+  };
+
+  let out;
+  beforeAll(() => { out = sanitizeAuthorAvatar(row, SECRET); });
+
+  test('pseudonymizes proton_pulse_user_id', () => {
+    expect(out.proton_pulse_user_id).not.toBe('user-uuid-real');
+    expect(out.proton_pulse_user_id).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test('excludes steam_id (directly linkable PII)', () => {
+    expect(out).not.toHaveProperty('steam_id');
+  });
+
+  test('preserves display_name, avatar_url, cached_at', () => {
+    expect(out.display_name).toBe('CoolGamer42');
+    expect(out.avatar_url).toBe('https://cdn.steam.com/avatar/abc.jpg');
+    expect(out.cached_at).toBe('2026-01-01T00:00:00Z');
   });
 });


### PR DESCRIPTION
Batches several fixes from staging:

- Backup workflow fails nightly: `author_avatars` has no `id` column, backup script was ordering by it. Now uses `proton_pulse_user_id` as the order key for that table.
- System edit: GPU Vendor was silently dropped on save. Now saved as `GPU Vendor:` line in sysinfo_text and parsed back on edit. Closes #74.
- System edit: expanded required-field validation to Label, GPU Vendor, RAM, OS with per-field red outlines and scroll-to-first-error.
- Cancel button on system-edit page now matches Save button size.