### PR TITLE
feat: backup improvements, discord notification, nav/admin polish

### DIFF
--- a/.github/scripts/backup.mjs
+++ b/.github/scripts/backup.mjs
@@ -18,6 +18,8 @@ import { mkdirSync, writeFileSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
+export const MANIFEST_FILE = 'backup-manifest.json';
+
 // ---------------------------------------------------------------------------
 // Pure helpers (exported for testing)
 // ---------------------------------------------------------------------------
@@ -165,6 +167,8 @@ async function run(type, { headers, date, outDir, siteDir, secret }) {
 
   console.log(`[${type}] exporting...`);
 
+  let rowCount = null;
+
   if (type === 'schema') {
     const schema = await fetchSchema(headers, date);
     writeFileSync(join(workDir, `schema-${date}.sql`), schema);
@@ -174,6 +178,7 @@ async function run(type, { headers, date, outDir, siteDir, secret }) {
     const rows = await fetchAll('user_configs', '*', '&is_hidden=eq.false', headers);
     const sanitized = rows.map(r => sanitizeUserConfig(r, secret));
     writeFileSync(join(workDir, `user_configs-${date}.json`), JSON.stringify(sanitized, null, 2));
+    rowCount = sanitized.length;
     console.log(`[user_configs] exported ${sanitized.length} rows`);
   }
 
@@ -181,6 +186,7 @@ async function run(type, { headers, date, outDir, siteDir, secret }) {
     const rows = await fetchAll('author_avatars', 'proton_pulse_user_id,display_name,avatar_url,cached_at', '', headers);
     const sanitized = rows.map(r => sanitizeAuthorAvatar(r, secret));
     writeFileSync(join(workDir, `author_avatars-${date}.json`), JSON.stringify(sanitized, null, 2));
+    rowCount = sanitized.length;
     console.log(`[author_avatars] exported ${sanitized.length} rows`);
   }
 
@@ -189,20 +195,26 @@ async function run(type, { headers, date, outDir, siteDir, secret }) {
     const siteOut = join(workDir, 'site');
     mkdirSync(siteOut, { recursive: true });
     const allowed = ['.html', '.js', '.css', '.svg', '.png', '.ico'];
+    let fileCount = 0;
     for (const f of readdirSync(siteDir)) {
       if (allowed.some(ext => f.endsWith(ext))) {
         const src = join(siteDir, f);
         if (statSync(src).isFile()) {
           execSync(`cp "${src}" "${siteOut}/"`);
+          fileCount++;
         }
       }
     }
+    rowCount = fileCount;
   }
 
   const outPath = join(outDir, `backup-${date}-${type}.tar.gz`);
   makeTarball(workDir, outPath);
-  console.log(`[${type}] wrote ${outPath}`);
+  const sizeBytes = statSync(outPath).size;
+  console.log(`[${type}] wrote ${outPath} (${sizeBytes} bytes)`);
   execSync(`rm -rf "${workDir}"`);
+
+  return { type, file: `backup-${date}-${type}.tar.gz`, size_bytes: sizeBytes, row_count: rowCount };
 }
 
 async function main() {
@@ -234,9 +246,19 @@ async function main() {
     ? ['schema', 'user_configs', 'author_avatars', 'site']
     : [type];
 
+  const results = [];
   for (const t of types) {
-    await run(t, { headers, date, outDir, siteDir, secret });
+    results.push(await run(t, { headers, date, outDir, siteDir, secret }));
   }
+
+  // Write manifest for the workflow to append to backups.jsonl
+  const manifest = {
+    ts: new Date().toISOString(),
+    date,
+    files: results.map(r => ({ name: r.file, size_bytes: r.size_bytes, row_count: r.row_count })),
+  };
+  writeFileSync(join(outDir, MANIFEST_FILE), JSON.stringify(manifest, null, 2) + '\n');
+  console.log(`[manifest] written to ${join(outDir, MANIFEST_FILE)}`);
 }
 
 // Only run as CLI entry point, not when imported by tests.

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     # Weekly, Sunday at 04:00 UTC.
     - cron: "0 4 * * 0"
+  workflow_run:
+    workflows: ["Update ProtonDB Data"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       type:
@@ -25,6 +28,8 @@ jobs:
   backup:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    # For workflow_run triggers, only run if the upstream workflow succeeded.
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
 
     steps:
       - name: Checkout source
@@ -56,16 +61,50 @@ jobs:
           OUT_DIR: backup-out
         run: node .github/scripts/backup.mjs
 
-      - name: Commit tarballs to backup repo
+      - name: Set trigger label
+        id: trigger
+        run: |
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            echo "label=scheduled" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            echo "label=post-deploy" >> "$GITHUB_OUTPUT"
+          else
+            echo "label=manual" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit tarballs and update backups.jsonl
         env:
           BACKUP_REPO_TOKEN: ${{ secrets.BACKUP_REPO_TOKEN }}
           DATE: ${{ steps.date.outputs.date }}
+          TRIGGER: ${{ steps.trigger.outputs.label }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_SHA: ${{ github.sha }}
         run: |
           git clone https://x-access-token:${BACKUP_REPO_TOKEN}@github.com/mdeguzis/proton-pulse-data-backup.git backup-repo
           cp backup-out/*.tar.gz backup-repo/
+
+          # Append JSONL entry from the manifest written by backup.mjs
+          python3 - <<'PYEOF'
+          import json, os
+
+          manifest = json.load(open('backup-out/backup-manifest.json'))
+          entry = {
+            'ts': manifest['ts'],
+            'date': manifest['date'],
+            'trigger': os.environ['TRIGGER'],
+            'run_id': os.environ['GITHUB_RUN_ID'],
+            'source_sha': os.environ['GITHUB_SHA'],
+            'files': manifest['files'],
+          }
+          log_path = 'backup-repo/backups.jsonl'
+          with open(log_path, 'a') as f:
+            f.write(json.dumps(entry) + '\n')
+          print(f'Appended entry to {log_path}: {json.dumps(entry)}')
+          PYEOF
+
           cd backup-repo
           git config user.name "mdeguzis"
           git config user.email "mdeguzis@gmail.com"
-          git add *.tar.gz
-          git commit -m "backup: ${DATE}"
+          git add *.tar.gz backups.jsonl
+          git commit -m "backup (${TRIGGER}): ${DATE}"
           git push

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -79,6 +79,8 @@ jobs:
           TRIGGER: ${{ steps.trigger.outputs.label }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_SHA: ${{ github.sha }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
         run: |
           git clone https://x-access-token:${BACKUP_REPO_TOKEN}@github.com/mdeguzis/proton-pulse-data-backup.git backup-repo
           cp backup-out/*.tar.gz backup-repo/
@@ -87,19 +89,27 @@ jobs:
           python3 - <<'PYEOF'
           import json, os
 
+          repo     = os.environ['GITHUB_REPOSITORY']
+          run_id   = os.environ['GITHUB_RUN_ID']
+          base_url = os.environ['GITHUB_SERVER_URL']
+          run_url  = f'{base_url}/{repo}/actions/runs/{run_id}'
+
           manifest = json.load(open('backup-out/backup-manifest.json'))
           entry = {
             'ts': manifest['ts'],
             'date': manifest['date'],
             'trigger': os.environ['TRIGGER'],
-            'run_id': os.environ['GITHUB_RUN_ID'],
+            'run_id': run_id,
+            'run_url': run_url,
             'source_sha': os.environ['GITHUB_SHA'],
+            'source_url': f'{base_url}/{repo}/commit/{os.environ["GITHUB_SHA"]}',
             'files': manifest['files'],
           }
           log_path = 'backup-repo/backups.jsonl'
           with open(log_path, 'a') as f:
             f.write(json.dumps(entry) + '\n')
-          print(f'Appended entry to {log_path}: {json.dumps(entry)}')
+          print(f'Appended to {log_path}')
+          print(f'run_url: {run_url}')
           PYEOF
 
           cd backup-repo

--- a/.github/workflows/discord-backups.yml
+++ b/.github/workflows/discord-backups.yml
@@ -1,0 +1,50 @@
+name: Discord Backup Status
+
+on:
+  workflow_run:
+    workflows: ["Backup"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to Discord
+        env:
+          WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_BACKUPS }}
+          WF_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          WF_URL:        ${{ github.event.workflow_run.html_url }}
+          WF_BRANCH:     ${{ github.event.workflow_run.head_branch }}
+          WF_SHA:        ${{ github.event.workflow_run.head_sha }}
+          WF_EVENT:      ${{ github.event.workflow_run.event }}
+          SENDER:        ${{ github.event.sender.login }}
+          REPO:          ${{ github.repository }}
+          SERVER_URL:    ${{ github.server_url }}
+        run: |
+          SHORT_SHA="${WF_SHA:0:7}"
+          COMMIT_URL="${SERVER_URL}/${REPO}/commit/${WF_SHA}"
+
+          # Map trigger event to a readable label
+          case "$WF_EVENT" in
+            schedule)         TRIGGER="scheduled"  ;;
+            workflow_dispatch) TRIGGER="manual"    ;;
+            workflow_run)     TRIGGER="post-deploy" ;;
+            *)                TRIGGER="$WF_EVENT"  ;;
+          esac
+
+          if [ "$WF_CONCLUSION" = "success" ]; then
+            STATUS="Backup complete"
+            COLOR=3066993
+          else
+            STATUS="Backup FAILED"
+            COLOR=15158332
+          fi
+
+          MSG=$(printf '**%s** (%s)\nBranch: `%s` | Commit: [%s](%s)\nTrigger: %s\n[View run](%s)' \
+            "$STATUS" "$WF_CONCLUSION" "$WF_BRANCH" "$SHORT_SHA" "$COMMIT_URL" "$TRIGGER" "$WF_URL")
+
+          jq -n --arg content "$MSG" '{content: $content}' \
+            | curl -s -H "Content-Type: application/json" -d @- "$WEBHOOK_URL"

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -286,6 +286,12 @@ jobs:
       - name: Hardware suggestions (PCI IDs)
         run: uv run python scripts/pipeline/hardware_suggestions.py
 
+      - name: Approve pending reports
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: uv run python scripts/pipeline/approve_reports.py
+
       - name: Save pipeline cache
         if: always()
         uses: actions/cache/save@v4

--- a/admin.html
+++ b/admin.html
@@ -280,6 +280,6 @@
 <script src="js/lib/analytics.js?v=89bd7747"></script>
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/admin/main.js?v=8e625f6a"></script>
+<script type="module" src="js/admin/main.js?v=385d3565"></script>
 </body>
 </html>

--- a/admin.html
+++ b/admin.html
@@ -54,7 +54,7 @@
           <div id="pending-loading" class="admin-loading">Loading pending reports...</div>
           <div id="pending-empty" class="admin-empty" hidden>No pending reports.</div>
           <table id="pending-table" class="admin-table" hidden>
-            <thead><tr><th>ID</th><th>Game</th><th>Author</th><th>Rating</th><th>Submitted</th><th></th></tr></thead>
+            <thead><tr><th>Game</th><th>Report ID</th><th>Submitted</th><th></th></tr></thead>
             <tbody id="pending-tbody"></tbody>
           </table>
           <div id="pending-detail" hidden></div>
@@ -281,6 +281,6 @@
 <script src="js/lib/analytics.js?v=89bd7747"></script>
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/admin/main.js?v=5798e4ce"></script>
+<script type="module" src="js/admin/main.js?v=c1cceffa"></script>
 </body>
 </html>

--- a/admin.html
+++ b/admin.html
@@ -281,6 +281,6 @@
 <script src="js/lib/analytics.js?v=89bd7747"></script>
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/admin/main.js?v=c1cceffa"></script>
+<script type="module" src="js/admin/main.js?v=073bd685"></script>
 </body>
 </html>

--- a/admin.html
+++ b/admin.html
@@ -54,9 +54,10 @@
           <div id="pending-loading" class="admin-loading">Loading pending reports...</div>
           <div id="pending-empty" class="admin-empty" hidden>No pending reports.</div>
           <table id="pending-table" class="admin-table" hidden>
-            <thead><tr><th>Game</th><th>Author</th><th>Rating</th><th>Submitted</th><th></th></tr></thead>
+            <thead><tr><th>ID</th><th>Game</th><th>Author</th><th>Rating</th><th>Submitted</th><th></th></tr></thead>
             <tbody id="pending-tbody"></tbody>
           </table>
+          <div id="pending-detail" hidden></div>
         </div>
       </section>
 
@@ -280,6 +281,6 @@
 <script src="js/lib/analytics.js?v=89bd7747"></script>
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/admin/main.js?v=385d3565"></script>
+<script type="module" src="js/admin/main.js?v=5798e4ce"></script>
 </body>
 </html>

--- a/admin.html
+++ b/admin.html
@@ -281,6 +281,6 @@
 <script src="js/lib/analytics.js?v=89bd7747"></script>
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/admin/main.js?v=5b41b3f5"></script>
+<script type="module" src="js/admin/main.js?v=8d094624"></script>
 </body>
 </html>

--- a/admin.html
+++ b/admin.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=86052a10">
 <link rel="stylesheet" href="css/shared/cards.css?v=c0a5fad1">
-<link rel="stylesheet" href="css/admin/admin.css?v=47b33e48">
+<link rel="stylesheet" href="css/admin/admin.css?v=391c2951">
 </head>
 <body>
 
@@ -54,7 +54,7 @@
           <div id="pending-loading" class="admin-loading">Loading pending reports...</div>
           <div id="pending-empty" class="admin-empty" hidden>No pending reports.</div>
           <table id="pending-table" class="admin-table" hidden>
-            <thead><tr><th>Game</th><th>Report ID</th><th>Submitted</th><th></th></tr></thead>
+            <thead><tr><th data-sort-col="0">Game</th><th data-sort-col="1">Report ID</th><th data-sort-col="2" data-sort-type="date">Submitted</th><th></th></tr></thead>
             <tbody id="pending-tbody"></tbody>
           </table>
           <div id="pending-detail" hidden></div>
@@ -90,11 +90,11 @@
         <table class="admin-table" id="flagged-table" hidden>
           <thead>
             <tr>
-              <th>Game</th>
-              <th>Source</th>
-              <th>Flagged</th>
-              <th>Reviewed</th>
-              <th>Status</th>
+              <th data-sort-col="0">Game</th>
+              <th data-sort-col="1">Source</th>
+              <th data-sort-col="2" data-sort-type="date">Flagged</th>
+              <th data-sort-col="3" data-sort-type="date">Reviewed</th>
+              <th data-sort-col="4">Status</th>
               <th>Actions</th>
             </tr>
           </thead>
@@ -121,9 +121,9 @@
         <table class="admin-table" id="banned-table" hidden>
           <thead>
             <tr>
-              <th>User</th>
-              <th>Reason</th>
-              <th>Banned</th>
+              <th data-sort-col="0">User</th>
+              <th data-sort-col="1">Reason</th>
+              <th data-sort-col="2" data-sort-type="date">Banned</th>
               <th>Actions</th>
             </tr>
           </thead>
@@ -134,7 +134,7 @@
       <!-- All Users -->
       <section id="tab-users" class="admin-section" hidden>
         <div class="admin-filters">
-          <div class="admin-search-wrap">
+          <div class="admin-search-wrap admin-search-wrap--wide">
             <input type="text" id="users-search" class="admin-input" placeholder="Search username or client ID...">
             <button class="admin-search-clear" id="users-search-clear" type="button" title="Clear search" aria-label="Clear search" hidden>
               <svg width="14" height="14" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
@@ -154,12 +154,12 @@
         <table class="admin-table" id="users-table" hidden>
           <thead>
             <tr>
-              <th>Username</th>
+              <th data-sort-col="0">Username</th>
               <th>Identity</th>
-              <th>Role</th>
-              <th>Reports</th>
-              <th>Last active</th>
-              <th>Last login</th>
+              <th data-sort-col="2">Role</th>
+              <th data-sort-col="3" data-sort-type="number">Reports</th>
+              <th data-sort-col="4" data-sort-type="date">Last active</th>
+              <th data-sort-col="5" data-sort-type="date">Last login</th>
               <th>Actions</th>
             </tr>
           </thead>
@@ -203,10 +203,10 @@
         <table class="admin-table" id="admins-table" hidden>
           <thead>
             <tr>
-              <th>Username</th>
-              <th>Role</th>
+              <th data-sort-col="0">Username</th>
+              <th data-sort-col="1">Role</th>
               <th>Permissions</th>
-              <th>Added</th>
+              <th data-sort-col="3" data-sort-type="date">Added</th>
               <th>Actions</th>
             </tr>
           </thead>
@@ -236,10 +236,10 @@
         <table class="admin-table" id="phrases-table" hidden>
           <thead>
             <tr>
-              <th>Pattern</th>
-              <th>Type</th>
-              <th>Description</th>
-              <th>Added</th>
+              <th data-sort-col="0">Pattern</th>
+              <th data-sort-col="1">Type</th>
+              <th data-sort-col="2">Description</th>
+              <th data-sort-col="3" data-sort-type="date">Added</th>
               <th>Actions</th>
             </tr>
           </thead>
@@ -281,6 +281,6 @@
 <script src="js/lib/analytics.js?v=89bd7747"></script>
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/admin/main.js?v=94a719b9"></script>
+<script type="module" src="js/admin/main.js?v=fe8aa86c"></script>
 </body>
 </html>

--- a/admin.html
+++ b/admin.html
@@ -281,6 +281,6 @@
 <script src="js/lib/analytics.js?v=89bd7747"></script>
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/admin/main.js?v=78069abc"></script>
+<script type="module" src="js/admin/main.js?v=5b41b3f5"></script>
 </body>
 </html>

--- a/admin.html
+++ b/admin.html
@@ -281,6 +281,6 @@
 <script src="js/lib/analytics.js?v=89bd7747"></script>
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/admin/main.js?v=8d094624"></script>
+<script type="module" src="js/admin/main.js?v=94a719b9"></script>
 </body>
 </html>

--- a/admin.html
+++ b/admin.html
@@ -281,6 +281,6 @@
 <script src="js/lib/analytics.js?v=89bd7747"></script>
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/admin/main.js?v=073bd685"></script>
+<script type="module" src="js/admin/main.js?v=78069abc"></script>
 </body>
 </html>

--- a/admin.html
+++ b/admin.html
@@ -37,6 +37,7 @@
       <div class="admin-nav">
         <select id="admin-tab-select" class="admin-select admin-nav-select">
           <option value="users">All Users</option>
+          <option value="pending">Pending Reports</option>
           <option value="flagged">Flagged Reports</option>
           <option value="banned">Banned Users</option>
           <option value="admins">Admins</option>
@@ -46,6 +47,18 @@
       </div>
 
       <div id="admin-perms-summary" class="admin-perms-summary" hidden></div>
+
+      <!-- Pending Reports (awaiting approval) -->
+      <section id="tab-pending" class="admin-section" hidden>
+        <div class="admin-card">
+          <div id="pending-loading" class="admin-loading">Loading pending reports...</div>
+          <div id="pending-empty" class="admin-empty" hidden>No pending reports.</div>
+          <table id="pending-table" class="admin-table" hidden>
+            <thead><tr><th>Game</th><th>Author</th><th>Rating</th><th>Submitted</th><th></th></tr></thead>
+            <tbody id="pending-tbody"></tbody>
+          </table>
+        </div>
+      </section>
 
       <!-- Flagged Reports list -->
       <section id="tab-flagged" class="admin-section">
@@ -267,6 +280,6 @@
 <script src="js/lib/analytics.js?v=89bd7747"></script>
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/admin/main.js?v=67de70b2"></script>
+<script type="module" src="js/admin/main.js?v=8e625f6a"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -19,7 +19,7 @@
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=51e901fe">
-<link rel="stylesheet" href="css/app/modals.css?v=68ffdfa5">
+<link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
 <link rel="stylesheet" href="css/app/home.css?v=13fd2117">
 </head>
 <body>
@@ -57,6 +57,6 @@
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=fdbc0147"></script>
+<script type="module" src="js/app/main.js?v=c54d957d"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -57,6 +57,6 @@
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=f760ff2f"></script>
+<script type="module" src="js/app/main.js?v=19591dd0"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -57,6 +57,6 @@
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=7f763f5b"></script>
+<script type="module" src="js/app/main.js?v=b5fb3928"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -19,7 +19,7 @@
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=51e901fe">
-<link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
+<link rel="stylesheet" href="css/app/modals.css?v=68ffdfa5">
 <link rel="stylesheet" href="css/app/home.css?v=13fd2117">
 </head>
 <body>
@@ -57,6 +57,6 @@
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=dbff4a88"></script>
+<script type="module" src="js/app/main.js?v=fdbc0147"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -57,6 +57,6 @@
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=626495ad"></script>
+<script type="module" src="js/app/main.js?v=dbff4a88"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -57,6 +57,6 @@
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=79386f21"></script>
+<script type="module" src="js/app/main.js?v=7f763f5b"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -57,6 +57,6 @@
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=86a70568"></script>
+<script type="module" src="js/app/main.js?v=626495ad"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -19,7 +19,7 @@
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=51e901fe">
-<link rel="stylesheet" href="css/app/modals.css?v=68ffdfa5">
+<link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
 <link rel="stylesheet" href="css/app/home.css?v=13fd2117">
 </head>
 <body>
@@ -57,6 +57,6 @@
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=b5fb3928"></script>
+<script type="module" src="js/app/main.js?v=86a70568"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -57,6 +57,6 @@
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=19591dd0"></script>
+<script type="module" src="js/app/main.js?v=79386f21"></script>
 </body>
 </html>

--- a/confidence.html
+++ b/confidence.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=51e901fe">
-<link rel="stylesheet" href="css/app/modals.css?v=68ffdfa5">
+<link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
 <link rel="stylesheet" href="css/app/home.css?v=13fd2117">
 <style>
 h1 {

--- a/css/admin/admin.css
+++ b/css/admin/admin.css
@@ -635,14 +635,16 @@
   opacity: 0.75;
 }
 
-/* Mobile: hide Reports and Last active columns from the users table */
+/* Mobile: hide Identity, Role, Reports, Last active, Last login columns */
 @media (max-width: 640px) {
   #users-table th:nth-child(2),
   #users-table td:nth-child(2),
   #users-table th:nth-child(3),
   #users-table td:nth-child(3),
   #users-table th:nth-child(4),
-  #users-table td:nth-child(4) {
+  #users-table td:nth-child(4),
+  #users-table th:nth-child(6),
+  #users-table td:nth-child(6) {
     display: none;
   }
 }

--- a/css/admin/admin.css
+++ b/css/admin/admin.css
@@ -174,6 +174,10 @@
   display: inline-flex;
   align-items: center;
 }
+
+.admin-search-wrap--wide {
+  min-width: 260px;
+}
 .admin-search-wrap .admin-input {
   padding-right: 26px;
 }
@@ -267,6 +271,26 @@
   padding: 6px 10px;
   text-align: left;
   text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.admin-table th[data-sort-col] {
+  cursor: pointer;
+  user-select: none;
+}
+
+.admin-table th[data-sort-col]:hover {
+  color: var(--text, #eee);
+}
+
+.admin-table th.admin-th--sorted {
+  color: var(--text, #eee);
+}
+
+.sort-indicator {
+  font-size: 0.6rem;
+  margin-left: 4px;
+  opacity: 0.8;
 }
 
 .admin-table td {

--- a/css/app/modals.css
+++ b/css/app/modals.css
@@ -288,3 +288,39 @@
   .search-result-card { flex-direction: column; }
   .search-result-side { align-items: flex-start; min-width: 0; }
 }
+
+.submit-approval-banner {
+  padding: 10px 14px;
+  margin-bottom: 16px;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  color: var(--text);
+  background: var(--s2);
+  border: 1px solid var(--border);
+}
+.submit-approval-banner code {
+  font-size: 0.75rem;
+  background: rgba(255,255,255,0.06);
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+.submit-approval-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-right: 8px;
+}
+.submit-approval-badge--approved {
+  background: rgba(76,175,128,0.15);
+  border: 1px solid rgba(76,175,128,0.4);
+  color: #a9d7b6;
+}
+.submit-approval-badge--pending {
+  background: rgba(160,120,200,0.15);
+  border: 1px solid rgba(160,120,200,0.4);
+  color: #c0a8e0;
+}

--- a/css/profile/profile.css
+++ b/css/profile/profile.css
@@ -661,6 +661,10 @@
 .profile-configs-unpublish-btn {
   min-width: 72px;
 }
+.profile-configs-unpublish-btn {
+  color: #d4b36a;
+  border-color: rgba(212,168,67,0.45);
+}
 .profile-configs-publish-btn,
 .profile-configs-view-link:not(.profile-configs-view-disabled),
 .profile-configs-edit-btn {

--- a/css/profile/profile.css
+++ b/css/profile/profile.css
@@ -601,6 +601,11 @@
   border-color: rgba(212,168,67,0.4);
   background: rgba(212,168,67,0.1);
 }
+.profile-configs-badge--pending {
+  color: #c0a8e0;
+  border-color: rgba(160,120,200,0.4);
+  background: rgba(160,120,200,0.1);
+}
 .profile-configs-badge--flagged {
   color: #e88a8a;
   border-color: rgba(220,80,80,0.4);

--- a/game-stats.html
+++ b/game-stats.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=51e901fe">
-<link rel="stylesheet" href="css/app/modals.css?v=68ffdfa5">
+<link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
 <link rel="stylesheet" href="css/app/home.css?v=13fd2117">
 <style>
 h1 {

--- a/gh-pages-manifest.txt
+++ b/gh-pages-manifest.txt
@@ -120,3 +120,5 @@ js/app/lib/steam-img.js
 system-edit.html
 js/profile/system-edit.js
 hardware-suggestions.json
+js/admin/api/pending.js
+js/admin/components/pending.js

--- a/js/admin/api/pending.js
+++ b/js/admin/api/pending.js
@@ -3,7 +3,7 @@ import { supabaseHeaders } from '../utils.js?v=86489fcb';
 
 export async function fetchPendingReports(session) {
   const [reportsRes, approvalsRes] = await Promise.all([
-    fetch(`${SUPABASE_URL}/rest/v1/user_configs?is_flagged=neq.true&select=id,app_id,client_id,rating,notes,os,gpu,created_at,display_name,proton_pulse_user_id&order=created_at.desc&limit=200`, {
+    fetch(`${SUPABASE_URL}/rest/v1/user_configs?is_flagged=neq.true&select=id,app_id,client_id,rating,notes,os,gpu,created_at,proton_pulse_user_id&order=created_at.desc&limit=200`, {
       headers: supabaseHeaders(session),
     }),
     fetch(`${SUPABASE_URL}/rest/v1/report_approvals?select=report_id,approval_hash`, {

--- a/js/admin/api/pending.js
+++ b/js/admin/api/pending.js
@@ -3,7 +3,7 @@ import { supabaseHeaders } from '../utils.js?v=86489fcb';
 
 export async function fetchPendingReports(session) {
   const [reportsRes, approvalsRes] = await Promise.all([
-    fetch(`${SUPABASE_URL}/rest/v1/user_configs?is_flagged=neq.true&select=id,app_id,client_id,rating,notes,os,gpu,created_at,proton_pulse_user_id&order=created_at.desc&limit=200`, {
+    fetch(`${SUPABASE_URL}/rest/v1/user_configs?is_flagged=neq.true&select=id,app_id,title,client_id,proton_pulse_user_id,rating,proton_version,cpu,gpu,gpu_driver,gpu_vendor,gpu_architecture,ram,vram_mb,os,kernel,duration,duration_minutes,notes,form_responses,config_key,game_owned,source,created_at,updated_at&order=created_at.desc&limit=200`, {
       headers: supabaseHeaders(session),
     }),
     fetch(`${SUPABASE_URL}/rest/v1/report_approvals?select=report_id,approval_hash`, {

--- a/js/admin/api/pending.js
+++ b/js/admin/api/pending.js
@@ -15,12 +15,13 @@ export async function fetchPendingReports(session) {
   const approvals = approvalsRes.ok ? await approvalsRes.json() : [];
   const approvalMap = new Map(approvals.map(a => [a.report_id, a.approval_hash]));
 
-  return reports.filter(r => {
-    const storedHash = approvalMap.get(r.id);
-    if (!storedHash) return true;
-    const expected = computeHash(r);
-    return storedHash !== expected;
-  });
+  return reports
+    .filter(r => {
+      const storedHash = approvalMap.get(r.id);
+      if (!storedHash) return true;
+      return storedHash !== computeHash(r);
+    })
+    .map(r => ({ ...r, _approval_hash: computeHash(r) }));
 }
 
 export async function approveReport(session, report) {

--- a/js/admin/api/pending.js
+++ b/js/admin/api/pending.js
@@ -1,0 +1,81 @@
+import { SUPABASE_URL } from '../config.js?v=ffed3d84';
+import { supabaseHeaders } from '../utils.js?v=86489fcb';
+
+export async function fetchPendingReports(session) {
+  const [reportsRes, approvalsRes] = await Promise.all([
+    fetch(`${SUPABASE_URL}/rest/v1/user_configs?is_flagged=neq.true&select=id,app_id,client_id,rating,notes,os,gpu,created_at,display_name,proton_pulse_user_id&order=created_at.desc&limit=200`, {
+      headers: supabaseHeaders(session),
+    }),
+    fetch(`${SUPABASE_URL}/rest/v1/report_approvals?select=report_id,approval_hash`, {
+      headers: supabaseHeaders(session),
+    }),
+  ]);
+  if (!reportsRes.ok) throw new Error(`Failed to fetch reports: ${reportsRes.status}`);
+  const reports = await reportsRes.json();
+  const approvals = approvalsRes.ok ? await approvalsRes.json() : [];
+  const approvalMap = new Map(approvals.map(a => [a.report_id, a.approval_hash]));
+
+  return reports.filter(r => {
+    const storedHash = approvalMap.get(r.id);
+    if (!storedHash) return true;
+    const expected = computeHash(r);
+    return storedHash !== expected;
+  });
+}
+
+export async function approveReport(session, report) {
+  const hash = computeHash(report);
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/report_approvals?on_conflict=report_id`, {
+    method: 'POST',
+    headers: supabaseHeaders(session, { Prefer: 'resolution=merge-duplicates,return=minimal' }),
+    body: JSON.stringify({
+      report_id: report.id,
+      approval_hash: hash,
+      approved_at: new Date().toISOString(),
+      approved_by: 'admin',
+    }),
+  });
+  if (!res.ok) throw new Error(`Approve failed: ${res.status}`);
+}
+
+function computeHash(row) {
+  const parts = [
+    String(row.app_id || ''),
+    String(row.client_id || ''),
+    String(row.rating || ''),
+    String(row.notes || ''),
+    String(row.os || ''),
+    String(row.gpu || ''),
+    String(row.created_at || ''),
+  ];
+  return md5(parts.join('|'));
+}
+
+function md5(str) {
+  const data = new TextEncoder().encode(str);
+  let h0 = 0x67452301, h1 = 0xEFCDAB89, h2 = 0x98BADCFE, h3 = 0x10325476;
+  const k = [], s = [7,12,17,22,7,12,17,22,7,12,17,22,7,12,17,22,5,9,14,20,5,9,14,20,5,9,14,20,5,9,14,20,4,11,16,23,4,11,16,23,4,11,16,23,4,11,16,23,6,10,15,21,6,10,15,21,6,10,15,21,6,10,15,21];
+  for (let i = 0; i < 64; i++) k[i] = Math.floor(2**32 * Math.abs(Math.sin(i + 1))) >>> 0;
+  const pad = new Uint8Array(((data.length + 9 + 63) & ~63));
+  pad.set(data); pad[data.length] = 0x80;
+  const dv = new DataView(pad.buffer);
+  dv.setUint32(pad.length - 8, (data.length * 8) >>> 0, true);
+  dv.setUint32(pad.length - 4, (data.length * 8 / 2**32) >>> 0, true);
+  for (let off = 0; off < pad.length; off += 64) {
+    const m = [];
+    for (let j = 0; j < 16; j++) m[j] = dv.getUint32(off + j * 4, true);
+    let [a, b, c, d] = [h0, h1, h2, h3];
+    for (let i = 0; i < 64; i++) {
+      let f, g;
+      if (i < 16) { f = (b & c) | (~b & d); g = i; }
+      else if (i < 32) { f = (d & b) | (~d & c); g = (5*i+1) % 16; }
+      else if (i < 48) { f = b ^ c ^ d; g = (3*i+5) % 16; }
+      else { f = c ^ (b | ~d); g = (7*i) % 16; }
+      f = (f + a + k[i] + m[g]) >>> 0;
+      a = d; d = c; c = b;
+      b = (b + ((f << s[i]) | (f >>> (32 - s[i])))) >>> 0;
+    }
+    h0 = (h0 + a) >>> 0; h1 = (h1 + b) >>> 0; h2 = (h2 + c) >>> 0; h3 = (h3 + d) >>> 0;
+  }
+  return [h0, h1, h2, h3].map(v => v.toString(16).padStart(8, '0').replace(/(..)(..)(..)(..)/, '$4$3$2$1')).join('');
+}

--- a/js/admin/api/users.js
+++ b/js/admin/api/users.js
@@ -109,7 +109,11 @@ export async function fetchAllUsers(session, { search } = {}) {
       for (const au of authUsers) {
         if (!au.id) continue;
         if (byUser.has(au.id)) {
-          byUser.get(au.id).last_login = au.last_sign_in_at || null;
+          const u = byUser.get(au.id);
+          u.last_login = au.last_sign_in_at || null;
+          if (au.last_sign_in_at && au.last_sign_in_at > (u.last_active || '')) {
+            u.last_active = au.last_sign_in_at;
+          }
         } else {
           // User exists in auth but has never submitted - still show them.
           byUser.set(au.id, {

--- a/js/admin/api/users.js
+++ b/js/admin/api/users.js
@@ -54,13 +54,18 @@ export async function fetchAllUsers(session, { search } = {}) {
   // Enrich with display names from author_avatars.
   const uuids = [...byUser.values()].map(u => u.proton_pulse_user_id).filter(Boolean);
   if (uuids.length) {
-    const avatarUrl = `${SUPABASE_URL}/rest/v1/author_avatars?select=proton_pulse_user_id,display_name&proton_pulse_user_id=in.(${uuids.join(',')})`;
+    const avatarUrl = `${SUPABASE_URL}/rest/v1/author_avatars?select=proton_pulse_user_id,display_name,last_seen_at&proton_pulse_user_id=in.(${uuids.join(',')})`;
     const avatarRes = await fetch(avatarUrl, { headers: supabaseHeaders(session) });
     if (avatarRes.ok) {
       const avatars = await avatarRes.json();
       for (const a of avatars) {
         const u = byUser.get(a.proton_pulse_user_id);
-        if (u) u.display_name = a.display_name || null;
+        if (u) {
+          u.display_name = a.display_name || null;
+          if (a.last_seen_at && a.last_seen_at > (u.last_active || '')) {
+            u.last_active = a.last_seen_at;
+          }
+        }
       }
     }
   }

--- a/js/admin/components/admins.js
+++ b/js/admin/components/admins.js
@@ -1,6 +1,6 @@
 // admins (components) for the admin page.
 
-import { escapeHtml, fmtDate } from '../utils.js?v=86489fcb';
+import { escapeHtml, fmtDateTime } from '../utils.js?v=86489fcb';
 import { PERMISSION_LABELS, effectivePermissions, resolveRoleLabel, permissionsToAdd } from '../permissions.js?v=529eb059';
 
 // Role <select> for a row or the add form. `uuid` is 'new' for the add form.
@@ -75,7 +75,7 @@ export function renderAdmins(rows, { currentUserId } = {}) {
       <td>${name}</td>
       <td>${roleSelectHtml(label, uid)}</td>
       <td>${permEditorHtml(label, eff, uid)}</td>
-      <td>${escapeHtml(fmtDate(r.added_at))}</td>
+      <td>${escapeHtml(fmtDateTime(r.added_at))}</td>
       <td>${removeBtn}</td>
     </tr>`;
   }).join('');

--- a/js/admin/components/banned.js
+++ b/js/admin/components/banned.js
@@ -1,6 +1,6 @@
 // banned (components) for the admin page.
 
-import { escapeHtml, fmtDate } from '../utils.js?v=86489fcb';
+import { escapeHtml, fmtDateTime } from '../utils.js?v=86489fcb';
 
 export function renderBanned(rows) {
   const loading = document.getElementById('banned-loading');
@@ -22,7 +22,7 @@ export function renderBanned(rows) {
   tbody.innerHTML = rows.map(r => {
     const name = escapeHtml(r.steam_username || r.client_id?.slice(0, 8) || 'unknown');
     const reason = escapeHtml(r.banned_reason || '—');
-    const bannedAt = escapeHtml(fmtDate(r.banned_at));
+    const bannedAt = escapeHtml(fmtDateTime(r.banned_at));
     const banId = escapeHtml(String(r.id));
     const userId = escapeHtml(r.proton_pulse_user_id || '');
     const clientId = escapeHtml(r.client_id || '');

--- a/js/admin/components/pending.js
+++ b/js/admin/components/pending.js
@@ -72,11 +72,20 @@ export async function renderPending(session, { onApproved } = {}) {
   }
 }
 
+export function closePendingReview() {
+  const detail = document.getElementById('pending-detail');
+  const table = document.getElementById('pending-table');
+  if (!detail || detail.hidden) return;
+  detail.hidden = true;
+  table.hidden = false;
+}
+
 function showReviewDetail(report) {
   const detail = document.getElementById('pending-detail');
   const table = document.getElementById('pending-table');
   if (!detail) return;
 
+  history.pushState({ adminView: 'pending-review' }, '', window.location.href);
   table.hidden = true;
   detail.hidden = false;
 

--- a/js/admin/components/pending.js
+++ b/js/admin/components/pending.js
@@ -1,4 +1,4 @@
-import { escapeHtml, fmtDate } from '../utils.js?v=86489fcb';
+import { escapeHtml, fmtDateTime } from '../utils.js?v=86489fcb';
 import { fetchPendingReports, approveReport } from '../api/pending.js?v=6eb54134';
 
 export async function renderPending(session, { onApproved } = {}) {
@@ -26,7 +26,7 @@ export async function renderPending(session, { onApproved } = {}) {
     tbody.innerHTML = reports.map(r => {
       const game = escapeHtml(r.app_id ? `App ${r.app_id}` : 'Unknown');
       const reportId = escapeHtml(r.id != null ? String(r.id).slice(0, 8) : '?');
-      const date = escapeHtml(fmtDate(r.created_at));
+      const date = escapeHtml(fmtDateTime(r.created_at));
       return `<tr data-report-id="${r.id}">
         <td><a class="admin-link" href="app.html#/app/${r.app_id}" target="_blank">${game}</a></td>
         <td><code>${reportId}</code></td>

--- a/js/admin/components/pending.js
+++ b/js/admin/components/pending.js
@@ -1,5 +1,5 @@
 import { escapeHtml, fmtDate } from '../utils.js?v=86489fcb';
-import { fetchPendingReports, approveReport } from '../api/pending.js?v=b722b8eb';
+import { fetchPendingReports, approveReport } from '../api/pending.js?v=814363ad';
 
 export async function renderPending(session, { onApproved } = {}) {
   const loading = document.getElementById('pending-loading');
@@ -70,16 +70,43 @@ function showReviewDetail(report, session, onApproved) {
   table.hidden = true;
   detail.hidden = false;
 
+  const val = (v) => (v != null && v !== '') ? String(v) : '(not set)';
   const fields = [
     ['Report ID', `#${String(report.id)}`],
-    ['App ID', report.app_id],
-    ['Rating', report.rating || '(not set)'],
-    ['GPU', report.gpu || '(not set)'],
-    ['OS', report.os || '(not set)'],
-    ['Notes', report.notes || '(none)'],
-    ['Submitted', report.created_at ? new Date(report.created_at).toLocaleString() : '?'],
+    ['App ID', val(report.app_id)],
+    ['Title', val(report.title)],
+    ['Source', val(report.source)],
+    ['Rating', val(report.rating)],
+    ['Proton Version', val(report.proton_version)],
+    ['CPU', val(report.cpu)],
+    ['GPU', val(report.gpu)],
+    ['GPU Driver', val(report.gpu_driver)],
+    ['GPU Vendor', val(report.gpu_vendor)],
+    ['GPU Architecture', val(report.gpu_architecture)],
+    ['RAM', val(report.ram)],
+    ['VRAM (MB)', val(report.vram_mb)],
+    ['OS', val(report.os)],
+    ['Kernel', val(report.kernel)],
+    ['Duration', val(report.duration)],
+    ['Duration (min)', val(report.duration_minutes)],
+    ['Game Owned', val(report.game_owned)],
+    ['Config Key', val(report.config_key)],
+    ['Notes', val(report.notes)],
     ['Author', report.proton_pulse_user_id || report.client_id || 'anonymous'],
+    ['Client ID', val(report.client_id)],
+    ['Submitted', report.created_at ? new Date(report.created_at).toLocaleString() : '?'],
+    ['Updated', report.updated_at ? new Date(report.updated_at).toLocaleString() : '(not set)'],
   ];
+
+  const formResponsesHtml = report.form_responses
+    ? `<tr>
+        <td style="font-weight:600;color:var(--muted);width:140px;vertical-align:top">Form Responses</td>
+        <td><pre style="margin:0;font-size:0.78rem;white-space:pre-wrap;word-break:break-all">${escapeHtml(JSON.stringify(report.form_responses, null, 2))}</pre></td>
+      </tr>`
+    : `<tr>
+        <td style="font-weight:600;color:var(--muted);width:140px">Form Responses</td>
+        <td>(none)</td>
+      </tr>`;
 
   detail.innerHTML = `
     <button class="admin-btn admin-btn--sm" id="pending-back-btn" style="margin-bottom:12px">Back to list</button>
@@ -89,10 +116,11 @@ function showReviewDetail(report, session, onApproved) {
         <tbody>
           ${fields.map(([label, value]) => `
             <tr>
-              <td style="font-weight:600;color:var(--muted);width:120px">${escapeHtml(label)}</td>
-              <td>${escapeHtml(String(value))}</td>
+              <td style="font-weight:600;color:var(--muted);width:140px">${escapeHtml(label)}</td>
+              <td>${escapeHtml(value)}</td>
             </tr>
           `).join('')}
+          ${formResponsesHtml}
         </tbody>
       </table>
       <div style="display:flex;gap:8px">

--- a/js/admin/components/pending.js
+++ b/js/admin/components/pending.js
@@ -24,15 +24,12 @@ export async function renderPending(session, { onApproved } = {}) {
 
     table.hidden = false;
     tbody.innerHTML = reports.map(r => {
-      const author = escapeHtml(r.proton_pulse_user_id?.slice(0, 8) || r.client_id?.slice(0, 8) || 'anonymous');
-      const game = escapeHtml(`App ${r.app_id}`);
+      const game = escapeHtml(r.app_id ? `App ${r.app_id}` : 'Unknown');
+      const reportId = escapeHtml(r.id?.slice(0, 8) || '?');
       const date = escapeHtml(fmtDate(r.created_at));
-      const rating = escapeHtml(r.rating || '?');
       return `<tr data-report-id="${r.id}">
-        <td>#${r.id}</td>
-        <td>${game}</td>
-        <td>${author}</td>
-        <td>${rating}</td>
+        <td><a class="admin-link" href="app.html#/app/${r.app_id}" target="_blank">${game}</a></td>
+        <td><code>${reportId}</code></td>
         <td>${date}</td>
         <td>
           <button class="admin-btn admin-btn--sm" data-action="review" data-report='${escapeHtml(JSON.stringify(r))}'>Review</button>

--- a/js/admin/components/pending.js
+++ b/js/admin/components/pending.js
@@ -22,7 +22,7 @@ export async function renderPending(session, { onApproved } = {}) {
 
     table.hidden = false;
     tbody.innerHTML = reports.map(r => {
-      const author = escapeHtml(r.display_name || r.client_id?.slice(0, 8) || 'anonymous');
+      const author = escapeHtml(r.proton_pulse_user_id?.slice(0, 8) || r.client_id?.slice(0, 8) || 'anonymous');
       const game = escapeHtml(r.app_id ? `App ${r.app_id}` : 'Unknown');
       const date = escapeHtml(fmtDate(r.created_at));
       const rating = escapeHtml(r.rating || '?');

--- a/js/admin/components/pending.js
+++ b/js/admin/components/pending.js
@@ -6,10 +6,12 @@ export async function renderPending(session, { onApproved } = {}) {
   const empty = document.getElementById('pending-empty');
   const table = document.getElementById('pending-table');
   const tbody = document.getElementById('pending-tbody');
+  const detail = document.getElementById('pending-detail');
 
   loading.hidden = false;
   empty.hidden = true;
   table.hidden = true;
+  if (detail) detail.hidden = true;
 
   try {
     const reports = await fetchPendingReports(session);
@@ -23,21 +25,33 @@ export async function renderPending(session, { onApproved } = {}) {
     table.hidden = false;
     tbody.innerHTML = reports.map(r => {
       const author = escapeHtml(r.proton_pulse_user_id?.slice(0, 8) || r.client_id?.slice(0, 8) || 'anonymous');
-      const game = escapeHtml(r.app_id ? `App ${r.app_id}` : 'Unknown');
+      const game = escapeHtml(`App ${r.app_id}`);
       const date = escapeHtml(fmtDate(r.created_at));
       const rating = escapeHtml(r.rating || '?');
       return `<tr data-report-id="${r.id}">
-        <td><a class="admin-link" href="app.html#/app/${r.app_id}" target="_blank">${game}</a></td>
+        <td>#${r.id}</td>
+        <td>${game}</td>
         <td>${author}</td>
         <td>${rating}</td>
         <td>${date}</td>
-        <td><button class="admin-btn admin-btn--ok admin-btn--sm" data-action="approve" data-report='${escapeHtml(JSON.stringify(r))}'>Approve</button></td>
+        <td>
+          <button class="admin-btn admin-btn--sm" data-action="review" data-report='${escapeHtml(JSON.stringify(r))}'>Review</button>
+          <button class="admin-btn admin-btn--ok admin-btn--sm" data-action="approve" data-report='${escapeHtml(JSON.stringify(r))}'>Approve</button>
+        </td>
       </tr>`;
     }).join('');
 
-    tbody.querySelectorAll('[data-action="approve"]').forEach(btn => {
-      btn.addEventListener('click', async () => {
-        const report = JSON.parse(btn.dataset.report);
+    tbody.addEventListener('click', async (e) => {
+      const btn = e.target.closest('button[data-action]');
+      if (!btn) return;
+      const report = JSON.parse(btn.dataset.report);
+
+      if (btn.dataset.action === 'review') {
+        showReviewDetail(report);
+        return;
+      }
+
+      if (btn.dataset.action === 'approve') {
         btn.disabled = true;
         btn.textContent = 'Approving...';
         try {
@@ -52,11 +66,53 @@ export async function renderPending(session, { onApproved } = {}) {
           btn.textContent = 'Failed';
           btn.disabled = false;
         }
-      });
+      }
     });
   } catch (e) {
     loading.hidden = true;
     empty.textContent = `Error: ${e.message}`;
     empty.hidden = false;
   }
+}
+
+function showReviewDetail(report) {
+  const detail = document.getElementById('pending-detail');
+  const table = document.getElementById('pending-table');
+  if (!detail) return;
+
+  table.hidden = true;
+  detail.hidden = false;
+
+  const fields = [
+    ['Report ID', `#${report.id}`],
+    ['App ID', report.app_id],
+    ['Rating', report.rating || '(not set)'],
+    ['GPU', report.gpu || '(not set)'],
+    ['OS', report.os || '(not set)'],
+    ['Notes', report.notes || '(none)'],
+    ['Submitted', report.created_at ? new Date(report.created_at).toLocaleString() : '?'],
+    ['Author', report.proton_pulse_user_id || report.client_id || 'anonymous'],
+  ];
+
+  detail.innerHTML = `
+    <button class="admin-btn admin-btn--sm" id="pending-back-btn" style="margin-bottom:12px">Back to list</button>
+    <div class="admin-card">
+      <div class="admin-subhead">Report Review (Read-only)</div>
+      <table class="admin-table">
+        <tbody>
+          ${fields.map(([label, value]) => `
+            <tr>
+              <td style="font-weight:600;color:var(--muted);width:120px">${escapeHtml(label)}</td>
+              <td>${escapeHtml(String(value))}</td>
+            </tr>
+          `).join('')}
+        </tbody>
+      </table>
+    </div>
+  `;
+
+  detail.querySelector('#pending-back-btn')?.addEventListener('click', () => {
+    detail.hidden = true;
+    table.hidden = false;
+  });
 }

--- a/js/admin/components/pending.js
+++ b/js/admin/components/pending.js
@@ -1,5 +1,5 @@
 import { escapeHtml, fmtDate } from '../utils.js?v=86489fcb';
-import { fetchPendingReports, approveReport } from '../api/pending.js?v=e38fa2f3';
+import { fetchPendingReports, approveReport } from '../api/pending.js?v=b722b8eb';
 
 export async function renderPending(session, { onApproved } = {}) {
   const loading = document.getElementById('pending-loading');

--- a/js/admin/components/pending.js
+++ b/js/admin/components/pending.js
@@ -1,0 +1,62 @@
+import { escapeHtml, fmtDate } from '../utils.js?v=86489fcb';
+import { fetchPendingReports, approveReport } from '../api/pending.js?v=e38fa2f3';
+
+export async function renderPending(session, { onApproved } = {}) {
+  const loading = document.getElementById('pending-loading');
+  const empty = document.getElementById('pending-empty');
+  const table = document.getElementById('pending-table');
+  const tbody = document.getElementById('pending-tbody');
+
+  loading.hidden = false;
+  empty.hidden = true;
+  table.hidden = true;
+
+  try {
+    const reports = await fetchPendingReports(session);
+    loading.hidden = true;
+
+    if (!reports.length) {
+      empty.hidden = false;
+      return;
+    }
+
+    table.hidden = false;
+    tbody.innerHTML = reports.map(r => {
+      const author = escapeHtml(r.display_name || r.client_id?.slice(0, 8) || 'anonymous');
+      const game = escapeHtml(r.app_id ? `App ${r.app_id}` : 'Unknown');
+      const date = escapeHtml(fmtDate(r.created_at));
+      const rating = escapeHtml(r.rating || '?');
+      return `<tr data-report-id="${r.id}">
+        <td><a class="admin-link" href="app.html#/app/${r.app_id}" target="_blank">${game}</a></td>
+        <td>${author}</td>
+        <td>${rating}</td>
+        <td>${date}</td>
+        <td><button class="admin-btn admin-btn--ok admin-btn--sm" data-action="approve" data-report='${escapeHtml(JSON.stringify(r))}'>Approve</button></td>
+      </tr>`;
+    }).join('');
+
+    tbody.querySelectorAll('[data-action="approve"]').forEach(btn => {
+      btn.addEventListener('click', async () => {
+        const report = JSON.parse(btn.dataset.report);
+        btn.disabled = true;
+        btn.textContent = 'Approving...';
+        try {
+          await approveReport(session, report);
+          btn.closest('tr').remove();
+          if (!tbody.children.length) {
+            table.hidden = true;
+            empty.hidden = false;
+          }
+          onApproved?.();
+        } catch (e) {
+          btn.textContent = 'Failed';
+          btn.disabled = false;
+        }
+      });
+    });
+  } catch (e) {
+    loading.hidden = true;
+    empty.textContent = `Error: ${e.message}`;
+    empty.hidden = false;
+  }
+}

--- a/js/admin/components/pending.js
+++ b/js/admin/components/pending.js
@@ -25,7 +25,7 @@ export async function renderPending(session, { onApproved } = {}) {
     table.hidden = false;
     tbody.innerHTML = reports.map(r => {
       const game = escapeHtml(r.app_id ? `App ${r.app_id}` : 'Unknown');
-      const reportId = escapeHtml(r.id?.slice(0, 8) || '?');
+      const reportId = escapeHtml(r.id != null ? String(r.id).slice(0, 8) : '?');
       const date = escapeHtml(fmtDate(r.created_at));
       return `<tr data-report-id="${r.id}">
         <td><a class="admin-link" href="app.html#/app/${r.app_id}" target="_blank">${game}</a></td>
@@ -81,7 +81,7 @@ function showReviewDetail(report) {
   detail.hidden = false;
 
   const fields = [
-    ['Report ID', `#${report.id}`],
+    ['Report ID', `#${String(report.id)}`],
     ['App ID', report.app_id],
     ['Rating', report.rating || '(not set)'],
     ['GPU', report.gpu || '(not set)'],

--- a/js/admin/components/pending.js
+++ b/js/admin/components/pending.js
@@ -33,36 +33,16 @@ export async function renderPending(session, { onApproved } = {}) {
         <td>${date}</td>
         <td>
           <button class="admin-btn admin-btn--sm" data-action="review" data-report='${escapeHtml(JSON.stringify(r))}'>Review</button>
-          <button class="admin-btn admin-btn--ok admin-btn--sm" data-action="approve" data-report='${escapeHtml(JSON.stringify(r))}'>Approve</button>
         </td>
       </tr>`;
     }).join('');
 
-    tbody.addEventListener('click', async (e) => {
+    tbody.addEventListener('click', (e) => {
       const btn = e.target.closest('button[data-action]');
       if (!btn) return;
       const report = JSON.parse(btn.dataset.report);
-
       if (btn.dataset.action === 'review') {
-        showReviewDetail(report);
-        return;
-      }
-
-      if (btn.dataset.action === 'approve') {
-        btn.disabled = true;
-        btn.textContent = 'Approving...';
-        try {
-          await approveReport(session, report);
-          btn.closest('tr').remove();
-          if (!tbody.children.length) {
-            table.hidden = true;
-            empty.hidden = false;
-          }
-          onApproved?.();
-        } catch (e) {
-          btn.textContent = 'Failed';
-          btn.disabled = false;
-        }
+        showReviewDetail(report, session, onApproved);
       }
     });
   } catch (e) {
@@ -72,7 +52,7 @@ export async function renderPending(session, { onApproved } = {}) {
   }
 }
 
-export function closePendingReview() {
+export function closePendingReview(approved = false) {
   const detail = document.getElementById('pending-detail');
   const table = document.getElementById('pending-table');
   if (!detail || detail.hidden) return;
@@ -80,9 +60,10 @@ export function closePendingReview() {
   table.hidden = false;
 }
 
-function showReviewDetail(report) {
+function showReviewDetail(report, session, onApproved) {
   const detail = document.getElementById('pending-detail');
   const table = document.getElementById('pending-table');
+  const tbody = document.getElementById('pending-tbody');
   if (!detail) return;
 
   history.pushState({ adminView: 'pending-review' }, '', window.location.href);
@@ -103,8 +84,8 @@ function showReviewDetail(report) {
   detail.innerHTML = `
     <button class="admin-btn admin-btn--sm" id="pending-back-btn" style="margin-bottom:12px">Back to list</button>
     <div class="admin-card">
-      <div class="admin-subhead">Report Review (Read-only)</div>
-      <table class="admin-table">
+      <div class="admin-subhead">Report Review</div>
+      <table class="admin-table" style="margin-bottom:16px">
         <tbody>
           ${fields.map(([label, value]) => `
             <tr>
@@ -114,11 +95,42 @@ function showReviewDetail(report) {
           `).join('')}
         </tbody>
       </table>
+      <div style="display:flex;gap:8px">
+        <button class="admin-btn admin-btn--ok" id="pending-approve-btn">Approve</button>
+        <button class="admin-btn admin-btn--warn" id="pending-decline-btn">Decline</button>
+      </div>
+      <div id="pending-action-status" style="font-size:0.8rem;margin-top:8px"></div>
     </div>
   `;
 
   detail.querySelector('#pending-back-btn')?.addEventListener('click', () => {
-    detail.hidden = true;
-    table.hidden = false;
+    closePendingReview();
+  });
+
+  const approveBtn = detail.querySelector('#pending-approve-btn');
+  const declineBtn = detail.querySelector('#pending-decline-btn');
+  const statusEl = detail.querySelector('#pending-action-status');
+
+  approveBtn?.addEventListener('click', async () => {
+    approveBtn.disabled = true;
+    declineBtn.disabled = true;
+    approveBtn.textContent = 'Approving...';
+    try {
+      await approveReport(session, report);
+      document.querySelector(`#pending-tbody tr[data-report-id="${report.id}"]`)?.remove();
+      if (tbody && !tbody.children.length) { table.hidden = true; }
+      onApproved?.();
+      closePendingReview();
+    } catch (e) {
+      approveBtn.textContent = 'Approve';
+      approveBtn.disabled = false;
+      declineBtn.disabled = false;
+      statusEl.textContent = e.message || 'Approve failed';
+      statusEl.style.color = 'var(--red)';
+    }
+  });
+
+  declineBtn?.addEventListener('click', () => {
+    closePendingReview();
   });
 }

--- a/js/admin/components/pending.js
+++ b/js/admin/components/pending.js
@@ -1,5 +1,5 @@
 import { escapeHtml, fmtDate } from '../utils.js?v=86489fcb';
-import { fetchPendingReports, approveReport } from '../api/pending.js?v=814363ad';
+import { fetchPendingReports, approveReport } from '../api/pending.js?v=6eb54134';
 
 export async function renderPending(session, { onApproved } = {}) {
   const loading = document.getElementById('pending-loading');
@@ -73,6 +73,7 @@ function showReviewDetail(report, session, onApproved) {
   const val = (v) => (v != null && v !== '') ? String(v) : '(not set)';
   const fields = [
     ['Report ID', `#${String(report.id)}`],
+    ['Approval Hash', val(report._approval_hash)],
     ['App ID', val(report.app_id)],
     ['Title', val(report.title)],
     ['Source', val(report.source)],

--- a/js/admin/components/phrases.js
+++ b/js/admin/components/phrases.js
@@ -1,6 +1,6 @@
 // phrases (components) for the admin page.
 
-import { escapeHtml, fmtDate } from '../utils.js?v=86489fcb';
+import { escapeHtml, fmtDateTime } from '../utils.js?v=86489fcb';
 
 export function renderPhrases(rows) {
   const loading = document.getElementById('phrases-loading');
@@ -28,7 +28,7 @@ export function renderPhrases(rows) {
       ? '<span class="admin-badge admin-badge--regex">Regex</span>'
       : '<span class="admin-badge">Literal</span>';
     const desc    = escapeHtml(r.description || '—');
-    const added   = escapeHtml(fmtDate(r.created_at));
+    const added   = escapeHtml(fmtDateTime(r.created_at));
     const toggleLabel = r.enabled ? 'Disable' : 'Enable';
     const toggleClass = r.enabled ? 'admin-btn--warn' : 'admin-btn--ok';
     return `<tr data-phrase-id="${id}"${r.enabled ? '' : ' class="admin-row--disabled"'}>

--- a/js/admin/components/userDetail.js
+++ b/js/admin/components/userDetail.js
@@ -1,6 +1,6 @@
 // userDetail (component) for the admin page - renders the full user detail screen.
 
-import { escapeHtml, fmtDate, fmtDateTime, ROLE_LABELS, roleLabel } from '../utils.js?v=86489fcb';
+import { escapeHtml, fmtDateTime, ROLE_LABELS, roleLabel } from '../utils.js?v=86489fcb';
 import { deleteUserReport, hideUserReport, editUserReport } from '../api/userDetail.js?v=916aedfc';
 
 function idRow(label, value) {
@@ -27,7 +27,7 @@ function idRow(label, value) {
 function memberSince(reports) {
   if (!reports.length) return '&#8212;';
   const earliest = reports.reduce((a, b) => (a.created_at < b.created_at ? a : b));
-  return escapeHtml(fmtDate(earliest.created_at));
+  return escapeHtml(fmtDateTime(earliest.created_at));
 }
 
 function renderReportsTable(reports) {
@@ -155,11 +155,11 @@ export function renderUserDetail(user, reports, authEvents, { session, onBack, o
       <div class="user-detail-timeline">
         <div class="user-detail-tl-row">
           <span class="user-detail-label">Last login</span>
-          <span>${escapeHtml(fmtDate(user.last_login))}</span>
+          <span>${escapeHtml(fmtDateTime(user.last_login))}</span>
         </div>
         <div class="user-detail-tl-row">
           <span class="user-detail-label">Last active</span>
-          <span>${escapeHtml(fmtDate(user.last_active))}</span>
+          <span>${escapeHtml(fmtDateTime(user.last_active))}</span>
         </div>
         <div class="user-detail-tl-row">
           <span class="user-detail-label">Member since</span>

--- a/js/admin/components/users.js
+++ b/js/admin/components/users.js
@@ -1,6 +1,6 @@
 // users (components) for the admin page.
 
-import { escapeHtml, fmtDate, ROLE_LABELS, roleLabel } from '../utils.js?v=86489fcb';
+import { escapeHtml, fmtDateTime, ROLE_LABELS, roleLabel } from '../utils.js?v=86489fcb';
 
 export function renderUsers(rows, { currentUserId, counts, canBan = true } = {}) {
   const loading = document.getElementById('users-loading');
@@ -56,8 +56,8 @@ export function renderUsers(rows, { currentUserId, counts, canBan = true } = {})
           </button>
         </span>`
       : '<span class="admin-uid">&mdash;</span>';
-    const lastActive = escapeHtml(fmtDate(r.last_active));
-    const lastLogin = escapeHtml(fmtDate(r.last_login));
+    const lastActive = escapeHtml(fmtDateTime(r.last_active));
+    const lastLogin = escapeHtml(fmtDateTime(r.last_login));
     // Only known roles get a modifier class; everyone else is the neutral "User" badge.
     const roleMod = ROLE_LABELS[r.role] ? ` admin-role-badge--${r.role}` : '';
     const roleCell = `<span class="admin-role-badge${roleMod}">${escapeHtml(roleLabel(r.role))}</span>`;

--- a/js/admin/main.js
+++ b/js/admin/main.js
@@ -17,7 +17,7 @@ import { renderUserDetail } from './components/userDetail.js?v=74450110';
 import { fetchAnalytics } from './api/analytics.js?v=f0ba00d2';
 import { renderAnalytics } from './components/analytics.js?v=e9b6ce1c';
 import { renderCacheStatus } from './components/cache-status.js?v=764c4d18';
-import { renderPending, closePendingReview } from './components/pending.js?v=15b1bbac';
+import { renderPending, closePendingReview } from './components/pending.js?v=c19f23ea';
 
 // ---------------------------------------------------------------------------
 // State

--- a/js/admin/main.js
+++ b/js/admin/main.js
@@ -4,20 +4,20 @@ import { effectivePermissions, hasPermission, canSeeTab, resolveRoleLabel, PERMI
 import { fetchFlaggedReports, updateFlagStatus, deleteFlaggedReport, fetchFlagReportContent, findPulseConfigId, shadowBanReport, releaseReportContent, deleteReportContent, suppressMirrorReport, unsuppressMirrorReport, fetchReportState } from './api/flagged.js?v=6202ee12';
 import { renderFlagged, renderFlagDetail } from './components/flagged.js?v=3f4bb02b';
 import { fetchBannedUsers, banUser, unbanUser } from './api/banned.js?v=aa9b6b53';
-import { renderBanned } from './components/banned.js?v=45d01d17';
+import { renderBanned } from './components/banned.js?v=1c1ba341';
 import { fetchAllUsers } from './api/users.js?v=72f82137';
-import { renderUsers } from './components/users.js?v=bb3b3f25';
+import { renderUsers } from './components/users.js?v=765cb3cc';
 import { fetchAdmins, addAdmin, removeAdmin, updateAdminRole } from './api/admins.js?v=16a55837';
-import { renderAdmins, renderNewAdminEditor } from './components/admins.js?v=84b4ecad';
+import { renderAdmins, renderNewAdminEditor } from './components/admins.js?v=30fa53a1';
 import { fetchBannedPhrases, addBannedPhrase, removeBannedPhrase, toggleBannedPhrase } from './api/phrases.js?v=ca024bd3';
-import { renderPhrases } from './components/phrases.js?v=79051c31';
+import { renderPhrases } from './components/phrases.js?v=20dbf1ea';
 import { loadWordlist, checkAgainstWordlist } from './api/wordlist.js?v=51c55965';
 import { fetchUserReports, fetchUserActivity } from './api/userDetail.js?v=916aedfc';
-import { renderUserDetail } from './components/userDetail.js?v=74450110';
+import { renderUserDetail } from './components/userDetail.js?v=de9360ad';
 import { fetchAnalytics } from './api/analytics.js?v=f0ba00d2';
 import { renderAnalytics } from './components/analytics.js?v=e9b6ce1c';
 import { renderCacheStatus } from './components/cache-status.js?v=764c4d18';
-import { renderPending, closePendingReview } from './components/pending.js?v=980babc0';
+import { renderPending, closePendingReview } from './components/pending.js?v=1fc5b1b4';
 
 // ---------------------------------------------------------------------------
 // State

--- a/js/admin/main.js
+++ b/js/admin/main.js
@@ -17,7 +17,7 @@ import { renderUserDetail } from './components/userDetail.js?v=74450110';
 import { fetchAnalytics } from './api/analytics.js?v=f0ba00d2';
 import { renderAnalytics } from './components/analytics.js?v=e9b6ce1c';
 import { renderCacheStatus } from './components/cache-status.js?v=764c4d18';
-import { renderPending } from './components/pending.js?v=9b1f78cc';
+import { renderPending } from './components/pending.js?v=a8dac46c';
 
 // ---------------------------------------------------------------------------
 // State

--- a/js/admin/main.js
+++ b/js/admin/main.js
@@ -17,7 +17,7 @@ import { renderUserDetail } from './components/userDetail.js?v=74450110';
 import { fetchAnalytics } from './api/analytics.js?v=f0ba00d2';
 import { renderAnalytics } from './components/analytics.js?v=e9b6ce1c';
 import { renderCacheStatus } from './components/cache-status.js?v=764c4d18';
-import { renderPending } from './components/pending.js?v=83437de7';
+import { renderPending, closePendingReview } from './components/pending.js?v=e6e814c2';
 
 // ---------------------------------------------------------------------------
 // State
@@ -661,6 +661,8 @@ function wireEvents() {
 
   // Browser back button / swipe back from detail screens.
   window.addEventListener('popstate', e => {
+    const pendingDetail = document.getElementById('pending-detail');
+    if (pendingDetail && !pendingDetail.hidden) { closePendingReview(); return; }
     if (!document.getElementById('tab-user-detail').hidden) activateTab('users');
     else if (!document.getElementById('tab-flag-detail').hidden) activateTab('flagged');
   });

--- a/js/admin/main.js
+++ b/js/admin/main.js
@@ -17,7 +17,7 @@ import { renderUserDetail } from './components/userDetail.js?v=74450110';
 import { fetchAnalytics } from './api/analytics.js?v=f0ba00d2';
 import { renderAnalytics } from './components/analytics.js?v=e9b6ce1c';
 import { renderCacheStatus } from './components/cache-status.js?v=764c4d18';
-import { renderPending } from './components/pending.js?v=0a783e2d';
+import { renderPending } from './components/pending.js?v=9b1f78cc';
 
 // ---------------------------------------------------------------------------
 // State

--- a/js/admin/main.js
+++ b/js/admin/main.js
@@ -842,6 +842,63 @@ function wireEvents() {
 }
 
 // ---------------------------------------------------------------------------
+// Generic client-side table sort
+// ---------------------------------------------------------------------------
+
+function setupTableSort(tableId) {
+  const table = document.getElementById(tableId);
+  if (!table) return;
+  const ths = table.querySelectorAll('thead th[data-sort-col]');
+  ths.forEach(th => {
+    const indicator = document.createElement('span');
+    indicator.className = 'sort-indicator';
+    indicator.setAttribute('aria-hidden', 'true');
+    th.appendChild(indicator);
+
+    th.addEventListener('click', () => {
+      const col  = parseInt(th.dataset.sortCol, 10);
+      const type = th.dataset.sortType || 'text';
+      const tbody = table.querySelector('tbody');
+      if (!tbody) return;
+
+      const wasActive = th.dataset.sortActive === '1';
+      const nowAsc    = wasActive ? th.dataset.sortDir !== 'asc' : true;
+
+      ths.forEach(h => {
+        h.dataset.sortActive = '';
+        h.dataset.sortDir    = '';
+        h.classList.remove('admin-th--sorted');
+        const ind = h.querySelector('.sort-indicator');
+        if (ind) ind.textContent = '';
+      });
+
+      th.dataset.sortActive = '1';
+      th.dataset.sortDir    = nowAsc ? 'asc' : 'desc';
+      th.classList.add('admin-th--sorted');
+      indicator.textContent = nowAsc ? ' \u25b2' : ' \u25bc';
+
+      const rows = Array.from(tbody.querySelectorAll('tr'));
+      rows.sort((a, b) => {
+        const aVal = a.cells[col]?.textContent.trim() ?? '';
+        const bVal = b.cells[col]?.textContent.trim() ?? '';
+        let cmp = 0;
+        if (type === 'number') {
+          cmp = (parseFloat(aVal) || 0) - (parseFloat(bVal) || 0);
+        } else if (type === 'date') {
+          const at = Date.parse(aVal);
+          const bt = Date.parse(bVal);
+          cmp = (isNaN(at) ? 0 : at) - (isNaN(bt) ? 0 : bt);
+        } else {
+          cmp = aVal.localeCompare(bVal, undefined, { sensitivity: 'base' });
+        }
+        return nowAsc ? cmp : -cmp;
+      });
+      rows.forEach(r => tbody.appendChild(r));
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Init
 // ---------------------------------------------------------------------------
 
@@ -868,6 +925,7 @@ async function init() {
   renderPermissionSummary();
   applyTabVisibility();
   wireEvents();
+  ['pending-table', 'flagged-table', 'banned-table', 'users-table', 'admins-table', 'phrases-table'].forEach(setupTableSort);
 
   const params = new URLSearchParams(window.location.search);
 

--- a/js/admin/main.js
+++ b/js/admin/main.js
@@ -5,7 +5,7 @@ import { fetchFlaggedReports, updateFlagStatus, deleteFlaggedReport, fetchFlagRe
 import { renderFlagged, renderFlagDetail } from './components/flagged.js?v=3f4bb02b';
 import { fetchBannedUsers, banUser, unbanUser } from './api/banned.js?v=aa9b6b53';
 import { renderBanned } from './components/banned.js?v=45d01d17';
-import { fetchAllUsers } from './api/users.js?v=52e867d2';
+import { fetchAllUsers } from './api/users.js?v=7b784e9c';
 import { renderUsers } from './components/users.js?v=bb3b3f25';
 import { fetchAdmins, addAdmin, removeAdmin, updateAdminRole } from './api/admins.js?v=16a55837';
 import { renderAdmins, renderNewAdminEditor } from './components/admins.js?v=84b4ecad';

--- a/js/admin/main.js
+++ b/js/admin/main.js
@@ -236,13 +236,29 @@ async function loadUserDetail(user) {
   content.innerHTML = '<div class="admin-loading">Loading reports...</div>';
 
   try {
-    const [reports, authEvents] = await Promise.all([
-      fetchUserReports(currentSession, {
-        userId: user.proton_pulse_user_id || null,
-        clientId: user.client_id || null,
-      }),
-      fetchUserActivity(currentSession, { userId: user.proton_pulse_user_id || null }),
+    const uid = user.proton_pulse_user_id || null;
+    const [reports, authEvents, avatarRows, authRows] = await Promise.all([
+      fetchUserReports(currentSession, { userId: uid, clientId: user.client_id || null }),
+      fetchUserActivity(currentSession, { userId: uid }),
+      uid ? fetch(`${SUPABASE_URL}/rest/v1/author_avatars?proton_pulse_user_id=eq.${encodeURIComponent(uid)}&select=last_seen_at`, { headers: supabaseHeaders(currentSession) }).then(r => r.ok ? r.json() : []).catch(() => []) : Promise.resolve([]),
+      uid ? fetch(`${SUPABASE_URL}/rest/v1/rpc/admin_list_users`, { method: 'POST', headers: { ...supabaseHeaders(currentSession), 'Content-Type': 'application/json' }, body: '{}' }).then(r => r.ok ? r.json() : []).catch(() => []) : Promise.resolve([]),
     ]);
+
+    // Re-derive last_active from all available signals so the detail view
+    // always reflects the most recent one, independent of what was serialized
+    // into the button's data-userobj at render time.
+    const avatarRow  = avatarRows[0];
+    const authUser   = uid ? authRows.find(a => a.id === uid) : null;
+    const candidates = [
+      user.last_active,
+      avatarRow?.last_seen_at,
+      authUser?.last_sign_in_at,
+    ].filter(Boolean);
+    if (candidates.length) {
+      user.last_active = candidates.reduce((a, b) => (a > b ? a : b));
+    }
+    if (authUser?.last_sign_in_at) user.last_login = authUser.last_sign_in_at;
+
     renderUserDetail(user, reports, authEvents, {
       session: currentSession,
       currentUserId: currentSession?.user?.id,

--- a/js/admin/main.js
+++ b/js/admin/main.js
@@ -17,7 +17,7 @@ import { renderUserDetail } from './components/userDetail.js?v=74450110';
 import { fetchAnalytics } from './api/analytics.js?v=f0ba00d2';
 import { renderAnalytics } from './components/analytics.js?v=e9b6ce1c';
 import { renderCacheStatus } from './components/cache-status.js?v=764c4d18';
-import { renderPending } from './components/pending.js?v=a8dac46c';
+import { renderPending } from './components/pending.js?v=83437de7';
 
 // ---------------------------------------------------------------------------
 // State

--- a/js/admin/main.js
+++ b/js/admin/main.js
@@ -17,7 +17,7 @@ import { renderUserDetail } from './components/userDetail.js?v=74450110';
 import { fetchAnalytics } from './api/analytics.js?v=f0ba00d2';
 import { renderAnalytics } from './components/analytics.js?v=e9b6ce1c';
 import { renderCacheStatus } from './components/cache-status.js?v=764c4d18';
-import { renderPending, closePendingReview } from './components/pending.js?v=e6e814c2';
+import { renderPending, closePendingReview } from './components/pending.js?v=15b1bbac';
 
 // ---------------------------------------------------------------------------
 // State

--- a/js/admin/main.js
+++ b/js/admin/main.js
@@ -17,7 +17,7 @@ import { renderUserDetail } from './components/userDetail.js?v=74450110';
 import { fetchAnalytics } from './api/analytics.js?v=f0ba00d2';
 import { renderAnalytics } from './components/analytics.js?v=e9b6ce1c';
 import { renderCacheStatus } from './components/cache-status.js?v=764c4d18';
-import { renderPending, closePendingReview } from './components/pending.js?v=c19f23ea';
+import { renderPending, closePendingReview } from './components/pending.js?v=980babc0';
 
 // ---------------------------------------------------------------------------
 // State

--- a/js/admin/main.js
+++ b/js/admin/main.js
@@ -17,6 +17,7 @@ import { renderUserDetail } from './components/userDetail.js?v=74450110';
 import { fetchAnalytics } from './api/analytics.js?v=f0ba00d2';
 import { renderAnalytics } from './components/analytics.js?v=e9b6ce1c';
 import { renderCacheStatus } from './components/cache-status.js?v=764c4d18';
+import { renderPending } from './components/pending.js?v=0a783e2d';
 
 // ---------------------------------------------------------------------------
 // State
@@ -114,6 +115,10 @@ async function applyAdminChange(uuid, role, permissions) {
 // ---------------------------------------------------------------------------
 // Load sections
 // ---------------------------------------------------------------------------
+
+async function loadPending() {
+  await renderPending(currentSession);
+}
 
 async function loadFlagged() {
   const loading = document.getElementById('flagged-loading');
@@ -318,6 +323,7 @@ async function loadAnalytics() {
 
 // Maps each tab to its data loader so tab clicks and ?tab= restore share one path.
 const TAB_LOADERS = {
+  pending: loadPending,
   flagged: loadFlagged,
   banned: loadBanned,
   users: loadUsers,

--- a/js/admin/main.js
+++ b/js/admin/main.js
@@ -5,7 +5,7 @@ import { fetchFlaggedReports, updateFlagStatus, deleteFlaggedReport, fetchFlagRe
 import { renderFlagged, renderFlagDetail } from './components/flagged.js?v=3f4bb02b';
 import { fetchBannedUsers, banUser, unbanUser } from './api/banned.js?v=aa9b6b53';
 import { renderBanned } from './components/banned.js?v=45d01d17';
-import { fetchAllUsers } from './api/users.js?v=7b784e9c';
+import { fetchAllUsers } from './api/users.js?v=72f82137';
 import { renderUsers } from './components/users.js?v=bb3b3f25';
 import { fetchAdmins, addAdmin, removeAdmin, updateAdminRole } from './api/admins.js?v=16a55837';
 import { renderAdmins, renderNewAdminEditor } from './components/admins.js?v=84b4ecad';

--- a/js/app/api/supabase.js
+++ b/js/app/api/supabase.js
@@ -40,17 +40,75 @@ export async function fetchSupabase(appId) {
   } catch { return []; }
 }
 
+function computeApprovalHash(row) {
+  const parts = [
+    String(row.app_id || ''),
+    String(row.client_id || ''),
+    String(row.rating || ''),
+    String(row.notes || ''),
+    String(row.os || ''),
+    String(row.gpu || ''),
+    String(row.created_at || ''),
+  ];
+  return md5(parts.join('|'));
+}
+
+function md5(str) {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(str);
+  let h0 = 0x67452301, h1 = 0xEFCDAB89, h2 = 0x98BADCFE, h3 = 0x10325476;
+  const k = [], s = [7,12,17,22,7,12,17,22,7,12,17,22,7,12,17,22,5,9,14,20,5,9,14,20,5,9,14,20,5,9,14,20,4,11,16,23,4,11,16,23,4,11,16,23,4,11,16,23,6,10,15,21,6,10,15,21,6,10,15,21,6,10,15,21];
+  for (let i = 0; i < 64; i++) k[i] = Math.floor(2**32 * Math.abs(Math.sin(i + 1))) >>> 0;
+  const pad = new Uint8Array(((data.length + 9 + 63) & ~63));
+  pad.set(data); pad[data.length] = 0x80;
+  const dv = new DataView(pad.buffer);
+  dv.setUint32(pad.length - 8, (data.length * 8) >>> 0, true);
+  dv.setUint32(pad.length - 4, (data.length * 8 / 2**32) >>> 0, true);
+  for (let off = 0; off < pad.length; off += 64) {
+    const m = [];
+    for (let j = 0; j < 16; j++) m[j] = dv.getUint32(off + j * 4, true);
+    let [a, b, c, d] = [h0, h1, h2, h3];
+    for (let i = 0; i < 64; i++) {
+      let f, g;
+      if (i < 16) { f = (b & c) | (~b & d); g = i; }
+      else if (i < 32) { f = (d & b) | (~d & c); g = (5*i+1) % 16; }
+      else if (i < 48) { f = b ^ c ^ d; g = (3*i+5) % 16; }
+      else { f = c ^ (b | ~d); g = (7*i) % 16; }
+      f = (f + a + k[i] + m[g]) >>> 0;
+      a = d; d = c; c = b;
+      b = (b + ((f << s[i]) | (f >>> (32 - s[i])))) >>> 0;
+    }
+    h0 = (h0 + a) >>> 0; h1 = (h1 + b) >>> 0; h2 = (h2 + c) >>> 0; h3 = (h3 + d) >>> 0;
+  }
+  return [h0, h1, h2, h3].map(v => v.toString(16).padStart(8, '0').replace(/(..)(..)(..)(..)/, '$4$3$2$1')).join('');
+}
+
 export async function fetchNativeReports(appId) {
   try {
-    const r = await fetch(
-      `${SB_URL}/user_configs?app_id=eq.${appId}&is_flagged=neq.true&select=id,client_id,proton_pulse_user_id,app_id,title,cpu,gpu,gpu_driver,gpu_vendor,gpu_architecture,ram,os,kernel,proton_version,rating,duration,duration_minutes,notes,vram_mb,form_responses,config_key,game_owned,created_at,updated_at,source,is_flagged&order=created_at.desc`,
-      { headers: { apikey: SB_KEY, Authorization: `Bearer ${SB_KEY}` } }
-    );
+    const [r, approvalRes] = await Promise.all([
+      fetch(
+        `${SB_URL}/user_configs?app_id=eq.${appId}&is_flagged=neq.true&select=id,client_id,proton_pulse_user_id,app_id,title,cpu,gpu,gpu_driver,gpu_vendor,gpu_architecture,ram,os,kernel,proton_version,rating,duration,duration_minutes,notes,vram_mb,form_responses,config_key,game_owned,created_at,updated_at,source,is_flagged&order=created_at.desc`,
+        { headers: { apikey: SB_KEY, Authorization: `Bearer ${SB_KEY}` } }
+      ),
+      fetch(
+        `${SB_URL}/report_approvals?select=report_id,approval_hash`,
+        { headers: { apikey: SB_KEY, Authorization: `Bearer ${SB_KEY}` } }
+      ).catch(() => ({ ok: false })),
+    ]);
     if (!r.ok) return [];
     const rows = await r.json();
+    const approvals = approvalRes.ok ? await approvalRes.json() : [];
+    const approvalMap = new Map(approvals.map(a => [a.report_id, a.approval_hash]));
+
+    // Filter to only approved reports (hash matches current content)
+    const approvedRows = rows.filter(row => {
+      const storedHash = approvalMap.get(row.id);
+      if (!storedHash) return false;
+      return storedHash === computeApprovalHash(row);
+    });
     // keep only the latest submission per client
     const seen = new Map();
-    for (const row of rows) {
+    for (const row of approvedRows) {
       const key = row.client_id || Math.random();
       const existing = seen.get(key);
       if (!existing || row.created_at > existing.created_at) seen.set(key, row);

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=596d887c';
+import { route } from '../router.js?v=183619dd';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=183619dd';
+import { route } from '../router.js?v=c1ccfb3e';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=cad33d06';
+import { route } from '../router.js?v=a77e8c62';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=14fedbaf';
+import { route } from '../router.js?v=a0b0bf02';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=c1ccfb3e';
+import { route } from '../router.js?v=cad33d06';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=9c3e3d48';
+import { route } from '../router.js?v=1787ca4e';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=1787ca4e';
+import { route } from '../router.js?v=006bcce9';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=a0b0bf02';
+import { route } from '../router.js?v=9c3e3d48';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=4031c5fa';
-import { route } from '../router.js?v=006bcce9';
+import { route } from '../router.js?v=596d887c';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -5,13 +5,13 @@ import { populateScoringTooltip, pulseTierFromReports, tierFromReports } from '.
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.js?v=64d7ee9d';
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
-import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=006daef4';
+import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=621c68c5';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=6d4d6884';
-import { enhanceAuthorBlocks } from './author.js?v=0d7df3e2';
+import { enhanceAuthorBlocks } from './author.js?v=e7ea4361';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=8048c60c';
-import { loadSearchIndex, searchIndex } from './search.js?v=b25820c2';
+import { renderCard } from './report-card.js?v=7ad6fa17';
+import { loadSearchIndex, searchIndex } from './search.js?v=f41e7138';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=006daef4';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=6d4d6884';
-import { enhanceAuthorBlocks } from './author.js?v=2417575e';
+import { enhanceAuthorBlocks } from './author.js?v=35d7bb8b';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=a3473a9c';
-import { loadSearchIndex, searchIndex } from './search.js?v=ed3dbb92';
+import { renderCard } from './report-card.js?v=c67310b9';
+import { loadSearchIndex, searchIndex } from './search.js?v=02779b50';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=006daef4';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=6d4d6884';
-import { enhanceAuthorBlocks } from './author.js?v=6b9f61ba';
+import { enhanceAuthorBlocks } from './author.js?v=fb0e0d52';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=b85ce7f0';
-import { loadSearchIndex, searchIndex } from './search.js?v=27bf6b80';
+import { renderCard } from './report-card.js?v=4e3ae9d3';
+import { loadSearchIndex, searchIndex } from './search.js?v=e60de7de';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -5,13 +5,13 @@ import { populateScoringTooltip, pulseTierFromReports, tierFromReports } from '.
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.js?v=64d7ee9d';
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
-import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=621c68c5';
+import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=006daef4';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=6d4d6884';
-import { enhanceAuthorBlocks } from './author.js?v=e7ea4361';
+import { enhanceAuthorBlocks } from './author.js?v=4b1fa98e';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=7ad6fa17';
-import { loadSearchIndex, searchIndex } from './search.js?v=f41e7138';
+import { renderCard } from './report-card.js?v=459b4354';
+import { loadSearchIndex, searchIndex } from './search.js?v=db75bfca';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=006daef4';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=6d4d6884';
-import { enhanceAuthorBlocks } from './author.js?v=35d7bb8b';
+import { enhanceAuthorBlocks } from './author.js?v=0d7df3e2';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=c67310b9';
-import { loadSearchIndex, searchIndex } from './search.js?v=02779b50';
+import { renderCard } from './report-card.js?v=8048c60c';
+import { loadSearchIndex, searchIndex } from './search.js?v=b25820c2';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=006daef4';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=6d4d6884';
-import { enhanceAuthorBlocks } from './author.js?v=d7ed7e0c';
+import { enhanceAuthorBlocks } from './author.js?v=6b9f61ba';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=7ad6fa17';
-import { loadSearchIndex, searchIndex } from './search.js?v=a62b7670';
+import { renderCard } from './report-card.js?v=b85ce7f0';
+import { loadSearchIndex, searchIndex } from './search.js?v=27bf6b80';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -5,13 +5,13 @@ import { populateScoringTooltip, pulseTierFromReports, tierFromReports } from '.
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.js?v=64d7ee9d';
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
-import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=621c68c5';
+import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=006daef4';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=6d4d6884';
-import { enhanceAuthorBlocks } from './author.js?v=353024a9';
+import { enhanceAuthorBlocks } from './author.js?v=46cd9f9a';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=319f8660';
-import { loadSearchIndex, searchIndex } from './search.js?v=2467d1c3';
+import { renderCard } from './report-card.js?v=45091cc8';
+import { loadSearchIndex, searchIndex } from './search.js?v=a869f104';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=006daef4';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=6d4d6884';
-import { enhanceAuthorBlocks } from './author.js?v=46cd9f9a';
+import { enhanceAuthorBlocks } from './author.js?v=d7ed7e0c';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=45091cc8';
-import { loadSearchIndex, searchIndex } from './search.js?v=a869f104';
+import { renderCard } from './report-card.js?v=7ad6fa17';
+import { loadSearchIndex, searchIndex } from './search.js?v=a62b7670';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=f3f1e031';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=006daef4';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=6d4d6884';
-import { enhanceAuthorBlocks } from './author.js?v=fb0e0d52';
+import { enhanceAuthorBlocks } from './author.js?v=2417575e';
 import { renderConfigCard } from './config-cards.js?v=2578d16a';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=b0fa82d9';
-import { renderCard } from './report-card.js?v=4e3ae9d3';
-import { loadSearchIndex, searchIndex } from './search.js?v=e60de7de';
+import { renderCard } from './report-card.js?v=a3473a9c';
+import { loadSearchIndex, searchIndex } from './search.js?v=ed3dbb92';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref } from '../config.js?v=4031c5fa';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=85cf4195';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=ed3dbb92';
+import { loadSearchIndex, searchIndex } from './search.js?v=02779b50';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=2467d1c3';
+import { loadSearchIndex, searchIndex } from './search.js?v=a869f104';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=a62b7670';
+import { loadSearchIndex, searchIndex } from './search.js?v=27bf6b80';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=02779b50';
+import { loadSearchIndex, searchIndex } from './search.js?v=b25820c2';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=27bf6b80';
+import { loadSearchIndex, searchIndex } from './search.js?v=e60de7de';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=b25820c2';
+import { loadSearchIndex, searchIndex } from './search.js?v=f41e7138';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=f41e7138';
+import { loadSearchIndex, searchIndex } from './search.js?v=db75bfca';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=a869f104';
+import { loadSearchIndex, searchIndex } from './search.js?v=a62b7670';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=a9fb53ae';
-import { loadSearchIndex, searchIndex } from './search.js?v=e60de7de';
+import { loadSearchIndex, searchIndex } from './search.js?v=ed3dbb92';
 import { SB_KEY, SB_URL, isNonSteamAppId } from '../config.js?v=4031c5fa';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=d7ed7e0c';
+import { renderAuthorBlock } from './author.js?v=6b9f61ba';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=6b9f61ba';
+import { renderAuthorBlock } from './author.js?v=fb0e0d52';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=0d7df3e2';
+import { renderAuthorBlock } from './author.js?v=e7ea4361';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=353024a9';
+import { renderAuthorBlock } from './author.js?v=46cd9f9a';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=e7ea4361';
+import { renderAuthorBlock } from './author.js?v=4b1fa98e';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=35d7bb8b';
+import { renderAuthorBlock } from './author.js?v=0d7df3e2';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=2417575e';
+import { renderAuthorBlock } from './author.js?v=35d7bb8b';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=fb0e0d52';
+import { renderAuthorBlock } from './author.js?v=2417575e';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=46cd9f9a';
+import { renderAuthorBlock } from './author.js?v=d7ed7e0c';
 import { buildFormRows } from './config-cards.js?v=2578d16a';
 import { renderSignalStrip } from './signals.js?v=a1026433';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=4031c5fa';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=00f18363';
+import { renderGamePage } from './game-page.js?v=cf7fe63a';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=c75b0b40';
+import { renderGamePage } from './game-page.js?v=902ef305';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=ea418e80';
+import { renderGamePage } from './game-page.js?v=3a67591c';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=3a67591c';
+import { renderGamePage } from './game-page.js?v=00f18363';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=9b594875';
+import { renderGamePage } from './game-page.js?v=988fee35';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=662d7c42';
+import { renderGamePage } from './game-page.js?v=ea418e80';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=8ca87928';
+import { renderGamePage } from './game-page.js?v=9b594875';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=988fee35';
+import { renderGamePage } from './game-page.js?v=662d7c42';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=a9fb53ae';
-import { renderGamePage } from './game-page.js?v=902ef305';
+import { renderGamePage } from './game-page.js?v=8ca87928';
 import { STEAM_IMG } from '../config.js?v=4031c5fa';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=3a07c55e';

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=1787ca4e';
-import { wireSearch } from './components/search.js?v=e60de7de';
+import { route } from './router.js?v=006bcce9';
+import { wireSearch } from './components/search.js?v=ed3dbb92';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=183619dd';
-import { wireSearch } from './components/search.js?v=b25820c2';
+import { route } from './router.js?v=c1ccfb3e';
+import { wireSearch } from './components/search.js?v=5d88c8f7';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=596d887c';
-import { wireSearch } from './components/search.js?v=02779b50';
+import { route } from './router.js?v=183619dd';
+import { wireSearch } from './components/search.js?v=b25820c2';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=14fedbaf';
-import { wireSearch } from './components/search.js?v=a869f104';
+import { route } from './router.js?v=a0b0bf02';
+import { wireSearch } from './components/search.js?v=a62b7670';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=9c3e3d48';
-import { wireSearch } from './components/search.js?v=27bf6b80';
+import { route } from './router.js?v=1787ca4e';
+import { wireSearch } from './components/search.js?v=e60de7de';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=cad33d06';
-import { wireSearch } from './components/search.js?v=f6b03275';
+import { route } from './router.js?v=a77e8c62';
+import { wireSearch } from './components/search.js?v=fb69ca86';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=c1ccfb3e';
-import { wireSearch } from './components/search.js?v=5d88c8f7';
+import { route } from './router.js?v=cad33d06';
+import { wireSearch } from './components/search.js?v=f6b03275';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=a0b0bf02';
-import { wireSearch } from './components/search.js?v=a62b7670';
+import { route } from './router.js?v=9c3e3d48';
+import { wireSearch } from './components/search.js?v=27bf6b80';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=006bcce9';
-import { wireSearch } from './components/search.js?v=ed3dbb92';
+import { route } from './router.js?v=596d887c';
+import { wireSearch } from './components/search.js?v=02779b50';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=c75b0b40';
-import { renderHomePage } from './components/home.js?v=e17c7904';
-import { renderSearchPage } from './components/search.js?v=a869f104';
+import { renderGamePage } from './components/game-page.js?v=902ef305';
+import { renderHomePage } from './components/home.js?v=3321aca4';
+import { renderSearchPage } from './components/search.js?v=a62b7670';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=9b594875';
-import { renderHomePage } from './components/home.js?v=18112866';
-import { renderSearchPage } from './components/search.js?v=e60de7de';
+import { renderGamePage } from './components/game-page.js?v=988fee35';
+import { renderHomePage } from './components/home.js?v=8f14096b';
+import { renderSearchPage } from './components/search.js?v=ed3dbb92';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=ea418e80';
-import { renderHomePage } from './components/home.js?v=de143023';
-import { renderSearchPage } from './components/search.js?v=b25820c2';
+import { renderGamePage } from './components/game-page.js?v=3a67591c';
+import { renderHomePage } from './components/home.js?v=9d8239f4';
+import { renderSearchPage } from './components/search.js?v=5d88c8f7';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=3a67591c';
-import { renderHomePage } from './components/home.js?v=9d8239f4';
-import { renderSearchPage } from './components/search.js?v=5d88c8f7';
+import { renderGamePage } from './components/game-page.js?v=00f18363';
+import { renderHomePage } from './components/home.js?v=83ef558e';
+import { renderSearchPage } from './components/search.js?v=f6b03275';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=00f18363';
-import { renderHomePage } from './components/home.js?v=83ef558e';
-import { renderSearchPage } from './components/search.js?v=f6b03275';
+import { renderGamePage } from './components/game-page.js?v=cf7fe63a';
+import { renderHomePage } from './components/home.js?v=b33ea51a';
+import { renderSearchPage } from './components/search.js?v=fb69ca86';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=8ca87928';
-import { renderHomePage } from './components/home.js?v=5e24a55d';
-import { renderSearchPage } from './components/search.js?v=27bf6b80';
+import { renderGamePage } from './components/game-page.js?v=9b594875';
+import { renderHomePage } from './components/home.js?v=18112866';
+import { renderSearchPage } from './components/search.js?v=e60de7de';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=662d7c42';
-import { renderHomePage } from './components/home.js?v=4938288f';
-import { renderSearchPage } from './components/search.js?v=02779b50';
+import { renderGamePage } from './components/game-page.js?v=ea418e80';
+import { renderHomePage } from './components/home.js?v=de143023';
+import { renderSearchPage } from './components/search.js?v=b25820c2';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=988fee35';
-import { renderHomePage } from './components/home.js?v=8f14096b';
-import { renderSearchPage } from './components/search.js?v=ed3dbb92';
+import { renderGamePage } from './components/game-page.js?v=662d7c42';
+import { renderHomePage } from './components/home.js?v=4938288f';
+import { renderSearchPage } from './components/search.js?v=02779b50';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=902ef305';
-import { renderHomePage } from './components/home.js?v=3321aca4';
-import { renderSearchPage } from './components/search.js?v=a62b7670';
+import { renderGamePage } from './components/game-page.js?v=8ca87928';
+import { renderHomePage } from './components/home.js?v=5e24a55d';
+import { renderSearchPage } from './components/search.js?v=27bf6b80';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/lib/topbar.js
+++ b/js/lib/topbar.js
@@ -225,21 +225,20 @@
             <svg class="nav-icon" aria-hidden="true"><use href="#icon-gamepad"/></svg>
             <span>Decky Plugin</span>
           </a>
+          <a href="https://github.com/mdeguzis/proton-pulse-web/issues/new/choose" target="_blank" rel="noopener" title="Report a bug, file a Game Report, or contact the maintainer">
+            <svg class="nav-icon" aria-hidden="true"><use href="#icon-contact"/></svg>
+            <span>Contact</span>
+          </a>
+          <a href="https://discord.gg/4p6e4X7xW" target="_blank" rel="noopener" title="Join the Proton Pulse Discord">
+            <svg class="nav-icon" aria-hidden="true"><use href="#icon-discord"/></svg>
+            <span>Discord</span>
+          </a>
         </div>
       </div>
       <!-- About: top-level, placed after the dropdowns (dropdowns come first) -->
       <a href="about.html" data-page="about" title="What Proton Pulse is and how it compares to ProtonDB">
         <svg class="nav-icon" aria-hidden="true"><use href="#icon-info"/></svg>
         <span>About</span>
-      </a>
-      <!-- GitHub issue chooser - shows Game Report / Missing ProtonDB / Plugin Issue / Blank etc. -->
-      <a href="https://github.com/mdeguzis/proton-pulse-web/issues/new/choose" target="_blank" rel="noopener" title="Report a bug, file a Game Report, or contact the maintainer">
-        <svg class="nav-icon" aria-hidden="true"><use href="#icon-contact"/></svg>
-        <span>Contact</span>
-      </a>
-      <a href="https://discord.gg/4p6e4X7xW" target="_blank" rel="noopener" title="Join the Proton Pulse Discord">
-        <svg class="nav-icon" aria-hidden="true"><use href="#icon-discord"/></svg>
-        <span>Discord</span>
       </a>
       <!-- Admin link: hidden until checkIsAdmin confirms the signed-in user is an admin -->
       <a href="admin.html" id="topbar-admin-link" class="auth-admin-navlink" hidden>

--- a/js/lib/topbar.js
+++ b/js/lib/topbar.js
@@ -756,6 +756,20 @@
       if (user) {
         if (signedOut) signedOut.hidden = true;
         if (signedIn)  signedIn.hidden  = false;
+
+        // Fire-and-forget: record that this user visited the site right now.
+        // Uses PATCH so it only updates existing rows (users who have opted in
+        // to showing their username). No-op if no row exists yet.
+        var sbUrl2 = (typeof SUPABASE_URL !== 'undefined') ? SUPABASE_URL : '';
+        var sbKey2 = (typeof SUPABASE_ANON_KEY !== 'undefined') ? SUPABASE_ANON_KEY : '';
+        var token2 = state.session && state.session.access_token;
+        if (sbUrl2 && token2) {
+          fetch(sbUrl2 + '/rest/v1/author_avatars?proton_pulse_user_id=eq.' + user.id, {
+            method: 'PATCH',
+            headers: { apikey: sbKey2, Authorization: 'Bearer ' + token2, 'Content-Type': 'application/json' },
+            body: JSON.stringify({ last_seen_at: new Date().toISOString() }),
+          }).catch(function () {});
+        }
         if (avatarEl)  avatarEl.src = (user.user_metadata && user.user_metadata.avatar_url) || '';
         if (avatarEl)  avatarEl.alt = (user.user_metadata && user.user_metadata.name) || user.email || '';
         const rawName = (user.user_metadata && user.user_metadata.name) || user.email || '';

--- a/js/profile/components/edit-modals.js
+++ b/js/profile/components/edit-modals.js
@@ -4,7 +4,7 @@
 import {
   escapeHtml, formatSystemUpdated, enabledVarsToText, textToEnabledVars,
   parseUploadedSystem, isGenericSystemLabel, inferSystemLabel,
-} from '../utils.js?v=2c832a3c';
+} from '../utils.js?v=c97505eb';
 import {
   fetchCloudConfig, patchCloudConfig, fetchFullUserConfig,
   fetchReportHistory, patchUserConfig,

--- a/js/profile/components/edit-modals.js
+++ b/js/profile/components/edit-modals.js
@@ -4,7 +4,7 @@
 import {
   escapeHtml, formatSystemUpdated, enabledVarsToText, textToEnabledVars,
   parseUploadedSystem, isGenericSystemLabel, inferSystemLabel,
-} from '../utils.js?v=9ed63d23';
+} from '../utils.js?v=2c832a3c';
 import {
   fetchCloudConfig, patchCloudConfig, fetchFullUserConfig,
   fetchReportHistory, patchUserConfig,

--- a/js/profile/components/edit-modals.js
+++ b/js/profile/components/edit-modals.js
@@ -4,7 +4,7 @@
 import {
   escapeHtml, formatSystemUpdated, enabledVarsToText, textToEnabledVars,
   parseUploadedSystem, isGenericSystemLabel, inferSystemLabel,
-} from '../utils.js?v=e44cbab2';
+} from '../utils.js?v=9ed63d23';
 import {
   fetchCloudConfig, patchCloudConfig, fetchFullUserConfig,
   fetchReportHistory, patchUserConfig,

--- a/js/profile/components/my-hardware.js
+++ b/js/profile/components/my-hardware.js
@@ -8,7 +8,7 @@ import {
   parseSteamSystemInfo, inferGpuVendor,
   getMyHwSourceMeta, setMyHwSourceMeta, getMyHwFieldOrigins,
   setMyHwFieldOrigins, setMyHwFieldOrigin,
-} from '../utils.js?v=2c832a3c';
+} from '../utils.js?v=c97505eb';
 
 /**
  * Initialise the My Hardware pane. Call once after DOM is ready.

--- a/js/profile/components/my-hardware.js
+++ b/js/profile/components/my-hardware.js
@@ -8,7 +8,7 @@ import {
   parseSteamSystemInfo, inferGpuVendor,
   getMyHwSourceMeta, setMyHwSourceMeta, getMyHwFieldOrigins,
   setMyHwFieldOrigins, setMyHwFieldOrigin,
-} from '../utils.js?v=9ed63d23';
+} from '../utils.js?v=2c832a3c';
 
 /**
  * Initialise the My Hardware pane. Call once after DOM is ready.

--- a/js/profile/components/my-hardware.js
+++ b/js/profile/components/my-hardware.js
@@ -8,7 +8,7 @@ import {
   parseSteamSystemInfo, inferGpuVendor,
   getMyHwSourceMeta, setMyHwSourceMeta, getMyHwFieldOrigins,
   setMyHwFieldOrigins, setMyHwFieldOrigin,
-} from '../utils.js?v=e44cbab2';
+} from '../utils.js?v=9ed63d23';
 
 /**
  * Initialise the My Hardware pane. Call once after DOM is ready.

--- a/js/profile/components/my-reports.js
+++ b/js/profile/components/my-reports.js
@@ -96,7 +96,7 @@ export function initMyReports(ctx) {
         <tr data-app-id="${escapeHtml(String(row.app_id))}">
           <td>
             <a href="${escapeHtml(appLink)}" class="profile-configs-game-link">${escapeHtml(name)}</a>
-            <div class="profile-configs-appid">App ${escapeHtml(String(row.app_id))}</div>
+            <div class="profile-configs-appid">App ${escapeHtml(String(row.app_id))}${row.published_id ? ` · Report #${row.published_id}` : ''}</div>
           </td>
           <td>${escapeHtml(row.rating || '—')}</td>
           <td><div class="profile-configs-status">${badges}</div>${flaggedNote}</td>

--- a/js/profile/components/my-reports.js
+++ b/js/profile/components/my-reports.js
@@ -5,12 +5,12 @@ import {
   getProtonPulseUserIdFromSession, escapeHtml, formatSystemUpdated,
   getWebClientIdProfile, getMyReportBadges, flaggedMessageHtml,
   mergeMyReportRows,
-} from '../utils.js?v=2c832a3c';
+} from '../utils.js?v=c97505eb';
 import {
   fetchMyUserConfigs, fetchMyCloudConfigs, deleteMyReportsEverywhere,
   unpublishReport,
 } from '../api/configs.js?v=a51234ab';
-import { showEditCloudConfigModal, showEditReportModal } from './edit-modals.js?v=e0dc33e4';
+import { showEditCloudConfigModal, showEditReportModal } from './edit-modals.js?v=9c4eb133';
 
 /**
  * Initialise the My Reports pane. Call once after DOM is ready.

--- a/js/profile/components/my-reports.js
+++ b/js/profile/components/my-reports.js
@@ -28,7 +28,10 @@ export function initMyReports(ctx) {
   const {
     myConfigsTable, myConfigsTbody, myConfigsEmpty,
     myConfigsLoading, myConfigsStatus, myConfigsRefresh,
+    myConfigsSearch,
   } = ctx;
+
+  let allRows = [];
 
   // ── Internal helpers ─────────────────────────────────────────────────────
 
@@ -38,9 +41,20 @@ export function initMyReports(ctx) {
 
   function renderMyConfigs(rows) {
     myConfigsLoading.hidden = true;
-    if (!rows || rows.length === 0) {
+    allRows = rows || [];
+    applySearch();
+  }
+
+  function applySearch() {
+    const q = (myConfigsSearch?.value || '').trim().toLowerCase();
+    const rows = q ? allRows.filter(r => {
+      const hay = [r.title, r.app_id, r.rating, r.os, r.gpu, r.notes].filter(Boolean).join(' ').toLowerCase();
+      return hay.includes(q);
+    }) : allRows;
+    if (!rows.length) {
       myConfigsTable.hidden = true;
       myConfigsEmpty.hidden = false;
+      myConfigsEmpty.textContent = q ? 'No reports match your search.' : 'Nothing synced yet.';
       return;
     }
     myConfigsEmpty.hidden = true;
@@ -132,6 +146,7 @@ export function initMyReports(ctx) {
   // ── Wire event listeners ─────────────────────────────────────────────────
 
   myConfigsRefresh?.addEventListener('click', () => { void refreshMyConfigs(); });
+  myConfigsSearch?.addEventListener('input', () => { applySearch(); });
 
   myConfigsTbody?.addEventListener('click', (e) => {
     const target = e.target;

--- a/js/profile/components/my-reports.js
+++ b/js/profile/components/my-reports.js
@@ -1,6 +1,6 @@
 // My Reports section: fetches published + cloud-synced configs, renders the
 // table, and handles publish/unpublish/delete/edit actions.
-import { SupaAuth } from '../config.js?v=87cd0f3d';
+import { SupaAuth, SUPABASE_URL, SUPABASE_ANON_KEY } from '../config.js?v=87cd0f3d';
 import {
   getProtonPulseUserIdFromSession, escapeHtml, formatSystemUpdated,
   getWebClientIdProfile, getMyReportBadges, flaggedMessageHtml,
@@ -136,6 +136,22 @@ export function initMyReports(ctx) {
           }
         }
       }
+      // Check approval status for published reports
+      try {
+        const approvalsRes = await fetch(
+          `${SUPABASE_URL}/rest/v1/report_approvals?select=report_id,approval_hash`,
+          { headers: { apikey: SUPABASE_ANON_KEY, Authorization: `Bearer ${SUPABASE_ANON_KEY}` } }
+        );
+        if (approvalsRes.ok) {
+          const approvals = await approvalsRes.json();
+          const approvalMap = new Map(approvals.map(a => [a.report_id, a.approval_hash]));
+          for (const row of merged) {
+            if (row.published_id && !approvalMap.has(row.published_id)) {
+              row.pending = true;
+            }
+          }
+        }
+      } catch {}
       renderMyConfigs(merged);
     } catch (e) {
       myConfigsLoading.hidden = true;

--- a/js/profile/components/my-reports.js
+++ b/js/profile/components/my-reports.js
@@ -5,12 +5,12 @@ import {
   getProtonPulseUserIdFromSession, escapeHtml, formatSystemUpdated,
   getWebClientIdProfile, getMyReportBadges, flaggedMessageHtml,
   mergeMyReportRows,
-} from '../utils.js?v=9ed63d23';
+} from '../utils.js?v=2c832a3c';
 import {
   fetchMyUserConfigs, fetchMyCloudConfigs, deleteMyReportsEverywhere,
   unpublishReport,
 } from '../api/configs.js?v=a51234ab';
-import { showEditCloudConfigModal, showEditReportModal } from './edit-modals.js?v=a7c14e27';
+import { showEditCloudConfigModal, showEditReportModal } from './edit-modals.js?v=e0dc33e4';
 
 /**
  * Initialise the My Reports pane. Call once after DOM is ready.
@@ -74,15 +74,16 @@ export function initMyReports(ctx) {
             <p>${flaggedMessageHtml(row.flagged_reason)}</p>
           </details>`
         : '';
+      const isLive = row.published_id && !row.pending;
       const actions = [
-        viewHref
+        isLive
           ? `<a class="profile-configs-view-link" href="${escapeHtml(viewHref)}">View</a>`
-          : `<span class="profile-configs-view-link profile-configs-view-disabled" title="Not published">View</span>`,
+          : `<span class="profile-configs-view-link profile-configs-view-disabled" title="Not published yet">View</span>`,
         row.cloud && row.unpublished
           ? `<a class="profile-configs-action profile-configs-publish-btn" href="submit.html?app=${escapeHtml(String(row.app_id))}&fromCloud=1&return=profile.html" target="_blank" rel="noopener">Publish</a>`
           : '',
         row.published_id
-          ? `<button type="button" class="profile-configs-action profile-configs-unpublish-btn" data-published-id="${escapeHtml(String(row.published_id))}">Unpublish</button>`
+          ? `<button type="button" class="profile-configs-action profile-configs-unpublish-btn" data-published-id="${escapeHtml(String(row.published_id))}">${row.pending ? 'Cancel' : 'Unpublish'}</button>`
           : '',
         row.published_id
           ? `<a class="profile-configs-action profile-configs-edit-btn" href="submit.html?app=${escapeHtml(String(row.app_id))}&edit=${escapeHtml(String(row.published_id))}&return=profile.html" target="_blank" rel="noopener">Edit</a>`

--- a/js/profile/components/my-reports.js
+++ b/js/profile/components/my-reports.js
@@ -5,12 +5,12 @@ import {
   getProtonPulseUserIdFromSession, escapeHtml, formatSystemUpdated,
   getWebClientIdProfile, getMyReportBadges, flaggedMessageHtml,
   mergeMyReportRows,
-} from '../utils.js?v=e44cbab2';
+} from '../utils.js?v=9ed63d23';
 import {
   fetchMyUserConfigs, fetchMyCloudConfigs, deleteMyReportsEverywhere,
   unpublishReport,
 } from '../api/configs.js?v=a51234ab';
-import { showEditCloudConfigModal, showEditReportModal } from './edit-modals.js?v=f3bac94a';
+import { showEditCloudConfigModal, showEditReportModal } from './edit-modals.js?v=a7c14e27';
 
 /**
  * Initialise the My Reports pane. Call once after DOM is ready.

--- a/js/profile/components/my-reports.js
+++ b/js/profile/components/my-reports.js
@@ -163,7 +163,17 @@ export function initMyReports(ctx) {
   // ── Wire event listeners ─────────────────────────────────────────────────
 
   myConfigsRefresh?.addEventListener('click', () => { void refreshMyConfigs(); });
-  myConfigsSearch?.addEventListener('input', () => { applySearch(); });
+
+  const searchClear = document.getElementById('my-configs-search-clear');
+  myConfigsSearch?.addEventListener('input', () => {
+    applySearch();
+    if (searchClear) searchClear.hidden = !myConfigsSearch.value;
+  });
+  searchClear?.addEventListener('click', () => {
+    if (myConfigsSearch) { myConfigsSearch.value = ''; myConfigsSearch.focus(); }
+    searchClear.hidden = true;
+    applySearch();
+  });
 
   myConfigsTbody?.addEventListener('click', (e) => {
     const target = e.target;

--- a/js/profile/components/systems.js
+++ b/js/profile/components/systems.js
@@ -6,7 +6,7 @@ import {
   getProtonPulseUserIdFromSession, parseSteamSystemInfo, inferGpuVendor,
   parseUploadedSystem, isGenericSystemLabel, inferSystemLabel,
   summarizeSystem, escapeHtml, formatSystemUpdated,
-} from '../utils.js?v=2c832a3c';
+} from '../utils.js?v=c97505eb';
 import {
   listUserSystems, setDefaultSystem, clearDefaultSystem,
   updateSystemLabel, deleteSystem,

--- a/js/profile/components/systems.js
+++ b/js/profile/components/systems.js
@@ -6,7 +6,7 @@ import {
   getProtonPulseUserIdFromSession, parseSteamSystemInfo, inferGpuVendor,
   parseUploadedSystem, isGenericSystemLabel, inferSystemLabel,
   summarizeSystem, escapeHtml, formatSystemUpdated,
-} from '../utils.js?v=e44cbab2';
+} from '../utils.js?v=9ed63d23';
 import {
   listUserSystems, setDefaultSystem, clearDefaultSystem,
   updateSystemLabel, deleteSystem,

--- a/js/profile/components/systems.js
+++ b/js/profile/components/systems.js
@@ -6,7 +6,7 @@ import {
   getProtonPulseUserIdFromSession, parseSteamSystemInfo, inferGpuVendor,
   parseUploadedSystem, isGenericSystemLabel, inferSystemLabel,
   summarizeSystem, escapeHtml, formatSystemUpdated,
-} from '../utils.js?v=9ed63d23';
+} from '../utils.js?v=2c832a3c';
 import {
   listUserSystems, setDefaultSystem, clearDefaultSystem,
   updateSystemLabel, deleteSystem,

--- a/js/profile/main.js
+++ b/js/profile/main.js
@@ -18,7 +18,7 @@ import {
 } from './api/plugin-links.js?v=59c9f51e';
 import { initMyHardware } from './components/my-hardware.js?v=350d68d5';
 import { initSystems } from './components/systems.js?v=6c3aa1d4';
-import { initMyReports } from './components/my-reports.js?v=95e6faa2';
+import { initMyReports } from './components/my-reports.js?v=1fe31246';
 
 (async function () {
   // ── DOM refs ──────────────────────────────────────────────────────────────

--- a/js/profile/main.js
+++ b/js/profile/main.js
@@ -9,16 +9,16 @@ import {
   getProtonPulseUserIdFromSession, getShowUsername, setShowUsername,
   escapeHtml, formatSystemUpdated, getWebClientIdProfile,
   getPluginLinkCodeFromLocation, getSteamIdFromSession,
-} from './utils.js?v=2c832a3c';
+} from './utils.js?v=c97505eb';
 import {
   deleteAllMyData, fetchAllMyData, checkMyDataExists,
 } from './api/configs.js?v=a51234ab';
 import {
   listLinkedPlugins, completePluginLink, removePluginLink,
 } from './api/plugin-links.js?v=59c9f51e';
-import { initMyHardware } from './components/my-hardware.js?v=42001fbf';
-import { initSystems } from './components/systems.js?v=6595349b';
-import { initMyReports } from './components/my-reports.js?v=d056bd01';
+import { initMyHardware } from './components/my-hardware.js?v=350d68d5';
+import { initSystems } from './components/systems.js?v=6c3aa1d4';
+import { initMyReports } from './components/my-reports.js?v=95e6faa2';
 
 (async function () {
   // ── DOM refs ──────────────────────────────────────────────────────────────

--- a/js/profile/main.js
+++ b/js/profile/main.js
@@ -18,7 +18,7 @@ import {
 } from './api/plugin-links.js?v=59c9f51e';
 import { initMyHardware } from './components/my-hardware.js?v=1b5c0cf0';
 import { initSystems } from './components/systems.js?v=ff74fe3e';
-import { initMyReports } from './components/my-reports.js?v=08320728';
+import { initMyReports } from './components/my-reports.js?v=82523e47';
 
 (async function () {
   // ── DOM refs ──────────────────────────────────────────────────────────────
@@ -94,6 +94,7 @@ import { initMyReports } from './components/my-reports.js?v=08320728';
     myConfigsLoading: document.getElementById('my-configs-loading'),
     myConfigsStatus:  document.getElementById('my-configs-status'),
     myConfigsRefresh: document.getElementById('my-configs-refresh-btn'),
+    myConfigsSearch:  document.getElementById('my-configs-search'),
   });
 
   // ── Session display helpers ───────────────────────────────────────────────

--- a/js/profile/main.js
+++ b/js/profile/main.js
@@ -18,7 +18,7 @@ import {
 } from './api/plugin-links.js?v=59c9f51e';
 import { initMyHardware } from './components/my-hardware.js?v=1b5c0cf0';
 import { initSystems } from './components/systems.js?v=ff74fe3e';
-import { initMyReports } from './components/my-reports.js?v=82523e47';
+import { initMyReports } from './components/my-reports.js?v=a9384a59';
 
 (async function () {
   // ── DOM refs ──────────────────────────────────────────────────────────────

--- a/js/profile/main.js
+++ b/js/profile/main.js
@@ -9,16 +9,16 @@ import {
   getProtonPulseUserIdFromSession, getShowUsername, setShowUsername,
   escapeHtml, formatSystemUpdated, getWebClientIdProfile,
   getPluginLinkCodeFromLocation, getSteamIdFromSession,
-} from './utils.js?v=e44cbab2';
+} from './utils.js?v=9ed63d23';
 import {
   deleteAllMyData, fetchAllMyData, checkMyDataExists,
 } from './api/configs.js?v=a51234ab';
 import {
   listLinkedPlugins, completePluginLink, removePluginLink,
 } from './api/plugin-links.js?v=59c9f51e';
-import { initMyHardware } from './components/my-hardware.js?v=174c6b89';
-import { initSystems } from './components/systems.js?v=12e707ae';
-import { initMyReports } from './components/my-reports.js?v=89e00c59';
+import { initMyHardware } from './components/my-hardware.js?v=1b5c0cf0';
+import { initSystems } from './components/systems.js?v=ff74fe3e';
+import { initMyReports } from './components/my-reports.js?v=08320728';
 
 (async function () {
   // ── DOM refs ──────────────────────────────────────────────────────────────

--- a/js/profile/main.js
+++ b/js/profile/main.js
@@ -9,16 +9,16 @@ import {
   getProtonPulseUserIdFromSession, getShowUsername, setShowUsername,
   escapeHtml, formatSystemUpdated, getWebClientIdProfile,
   getPluginLinkCodeFromLocation, getSteamIdFromSession,
-} from './utils.js?v=9ed63d23';
+} from './utils.js?v=2c832a3c';
 import {
   deleteAllMyData, fetchAllMyData, checkMyDataExists,
 } from './api/configs.js?v=a51234ab';
 import {
   listLinkedPlugins, completePluginLink, removePluginLink,
 } from './api/plugin-links.js?v=59c9f51e';
-import { initMyHardware } from './components/my-hardware.js?v=1b5c0cf0';
-import { initSystems } from './components/systems.js?v=ff74fe3e';
-import { initMyReports } from './components/my-reports.js?v=a9384a59';
+import { initMyHardware } from './components/my-hardware.js?v=42001fbf';
+import { initSystems } from './components/systems.js?v=6595349b';
+import { initMyReports } from './components/my-reports.js?v=d056bd01';
 
 (async function () {
   // ── DOM refs ──────────────────────────────────────────────────────────────

--- a/js/profile/system-edit.js
+++ b/js/profile/system-edit.js
@@ -2,7 +2,7 @@ import { SUPABASE_URL, SUPABASE_ANON_KEY, SupaAuth } from './config.js?v=87cd0f3
 import {
   getProtonPulseUserIdFromSession, parseSteamSystemInfo, inferGpuVendor, inferCpuVendor,
   parseUploadedSystem, isGenericSystemLabel, inferSystemLabel, escapeHtml,
-} from './utils.js?v=2c832a3c';
+} from './utils.js?v=c97505eb';
 import { supabaseHeaders } from './api/supabase.js?v=bdf4b262';
 import { supabaseUserSystemsUrl, listUserSystems, updateSystem } from './api/systems.js?v=8c9eb2f2';
 

--- a/js/profile/system-edit.js
+++ b/js/profile/system-edit.js
@@ -2,7 +2,7 @@ import { SUPABASE_URL, SUPABASE_ANON_KEY, SupaAuth } from './config.js?v=87cd0f3
 import {
   getProtonPulseUserIdFromSession, parseSteamSystemInfo, inferGpuVendor, inferCpuVendor,
   parseUploadedSystem, isGenericSystemLabel, inferSystemLabel, escapeHtml,
-} from './utils.js?v=9ed63d23';
+} from './utils.js?v=2c832a3c';
 import { supabaseHeaders } from './api/supabase.js?v=bdf4b262';
 import { supabaseUserSystemsUrl, listUserSystems, updateSystem } from './api/systems.js?v=8c9eb2f2';
 

--- a/js/profile/system-edit.js
+++ b/js/profile/system-edit.js
@@ -2,7 +2,7 @@ import { SUPABASE_URL, SUPABASE_ANON_KEY, SupaAuth } from './config.js?v=87cd0f3
 import {
   getProtonPulseUserIdFromSession, parseSteamSystemInfo, inferGpuVendor, inferCpuVendor,
   parseUploadedSystem, isGenericSystemLabel, inferSystemLabel, escapeHtml,
-} from './utils.js?v=e44cbab2';
+} from './utils.js?v=9ed63d23';
 import { supabaseHeaders } from './api/supabase.js?v=bdf4b262';
 import { supabaseUserSystemsUrl, listUserSystems, updateSystem } from './api/systems.js?v=8c9eb2f2';
 

--- a/js/profile/utils.js
+++ b/js/profile/utils.js
@@ -478,13 +478,14 @@ export function textToEnabledVars(text) {
  */
 export function getMyReportBadges(row) {
   const badges = [];
-  if (row.cloud) badges.push({ label: 'Cloud', tone: 'cloud' });
   if (row.pending) {
+    badges.push({ label: 'Cloud', tone: 'cloud' });
     badges.push({ label: 'Pending', tone: 'pending' });
-  } else if (row.published) {
-    badges.push({ label: 'Published', tone: 'published' });
+  } else {
+    if (row.cloud) badges.push({ label: 'Cloud', tone: 'cloud' });
+    if (row.published) badges.push({ label: 'Published', tone: 'published' });
+    if (row.unpublished) badges.push({ label: 'Unpublished', tone: 'unpublished' });
   }
-  if (row.unpublished && !row.pending) badges.push({ label: 'Unpublished', tone: 'unpublished' });
   if (row.flagged) badges.push({ label: 'Flagged', tone: 'flagged' });
   return badges;
 }

--- a/js/profile/utils.js
+++ b/js/profile/utils.js
@@ -479,9 +479,12 @@ export function textToEnabledVars(text) {
 export function getMyReportBadges(row) {
   const badges = [];
   if (row.cloud) badges.push({ label: 'Cloud', tone: 'cloud' });
-  if (row.published) badges.push({ label: 'Published', tone: 'published' });
-  if (row.unpublished) badges.push({ label: 'Unpublished', tone: 'unpublished' });
-  if (row.pending) badges.push({ label: 'Pending', tone: 'pending' });
+  if (row.pending) {
+    badges.push({ label: 'Pending', tone: 'pending' });
+  } else if (row.published) {
+    badges.push({ label: 'Published', tone: 'published' });
+  }
+  if (row.unpublished && !row.pending) badges.push({ label: 'Unpublished', tone: 'unpublished' });
   if (row.flagged) badges.push({ label: 'Flagged', tone: 'flagged' });
   return badges;
 }

--- a/js/profile/utils.js
+++ b/js/profile/utils.js
@@ -481,6 +481,7 @@ export function getMyReportBadges(row) {
   if (row.cloud) badges.push({ label: 'Cloud', tone: 'cloud' });
   if (row.published) badges.push({ label: 'Published', tone: 'published' });
   if (row.unpublished) badges.push({ label: 'Unpublished', tone: 'unpublished' });
+  if (row.pending) badges.push({ label: 'Pending', tone: 'pending' });
   if (row.flagged) badges.push({ label: 'Flagged', tone: 'flagged' });
   return badges;
 }

--- a/js/submit/main.js
+++ b/js/submit/main.js
@@ -185,6 +185,25 @@ import { SupaAuth } from '../shared/config.js?v=f6f2c00a';
         }
         form._formState = state;
         console.debug('[submit] edit mode: prefilled from report', { editReportId, appId });
+
+        // Show approval status banner
+        try {
+          const approvalRes = await fetch(
+            `${SUPABASE_URL}/rest/v1/report_approvals?report_id=eq.${editReportId}&select=approval_hash,approved_at,approved_by`,
+            { headers: { apikey: SUPABASE_ANON_KEY, Authorization: `Bearer ${session.access_token}` } }
+          );
+          const approvalRows = approvalRes.ok ? await approvalRes.json() : [];
+          const approval = approvalRows[0];
+          const banner = document.createElement('div');
+          banner.className = 'submit-approval-banner';
+          if (approval) {
+            banner.innerHTML = `<span class="submit-approval-badge submit-approval-badge--approved">Approved</span> Report #${editReportId} | Hash: <code>${approval.approval_hash.slice(0, 12)}...</code> | Approved: ${new Date(approval.approved_at).toLocaleDateString()} | By: ${approval.approved_by || 'pipeline'}`;
+          } else {
+            banner.innerHTML = `<span class="submit-approval-badge submit-approval-badge--pending">Pending Approval</span> Report #${editReportId} | This report is awaiting review. It will not appear publicly until approved. Reference this ID if you need to request a manual review.`;
+          }
+          const formContent = document.getElementById('submit-form-content');
+          formContent?.insertBefore(banner, formContent.firstChild);
+        } catch {}
       }
     } catch (err) {
       console.warn('[submit] edit prefill failed:', err);

--- a/profile.html
+++ b/profile.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=86052a10">
 <link rel="stylesheet" href="css/shared/cards.css?v=c0a5fad1">
-<link rel="stylesheet" href="css/profile/profile.css?v=9245cdbd">
+<link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>
 
@@ -288,6 +288,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/profile/main.js?v=585742a6"></script>
+<script type="module" src="js/profile/main.js?v=d05876e7"></script>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -288,6 +288,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/profile/main.js?v=d05876e7"></script>
+<script type="module" src="js/profile/main.js?v=6e9857e7"></script>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -288,6 +288,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/profile/main.js?v=67d3672d"></script>
+<script type="module" src="js/profile/main.js?v=746c670e"></script>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -238,6 +238,7 @@
           <button type="button" class="profile-refresh-btn" id="my-configs-refresh-btn">Refresh</button>
         </div>
         <div class="profile-field">
+          <input type="text" id="my-configs-search" class="profile-select" style="width:100%;margin-bottom:10px" placeholder="Search reports by game, rating, OS...">
           <div id="my-configs-empty" class="profile-field-hint" hidden>
             Nothing synced yet. Open a game in the Decky plugin and use <strong>Upload to Pulse</strong> or cloud sync, or submit a report from a game page.
           </div>
@@ -287,6 +288,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/profile/main.js?v=00a94bec"></script>
+<script type="module" src="js/profile/main.js?v=67d3672d"></script>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -238,7 +238,10 @@
           <button type="button" class="profile-refresh-btn" id="my-configs-refresh-btn">Refresh</button>
         </div>
         <div class="profile-field">
-          <input type="text" id="my-configs-search" class="profile-select" style="width:100%;margin-bottom:10px" placeholder="Search reports by game, rating, OS...">
+          <div style="position:relative;margin-bottom:10px">
+            <input type="text" id="my-configs-search" class="profile-select" style="width:100%;padding-right:32px" placeholder="Search reports by game, rating, OS...">
+            <button id="my-configs-search-clear" type="button" aria-label="Clear search" hidden style="position:absolute;right:8px;top:50%;transform:translateY(-50%);background:none;border:none;cursor:pointer;color:var(--red);font-size:1rem;line-height:1;padding:0">&#x2715;</button>
+          </div>
           <div id="my-configs-empty" class="profile-field-hint" hidden>
             Nothing synced yet. Open a game in the Decky plugin and use <strong>Upload to Pulse</strong> or cloud sync, or submit a report from a game page.
           </div>
@@ -288,6 +291,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/profile/main.js?v=6e9857e7"></script>
+<script type="module" src="js/profile/main.js?v=d49f08ab"></script>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=86052a10">
 <link rel="stylesheet" href="css/shared/cards.css?v=c0a5fad1">
-<link rel="stylesheet" href="css/profile/profile.css?v=ef82d101">
+<link rel="stylesheet" href="css/profile/profile.css?v=9245cdbd">
 </head>
 <body>
 
@@ -287,6 +287,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/profile/main.js?v=7737baf1"></script>
+<script type="module" src="js/profile/main.js?v=00a94bec"></script>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -288,6 +288,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=38d23fe3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/profile/main.js?v=746c670e"></script>
+<script type="module" src="js/profile/main.js?v=585742a6"></script>
 </body>
 </html>

--- a/scripts/pipeline/approve_reports.py
+++ b/scripts/pipeline/approve_reports.py
@@ -1,0 +1,114 @@
+"""Approve pending reports by generating md5 hashes of their content.
+
+A report is considered "pending" when it has no matching row in
+report_approvals or the stored hash doesn't match the current content.
+
+The hash is: md5(app_id + client_id + rating + notes + os + gpu + created_at)
+
+This script runs as part of the daily pipeline. It fetches all reports
+without a valid approval, computes the hash, and upserts into
+report_approvals.
+"""
+
+import hashlib
+import json
+import os
+import urllib.request
+
+SUPABASE_URL = os.environ.get('SUPABASE_URL', 'https://ilsgdshkaocrmibwdezk.supabase.co')
+SUPABASE_KEY = os.environ.get('SUPABASE_SERVICE_KEY', '')
+
+
+def compute_approval_hash(report):
+    """Generate md5 hash from key report fields."""
+    parts = [
+        str(report.get('app_id', '')),
+        str(report.get('client_id', '')),
+        str(report.get('rating', '')),
+        str(report.get('notes', '')),
+        str(report.get('os', '')),
+        str(report.get('gpu', '')),
+        str(report.get('created_at', '')),
+    ]
+    raw = '|'.join(parts)
+    return hashlib.md5(raw.encode('utf-8')).hexdigest()
+
+
+def fetch_pending_reports():
+    """Fetch reports that don't have a valid approval hash."""
+    url = (
+        f'{SUPABASE_URL}/rest/v1/user_configs'
+        '?select=id,app_id,client_id,rating,notes,os,gpu,created_at'
+        '&is_flagged=neq.true'
+        '&order=created_at.desc'
+        '&limit=500'
+    )
+    req = urllib.request.Request(url, headers={
+        'apikey': SUPABASE_KEY,
+        'Authorization': f'Bearer {SUPABASE_KEY}',
+    })
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        reports = json.loads(resp.read())
+
+    # Fetch existing approvals
+    approval_url = f'{SUPABASE_URL}/rest/v1/report_approvals?select=report_id,approval_hash'
+    req2 = urllib.request.Request(approval_url, headers={
+        'apikey': SUPABASE_KEY,
+        'Authorization': f'Bearer {SUPABASE_KEY}',
+    })
+    with urllib.request.urlopen(req2, timeout=30) as resp:
+        approvals = json.loads(resp.read())
+
+    existing = {a['report_id']: a['approval_hash'] for a in approvals}
+
+    pending = []
+    for r in reports:
+        expected_hash = compute_approval_hash(r)
+        stored_hash = existing.get(r['id'])
+        if stored_hash != expected_hash:
+            pending.append((r, expected_hash))
+
+    return pending
+
+
+def approve_reports(pending):
+    """Upsert approval hashes for pending reports."""
+    if not pending:
+        print('[approve_reports] No pending reports to approve')
+        return
+
+    rows = []
+    for report, hash_val in pending:
+        rows.append({
+            'report_id': report['id'],
+            'approval_hash': hash_val,
+            'approved_at': 'now()',
+            'approved_by': 'pipeline',
+        })
+
+    # Batch upsert via PostgREST
+    url = f'{SUPABASE_URL}/rest/v1/report_approvals?on_conflict=report_id'
+    data = json.dumps(rows).encode('utf-8')
+    req = urllib.request.Request(url, data=data, method='POST', headers={
+        'apikey': SUPABASE_KEY,
+        'Authorization': f'Bearer {SUPABASE_KEY}',
+        'Content-Type': 'application/json',
+        'Prefer': 'resolution=merge-duplicates,return=minimal',
+    })
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        pass
+
+    print(f'[approve_reports] Approved {len(rows)} reports')
+
+
+def run():
+    if not SUPABASE_KEY:
+        print('[approve_reports] SUPABASE_SERVICE_KEY not set, skipping')
+        return
+    pending = fetch_pending_reports()
+    print(f'[approve_reports] Found {len(pending)} pending reports')
+    approve_reports(pending)
+
+
+if __name__ == '__main__':
+    run()

--- a/submit.html
+++ b/submit.html
@@ -54,6 +54,6 @@
   </div>
 </div>
 
-<script type="module" src="js/submit/main.js?v=fc33283b"></script>
+<script type="module" src="js/submit/main.js?v=2ae0023a"></script>
 </body>
 </html>

--- a/submit.html
+++ b/submit.html
@@ -15,7 +15,7 @@
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=51e901fe">
-<link rel="stylesheet" href="css/app/modals.css?v=68ffdfa5">
+<link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
 <link rel="stylesheet" href="css/app/home.css?v=13fd2117">
 </head>
 <body>
@@ -54,6 +54,6 @@
   </div>
 </div>
 
-<script type="module" src="js/submit/main.js?v=ff057316"></script>
+<script type="module" src="js/submit/main.js?v=fc33283b"></script>
 </body>
 </html>

--- a/supabase/migrations/20260621010000_report_approvals.sql
+++ b/supabase/migrations/20260621010000_report_approvals.sql
@@ -1,0 +1,31 @@
+-- Report approval system: reports require pipeline or admin approval before
+-- they become publicly visible. The approval_hash is md5 of the report's key
+-- fields. If the user edits their report, the hash no longer matches and the
+-- report returns to pending state until re-approved.
+
+create table if not exists report_approvals (
+  report_id bigint primary key references user_configs(id) on delete cascade,
+  approval_hash text not null,
+  approved_at timestamptz not null default now(),
+  approved_by text -- 'pipeline' or admin user_id
+);
+
+-- Index for fast lookup of approved reports
+create index if not exists idx_report_approvals_hash on report_approvals(report_id, approval_hash);
+
+-- RLS: anyone can read approvals (needed for public report filtering),
+-- only service role and admins can insert/update
+alter table report_approvals enable row level security;
+
+create policy "Anyone can read approvals"
+  on report_approvals for select
+  using (true);
+
+create policy "Service role can manage approvals"
+  on report_approvals for all
+  using (true)
+  with check (true);
+
+-- Grant anon/authenticated read access
+grant select on report_approvals to anon, authenticated;
+grant insert, update, delete on report_approvals to authenticated;

--- a/supabase/migrations/20260622010000_author_avatars_last_seen.sql
+++ b/supabase/migrations/20260622010000_author_avatars_last_seen.sql
@@ -1,0 +1,4 @@
+-- Track when a logged-in user last visited the site. Updated client-side
+-- from topbar.js on every page load while a session is active.
+alter table public.author_avatars
+  add column if not exists last_seen_at timestamptz;

--- a/system-edit.html
+++ b/system-edit.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=86052a10">
 <link rel="stylesheet" href="css/shared/cards.css?v=c0a5fad1">
-<link rel="stylesheet" href="css/profile/profile.css?v=9245cdbd">
+<link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>
 
@@ -132,6 +132,6 @@
   </div>
 </div>
 
-<script type="module" src="js/profile/system-edit.js?v=6e5c8434"></script>
+<script type="module" src="js/profile/system-edit.js?v=6dfebc5c"></script>
 </body>
 </html>

--- a/system-edit.html
+++ b/system-edit.html
@@ -132,6 +132,6 @@
   </div>
 </div>
 
-<script type="module" src="js/profile/system-edit.js?v=00a229da"></script>
+<script type="module" src="js/profile/system-edit.js?v=6e5c8434"></script>
 </body>
 </html>

--- a/system-edit.html
+++ b/system-edit.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=86052a10">
 <link rel="stylesheet" href="css/shared/cards.css?v=c0a5fad1">
-<link rel="stylesheet" href="css/profile/profile.css?v=ef82d101">
+<link rel="stylesheet" href="css/profile/profile.css?v=9245cdbd">
 </head>
 <body>
 
@@ -132,6 +132,6 @@
   </div>
 </div>
 
-<script type="module" src="js/profile/system-edit.js?v=f9bcb57c"></script>
+<script type="module" src="js/profile/system-edit.js?v=00a229da"></script>
 </body>
 </html>


### PR DESCRIPTION
Batches everything on staging since the last main merge.

Backup system:
- Backup workflow fires after every successful "Update ProtonDB Data" run (post-deploy) and on schedule (weekly Sunday 04:00 UTC)
- Trigger source labeled in commit message: scheduled / post-deploy / manual
- backup.mjs writes backup-manifest.json with row counts and file sizes
- backups.jsonl in proton-pulse-data-backup gets one entry per run with ts, trigger, run_url, source_url, and file details
- New discord-backups.yml posts formatted success/failure message to the backup Discord channel

Admin panel:
- All timestamps show full date + time
- Pending report detail shows all fields including form_responses and approval hash
- Column header sorting on all 6 tables
- Wider user search box
- Last login column hidden on mobile
- User detail last_active fixed (pulls from last_seen_at, last_sign_in_at, and activity)

Nav:
- Contact and Discord moved under Resources dropdown

Supabase:
- author_avatars.last_seen_at column added (migration 20260622010000)
- topbar.js PATCHes last_seen_at on every page load for logged-in users