### PR TITLE
Browse filter UX overhaul, home filter parity, reports-per-page preference (v1.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to Proton Pulse (web) should be recorded here.
+
+## v1.3.0
+
+- Browse filter panel widens on desktop and lays the pills out in an aligned grid instead of wrapping unevenly
+- Text filter box moved out of the dropdown to sit beside the Filters button; it filters the loaded list (placeholder reads "Filter loaded list")
+- Save filters button remembers your full filter set and restores it on your next visit; Clear filters wipes it
+- Filter footer: Save and Clear are matching pills, right aligned, with Clear styled as a dark red pill
+- Home page filter button now matches the browse page (funnel icon); its store and rating pills are multi-select with an All pill that clears the others
+- Home page Rated / Not Rated counts reflect the selected stores (Steam, GOG, Epic), not just Steam
+- Unrated game cards show "No Rating" instead of "Pending"
+- Reports per page preference (50 / 100 / 150 / 200) added to the site options page; each browse section shows a loaded count like "50 of 132 loaded"
+- About page wording cleanup

--- a/about.html
+++ b/about.html
@@ -14,9 +14,9 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
-<link rel="stylesheet" href="css/shared/site.css?v=86052a10">
-<link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
-<link rel="stylesheet" href="css/index/index.css?v=ca1427ec">
+<link rel="stylesheet" href="css/shared/site.css?v=2b59a85c">
+<link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
+<link rel="stylesheet" href="css/index/index.css?v=7c9c47a4">
 </head>
 <body>
 
@@ -133,7 +133,7 @@
             <td class="cell-no">No</td>
           </tr>
           <tr>
-            <td>Non-Steam game support (Heroic, GOG)</td>
+            <td>Non-Steam game support (GOG, Epic, Heroic)</td>
             <td class="cell-yes">Yes</td>
             <td class="cell-no">No</td>
           </tr>
@@ -194,7 +194,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=46cb7ea1"></script>
+<script src="js/lib/topbar.js?v=1f85d476"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/about/version.js?v=30fa403d"></script>
 </body>

--- a/about.html
+++ b/about.html
@@ -59,7 +59,7 @@
     <!-- Spotlight differentiator: you own your reports -->
     <div class="spotlight">
       <div class="spotlight-eyebrow">Your data, your control</div>
-      <div class="spotlight-title">Edit and delete your own reports, something ProtonDB still can't do</div>
+      <div class="spotlight-title">Edit and delete your own reports, something ProtonDB can't do</div>
       <div class="spotlight-body">
         ProtonDB reports are permanent. Wrong version, wrong GPU, bad flags, it doesn't matter, you need an admin to pull it. On Proton Pulse, <strong>you edit or delete your own submissions</strong>. Stale configs, wrong hardware, outdated flags: fix them yourself without waiting on anyone.
       </div>

--- a/about.html
+++ b/about.html
@@ -14,9 +14,9 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
-<link rel="stylesheet" href="css/shared/site.css?v=2b59a85c">
+<link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
-<link rel="stylesheet" href="css/index/index.css?v=7c9c47a4">
+<link rel="stylesheet" href="css/index/index.css?v=07446e4c">
 </head>
 <body>
 
@@ -194,7 +194,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=1f85d476"></script>
+<script src="js/lib/topbar.js?v=50b75e70"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/about/version.js?v=30fa403d"></script>
 </body>

--- a/about.html
+++ b/about.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=86052a10">
 <link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
-<link rel="stylesheet" href="css/index/index.css?v=0bdafa7e">
+<link rel="stylesheet" href="css/index/index.css?v=ff4b9357">
 </head>
 <body>
 

--- a/about.html
+++ b/about.html
@@ -15,7 +15,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=86052a10">
-<link rel="stylesheet" href="css/shared/cards.css?v=eab020ab">
+<link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
 <link rel="stylesheet" href="css/index/index.css?v=0bdafa7e">
 </head>
 <body>

--- a/about.html
+++ b/about.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
-<link rel="stylesheet" href="css/index/index.css?v=96c3d47b">
+<link rel="stylesheet" href="css/index/index.css?v=d6d74d80">
 </head>
 <body>
 

--- a/about.html
+++ b/about.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=86052a10">
 <link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
-<link rel="stylesheet" href="css/index/index.css?v=ff4b9357">
+<link rel="stylesheet" href="css/index/index.css?v=ca1427ec">
 </head>
 <body>
 

--- a/about.html
+++ b/about.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
-<link rel="stylesheet" href="css/index/index.css?v=07446e4c">
+<link rel="stylesheet" href="css/index/index.css?v=ca60e7d4">
 </head>
 <body>
 

--- a/about.html
+++ b/about.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
-<link rel="stylesheet" href="css/index/index.css?v=ca60e7d4">
+<link rel="stylesheet" href="css/index/index.css?v=96c3d47b">
 </head>
 <body>
 

--- a/admin.html
+++ b/admin.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=86052a10">
-<link rel="stylesheet" href="css/shared/cards.css?v=eab020ab">
+<link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
 <link rel="stylesheet" href="css/admin/admin.css?v=b3e96439">
 </head>
 <body>

--- a/admin.html
+++ b/admin.html
@@ -10,8 +10,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
-<link rel="stylesheet" href="css/shared/site.css?v=86052a10">
-<link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
+<link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
+<link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/admin/admin.css?v=b3e96439">
 </head>
 <body>
@@ -320,7 +320,7 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/analytics.js?v=89bd7747"></script>
-<script src="js/lib/topbar.js?v=46cb7ea1"></script>
+<script src="js/lib/topbar.js?v=50b75e70"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/admin/main.js?v=4ccbece8"></script>
 </body>

--- a/app.html
+++ b/app.html
@@ -19,9 +19,9 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=f47a36cc">
+<link rel="stylesheet" href="css/app/reports.css?v=80a67287">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
-<link rel="stylesheet" href="css/app/home.css?v=bc0c5cd8">
+<link rel="stylesheet" href="css/app/home.css?v=f48067b5">
 </head>
 <body>
 
@@ -58,6 +58,6 @@
 <script src="js/lib/topbar.js?v=50b75e70"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=d1738957"></script>
+<script type="module" src="js/app/main.js?v=7e1aab0e"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -14,8 +14,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
-<link rel="stylesheet" href="css/shared/site.css?v=86052a10">
-<link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
+<link rel="stylesheet" href="css/shared/site.css?v=2b59a85c">
+<link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=51e901fe">
@@ -54,9 +54,9 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=46cb7ea1"></script>
+<script src="js/lib/topbar.js?v=1f85d476"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=53d6b6e0"></script>
+<script type="module" src="js/app/main.js?v=b81fd8d6"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -18,7 +18,7 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=51e901fe">
+<link rel="stylesheet" href="css/app/reports.css?v=7c356ffd">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
 <link rel="stylesheet" href="css/app/home.css?v=d8aa3fe5">
 </head>
@@ -57,6 +57,6 @@
 <script src="js/lib/topbar.js?v=50b75e70"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=57c60d0b"></script>
+<script type="module" src="js/app/main.js?v=f55cb956"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -57,6 +57,6 @@
 <script src="js/lib/topbar.js?v=46cb7ea1"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=7beade9b"></script>
+<script type="module" src="js/app/main.js?v=9e0f8145"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -57,6 +57,6 @@
 <script src="js/lib/topbar.js?v=46cb7ea1"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=a8e7f41f"></script>
+<script type="module" src="js/app/main.js?v=53d6b6e0"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -57,6 +57,6 @@
 <script src="js/lib/topbar.js?v=50b75e70"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=950b4b44"></script>
+<script type="module" src="js/app/main.js?v=eab10a0d"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -57,6 +57,6 @@
 <script src="js/lib/topbar.js?v=46cb7ea1"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=9e0f8145"></script>
+<script type="module" src="js/app/main.js?v=08e6e4bb"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -15,13 +15,13 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/filters.css?v=4e3a1985">
+<link rel="stylesheet" href="css/shared/filters.css?v=cfea13a2">
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=f4016583">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
-<link rel="stylesheet" href="css/app/home.css?v=d8aa3fe5">
+<link rel="stylesheet" href="css/app/home.css?v=bc0c5cd8">
 </head>
 <body>
 
@@ -58,6 +58,6 @@
 <script src="js/lib/topbar.js?v=50b75e70"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=6f1d79d5"></script>
+<script type="module" src="js/app/main.js?v=f340e9c9"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -57,6 +57,6 @@
 <script src="js/lib/topbar.js?v=46cb7ea1"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=08e6e4bb"></script>
+<script type="module" src="js/app/main.js?v=a8e7f41f"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -19,7 +19,7 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=2f616c56">
+<link rel="stylesheet" href="css/app/reports.css?v=f47a36cc">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
 <link rel="stylesheet" href="css/app/home.css?v=bc0c5cd8">
 </head>
@@ -58,6 +58,6 @@
 <script src="js/lib/topbar.js?v=50b75e70"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=fa0b76fd"></script>
+<script type="module" src="js/app/main.js?v=d1738957"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -15,11 +15,11 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/filters.css?v=cfea13a2">
+<link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=f4016583">
+<link rel="stylesheet" href="css/app/reports.css?v=cd9a2e42">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
 <link rel="stylesheet" href="css/app/home.css?v=bc0c5cd8">
 </head>
@@ -58,6 +58,6 @@
 <script src="js/lib/topbar.js?v=50b75e70"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=f340e9c9"></script>
+<script type="module" src="js/app/main.js?v=b559291d"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -57,6 +57,6 @@
 <script src="js/lib/topbar.js?v=46cb7ea1"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=363d7d6f"></script>
+<script type="module" src="js/app/main.js?v=d36385af"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -19,7 +19,7 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=1f1ae6cf">
+<link rel="stylesheet" href="css/app/reports.css?v=2f616c56">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
 <link rel="stylesheet" href="css/app/home.css?v=bc0c5cd8">
 </head>
@@ -58,6 +58,6 @@
 <script src="js/lib/topbar.js?v=50b75e70"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=ef261a09"></script>
+<script type="module" src="js/app/main.js?v=fa0b76fd"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -57,6 +57,6 @@
 <script src="js/lib/topbar.js?v=46cb7ea1"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=d36385af"></script>
+<script type="module" src="js/app/main.js?v=7beade9b"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -15,7 +15,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=86052a10">
-<link rel="stylesheet" href="css/shared/cards.css?v=eab020ab">
+<link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=51e901fe">
@@ -57,6 +57,6 @@
 <script src="js/lib/topbar.js?v=46cb7ea1"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=5ee38aa1"></script>
+<script type="module" src="js/app/main.js?v=363d7d6f"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -15,7 +15,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/filters.css?v=3b0c60ff">
+<link rel="stylesheet" href="css/shared/filters.css?v=4e3a1985">
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
@@ -58,6 +58,6 @@
 <script src="js/lib/topbar.js?v=50b75e70"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=96c048a9"></script>
+<script type="module" src="js/app/main.js?v=6f1d79d5"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -57,6 +57,6 @@
 <script src="js/lib/topbar.js?v=50b75e70"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=eab10a0d"></script>
+<script type="module" src="js/app/main.js?v=57c60d0b"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -19,7 +19,7 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=cd9a2e42">
+<link rel="stylesheet" href="css/app/reports.css?v=1f1ae6cf">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
 <link rel="stylesheet" href="css/app/home.css?v=bc0c5cd8">
 </head>
@@ -58,6 +58,6 @@
 <script src="js/lib/topbar.js?v=50b75e70"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=0a83d01f"></script>
+<script type="module" src="js/app/main.js?v=ef261a09"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -15,10 +15,11 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
+<link rel="stylesheet" href="css/shared/filters.css?v=3b0c60ff">
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=7c356ffd">
+<link rel="stylesheet" href="css/app/reports.css?v=f4016583">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
 <link rel="stylesheet" href="css/app/home.css?v=d8aa3fe5">
 </head>
@@ -57,6 +58,6 @@
 <script src="js/lib/topbar.js?v=50b75e70"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=f55cb956"></script>
+<script type="module" src="js/app/main.js?v=96c048a9"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -58,6 +58,6 @@
 <script src="js/lib/topbar.js?v=50b75e70"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=b559291d"></script>
+<script type="module" src="js/app/main.js?v=0a83d01f"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -14,7 +14,7 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
-<link rel="stylesheet" href="css/shared/site.css?v=2b59a85c">
+<link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
@@ -54,9 +54,9 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=1f85d476"></script>
+<script src="js/lib/topbar.js?v=50b75e70"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
-<script type="module" src="js/app/main.js?v=b81fd8d6"></script>
+<script type="module" src="js/app/main.js?v=950b4b44"></script>
 </body>
 </html>

--- a/auth.html
+++ b/auth.html
@@ -10,8 +10,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
-<link rel="stylesheet" href="css/shared/site.css?v=86052a10">
-<link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
+<link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
+<link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/auth.html
+++ b/auth.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=86052a10">
-<link rel="stylesheet" href="css/shared/cards.css?v=eab020ab">
+<link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/confidence.html
+++ b/confidence.html
@@ -15,7 +15,7 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=51e901fe">
+<link rel="stylesheet" href="css/app/reports.css?v=7c356ffd">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
 <link rel="stylesheet" href="css/app/home.css?v=d8aa3fe5">
 <style>

--- a/confidence.html
+++ b/confidence.html
@@ -15,7 +15,7 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=1f1ae6cf">
+<link rel="stylesheet" href="css/app/reports.css?v=2f616c56">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
 <link rel="stylesheet" href="css/app/home.css?v=bc0c5cd8">
 <style>

--- a/confidence.html
+++ b/confidence.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=86052a10">
-<link rel="stylesheet" href="css/shared/cards.css?v=eab020ab">
+<link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=51e901fe">

--- a/confidence.html
+++ b/confidence.html
@@ -15,7 +15,7 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=2f616c56">
+<link rel="stylesheet" href="css/app/reports.css?v=f47a36cc">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
 <link rel="stylesheet" href="css/app/home.css?v=bc0c5cd8">
 <style>

--- a/confidence.html
+++ b/confidence.html
@@ -15,7 +15,7 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=f4016583">
+<link rel="stylesheet" href="css/app/reports.css?v=cd9a2e42">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
 <link rel="stylesheet" href="css/app/home.css?v=bc0c5cd8">
 <style>

--- a/confidence.html
+++ b/confidence.html
@@ -17,7 +17,7 @@
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=f4016583">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
-<link rel="stylesheet" href="css/app/home.css?v=d8aa3fe5">
+<link rel="stylesheet" href="css/app/home.css?v=bc0c5cd8">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/confidence.html
+++ b/confidence.html
@@ -15,9 +15,9 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=f47a36cc">
+<link rel="stylesheet" href="css/app/reports.css?v=80a67287">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
-<link rel="stylesheet" href="css/app/home.css?v=bc0c5cd8">
+<link rel="stylesheet" href="css/app/home.css?v=f48067b5">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/confidence.html
+++ b/confidence.html
@@ -11,8 +11,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
-<link rel="stylesheet" href="css/shared/site.css?v=86052a10">
-<link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
+<link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
+<link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=51e901fe">
@@ -203,7 +203,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=46cb7ea1"></script>
+<script src="js/lib/topbar.js?v=50b75e70"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/confidence.html
+++ b/confidence.html
@@ -15,7 +15,7 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=cd9a2e42">
+<link rel="stylesheet" href="css/app/reports.css?v=1f1ae6cf">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
 <link rel="stylesheet" href="css/app/home.css?v=bc0c5cd8">
 <style>

--- a/confidence.html
+++ b/confidence.html
@@ -15,7 +15,7 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=7c356ffd">
+<link rel="stylesheet" href="css/app/reports.css?v=f4016583">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
 <link rel="stylesheet" href="css/app/home.css?v=d8aa3fe5">
 <style>

--- a/css/app/home.css
+++ b/css/app/home.css
@@ -28,6 +28,13 @@
   gap: 10px;
 }
 .section-label-row .section-label::after { display: none; }
+.section-count {
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  white-space: nowrap;
+}
 .unrated-toggle {
   display: inline-flex;
   align-items: center;

--- a/css/app/home.css
+++ b/css/app/home.css
@@ -132,6 +132,10 @@
 .home-size-btn.active { color: var(--accent); border-color: var(--accent); background: rgba(74,159,208,0.08); }
 .home-size-btn:disabled { opacity: 0.4; cursor: default; }
 .home-size-toggle--disabled { opacity: 0.6; }
+.home-size-btn--desktop-only { display: none; }
+@media (min-width: 760px) {
+  .home-size-btn--desktop-only { display: inline-flex; align-items: center; justify-content: center; }
+}
 
 /* Card size preference. Medium matches the default desktop row; small is
    denser, large is roomier. Title/sub scale with the boxart. The size class
@@ -139,11 +143,15 @@
 .cards--sm .game-card-thumb { width: 100px; height: 47px; }
 .cards--md .game-card-thumb { width: 138px; height: 64px; }
 .cards--lg .game-card-thumb { width: 200px; height: 93px; }
+.cards--xl .game-card-thumb { width: 280px; height: 130px; }
 .cards--sm .game-card { gap: 12px; padding: 8px 12px 8px 8px; }
 .cards--lg .game-card { gap: 20px; padding: 14px 20px 14px 12px; }
+.cards--xl .game-card { gap: 24px; padding: 16px 22px 16px 14px; }
 .cards--sm .game-card-title { font-size: 0.92rem; }
 .cards--lg .game-card-title { font-size: 1.12rem; }
 .cards--lg .game-card-sub { font-size: 0.85rem; }
+.cards--xl .game-card-title { font-size: 1.25rem; }
+.cards--xl .game-card-sub { font-size: 0.9rem; }
 @media (max-width: 560px) {
   /* Keep large from overwhelming small screens. */
   .cards--lg .game-card-thumb { width: 150px; height: 70px; }

--- a/css/app/reports.css
+++ b/css/app/reports.css
@@ -140,7 +140,7 @@
   gap: 16px 24px;
 }
 .filter-panel--stack .filter-item { gap: 4px; min-width: 130px; }
-.filter-panel--stack .filter-checks { min-width: 120px; }
+.filter-panel--stack .pg-filter-group { min-width: 120px; }
 .filter-panel-footer--stack {
   flex-basis: 100%;
   margin-top: 2px;
@@ -162,35 +162,8 @@
   cursor: pointer;
 }
 
-/* Multi-select checkbox filter group. The label sits above a column of
-   checkable rows; "All" is the first row. Mirrors the clean panel styling of
-   the game-page report filters. */
-.filter-checks { display: flex; flex-direction: column; gap: 5px; }
-.filter-checks-label {
-  font-size: 0.65rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--muted);
-  margin-bottom: 1px;
-}
-.filter-check {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 0.8rem;
-  color: var(--text);
-  cursor: pointer;
-  user-select: none;
-  padding: 1px 0;
-}
-.filter-check input {
-  accent-color: var(--accent);
-  width: 15px;
-  height: 15px;
-  cursor: pointer;
-  flex-shrink: 0;
-}
-.filter-check:hover { color: var(--accent); }
+/* .filter-checks / .filter-check removed -- filter groups now use
+   .pg-filter-group + .pg-filter pill buttons (css/shared/filters.css) */
 
 /* Live ProtonDB summary note: shown when a game is not in our mirror but the
    user checked ProtonDB live. We only have the aggregate (tier + total), so we

--- a/css/app/reports.css
+++ b/css/app/reports.css
@@ -99,6 +99,10 @@
   box-shadow: 0 8px 24px rgba(0,0,0,0.4);
 }
 .filter-panel.open { display: block; }
+@media (min-width: 601px) {
+  .filter-panel { min-width: 480px; }
+  .filter-panel-grid { grid-template-columns: repeat(3, 1fr); }
+}
 .filter-panel-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);

--- a/css/app/reports.css
+++ b/css/app/reports.css
@@ -146,7 +146,7 @@
   margin-top: 2px;
   padding-top: 12px;
   border-top: 1px solid var(--border);
-  justify-content: flex-end;
+  justify-content: space-between;
 }
 @media (max-width: 560px) {
   .filter-panel--stack.open { flex-direction: column; gap: 14px; }
@@ -162,22 +162,27 @@
   cursor: pointer;
 }
 
-/* Text filter box: filters the shown games by title substring. Full width of
-   the panel so it stretches wider automatically on the wider desktop panel. */
-.filter-panel--stack .home-filter-text {
-  width: 100%;
+/* Text filter box: sits in the bar to the right of the Filters button (not in
+   the dropdown). Wider on desktop, shorter on mobile. */
+.home-filter-left { display: flex; align-items: center; gap: 8px; }
+.home-filter-text {
+  width: 220px;
+  max-width: 40vw;
   box-sizing: border-box;
   background: var(--bg);
   border: 1px solid var(--border2);
   color: var(--text);
-  padding: 6px 10px;
-  font-size: 0.8rem;
+  padding: 7px 12px;
+  font-size: 0.85rem;
   font-family: inherit;
-  border-radius: 4px;
+  border-radius: 999px;
   outline: none;
   transition: border-color .1s;
 }
-.filter-panel--stack .home-filter-text:focus { border-color: var(--accent); }
+.home-filter-text:focus { border-color: var(--accent); }
+@media (max-width: 560px) {
+  .home-filter-text { width: 130px; }
+}
 
 /* Desktop: the narrow row-wrap of groups made the variable-width pills wrap
    raggedly. On wider screens lay the panel out as a single vertical column of

--- a/css/app/reports.css
+++ b/css/app/reports.css
@@ -104,17 +104,38 @@
   border-top: 1px solid var(--border);
 }
 .filter-clear-btn {
-  background: none;
-  border: 1px solid var(--border2);
-  color: var(--muted);
+  background: rgba(220, 70, 70, 0.12);
+  border: 1px solid rgba(220, 70, 70, 0.45);
+  color: #ff9b9b;
   font-size: 0.72rem;
   font-family: inherit;
-  padding: 4px 10px;
-  border-radius: 4px;
+  padding: 6px 14px;
+  border-radius: 999px;
   cursor: pointer;
-  transition: color .1s, border-color .1s;
+  transition: color .1s, border-color .1s, background .1s;
 }
-.filter-clear-btn:hover { color: var(--text); border-color: var(--text); }
+.filter-clear-btn:hover { background: rgba(220, 70, 70, 0.22); border-color: #ff6b6b; color: #ffc1c1; }
+/* Save filters: rounded pill matching the toggle/pill style; fills when active. */
+.filter-save-btn {
+  background: var(--s1);
+  border: 1.5px solid var(--border);
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 600;
+  font-family: inherit;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 6px 14px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: color .1s, border-color .1s, background .1s;
+}
+.filter-save-btn:hover { border-color: var(--accent); color: var(--strong); }
+.filter-save-btn.is-active {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  color: var(--accent-hi);
+}
 .filter-count { font-size: 0.72rem; color: var(--muted); }
 .filter-persist {
   display: inline-flex;
@@ -146,7 +167,8 @@
   margin-top: 2px;
   padding-top: 12px;
   border-top: 1px solid var(--border);
-  justify-content: space-between;
+  justify-content: flex-end;
+  gap: 8px;
 }
 @media (max-width: 560px) {
   .filter-panel--stack.open { flex-direction: column; gap: 14px; }
@@ -166,7 +188,7 @@
    the dropdown). Wider on desktop, shorter on mobile. */
 .home-filter-left { display: flex; align-items: center; gap: 8px; }
 .home-filter-text {
-  width: 220px;
+  width: 240px;
   max-width: 40vw;
   box-sizing: border-box;
   background: var(--bg);

--- a/css/app/reports.css
+++ b/css/app/reports.css
@@ -103,23 +103,10 @@
   padding-top: 10px;
   border-top: 1px solid var(--border);
 }
+/* Save filters and Clear filters share one pill shape: same size, text size,
+   and border thickness. Only the colors differ. */
+.filter-save-btn,
 .filter-clear-btn {
-  background: rgba(220, 70, 70, 0.12);
-  border: 1px solid rgba(220, 70, 70, 0.45);
-  color: #ff9b9b;
-  font-size: 0.72rem;
-  font-family: inherit;
-  padding: 6px 14px;
-  border-radius: 999px;
-  cursor: pointer;
-  transition: color .1s, border-color .1s, background .1s;
-}
-.filter-clear-btn:hover { background: rgba(220, 70, 70, 0.22); border-color: #ff6b6b; color: #ffc1c1; }
-/* Save filters: rounded pill matching the toggle/pill style; fills when active. */
-.filter-save-btn {
-  background: var(--s1);
-  border: 1.5px solid var(--border);
-  color: var(--muted);
   font-size: 0.72rem;
   font-weight: 600;
   font-family: inherit;
@@ -127,8 +114,21 @@
   letter-spacing: 0.04em;
   padding: 6px 14px;
   border-radius: 999px;
+  border-width: 1.5px;
+  border-style: solid;
   cursor: pointer;
   transition: color .1s, border-color .1s, background .1s;
+}
+.filter-clear-btn {
+  background: rgba(220, 70, 70, 0.12);
+  border-color: rgba(220, 70, 70, 0.45);
+  color: #ff9b9b;
+}
+.filter-clear-btn:hover { background: rgba(220, 70, 70, 0.22); border-color: #ff6b6b; color: #ffc1c1; }
+.filter-save-btn {
+  background: var(--s1);
+  border-color: var(--border);
+  color: var(--muted);
 }
 .filter-save-btn:hover { border-color: var(--accent); color: var(--strong); }
 .filter-save-btn.is-active {
@@ -164,6 +164,7 @@
 .filter-panel--stack .pg-filter-group { min-width: 120px; }
 .filter-panel-footer--stack {
   flex-basis: 100%;
+  width: 100%;
   margin-top: 2px;
   padding-top: 12px;
   border-top: 1px solid var(--border);

--- a/css/app/reports.css
+++ b/css/app/reports.css
@@ -59,48 +59,11 @@
   align-items: center;
   gap: 10px;
 }
-.filter-toggle-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  background: var(--s1);
-  border: 1px solid var(--border2);
-  border-radius: 6px;
-  color: var(--muted);
-  font-size: 0.76rem;
-  font-weight: 600;
-  font-family: inherit;
-  cursor: pointer;
-  transition: background .1s, color .1s, border-color .1s;
-}
-.filter-toggle-btn:hover { background: var(--s2); color: var(--text); }
-.filter-toggle-btn.has-filters { color: var(--accent); border-color: var(--accent); background: rgba(74,159,208,0.08); }
-.filter-badge {
-  background: var(--accent);
-  color: #fff;
-  border-radius: 10px;
-  padding: 1px 6px;
-  font-size: 0.65rem;
-  font-weight: 700;
-  line-height: 1.4;
-}
-.filter-panel {
-  display: none;
-  position: absolute;
-  top: calc(100% + 6px);
-  left: 0;
-  z-index: 200;
-  background: var(--s1);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 14px;
-  min-width: 280px;
-  box-shadow: 0 8px 24px rgba(0,0,0,0.4);
-}
+/* .filter-toggle-btn, .filter-badge -- base styles in css/shared/filters.css */
+/* .filter-panel base -- positioning, bg, border, radius, shadow in css/shared/filters.css */
+.filter-panel { display: none; }
 .filter-panel.open { display: block; }
 @media (min-width: 601px) {
-  .filter-panel { min-width: 480px; }
   .filter-panel-grid { grid-template-columns: repeat(3, 1fr); }
 }
 .filter-panel-grid {

--- a/css/app/reports.css
+++ b/css/app/reports.css
@@ -162,6 +162,52 @@
   cursor: pointer;
 }
 
+/* Text filter box: filters the shown games by title substring. Full width of
+   the panel so it stretches wider automatically on the wider desktop panel. */
+.filter-panel--stack .home-filter-text {
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--bg);
+  border: 1px solid var(--border2);
+  color: var(--text);
+  padding: 6px 10px;
+  font-size: 0.8rem;
+  font-family: inherit;
+  border-radius: 4px;
+  outline: none;
+  transition: border-color .1s;
+}
+.filter-panel--stack .home-filter-text:focus { border-color: var(--accent); }
+
+/* Desktop: the narrow row-wrap of groups made the variable-width pills wrap
+   raggedly. On wider screens lay the panel out as a single vertical column of
+   full-width groups, each group an even pill grid so they align in tidy
+   columns. Mobile keeps the compact stack from the max-width:560 rule above. */
+@media (min-width: 561px) {
+  .filter-panel--stack.open {
+    flex-direction: column;
+    flex-wrap: nowrap;
+    gap: 14px;
+    min-width: 540px;
+  }
+  .filter-panel--stack .filter-item,
+  .filter-panel--stack .pg-filter-group {
+    width: 100%;
+    min-width: 0;
+  }
+  .filter-panel--stack .pg-filter-group {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 8px;
+    align-items: stretch;
+  }
+  .filter-panel--stack .pg-filter-group-label { grid-column: 1 / -1; }
+  .filter-panel--stack .pg-filter {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
 /* .filter-checks / .filter-check removed -- filter groups now use
    .pg-filter-group + .pg-filter pill buttons (css/shared/filters.css) */
 

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -292,8 +292,8 @@
 .pg-head {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 14px;
-  flex-wrap: wrap;
   margin-bottom: 10px;
 }
 .pg-section-heading { margin: 6px 0 2px; }
@@ -788,5 +788,4 @@
   .quick-actions { flex-direction: column; }
   .qa-link { justify-content: center; }
   .pg-head { gap: 8px; }
-  .pg-view-controls { margin-left: 0; width: 100%; justify-content: flex-end; }
 }

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -297,6 +297,69 @@
   margin-bottom: 4px;
 }
 .pg-head .section-label { margin-bottom: 0; }
+/* Unified Filters popover for the popular section */
+.pg-filter-wrap { position: relative; }
+.pg-filter-toggle-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  background: var(--s1);
+  border: 1.5px solid var(--border);
+  color: var(--muted);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  cursor: pointer;
+  border-radius: 999px;
+  white-space: nowrap;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+.pg-filter-toggle-btn:hover { border-color: var(--accent); color: var(--strong); }
+.pg-filter-toggle-btn.has-filters { color: var(--accent); border-color: var(--accent); background: rgba(74,159,208,0.08); }
+.pg-filter-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #0a0c10;
+  font-size: 0.65rem;
+  font-weight: 800;
+}
+.pg-filter-panel {
+  display: none;
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 200;
+  background: var(--s1);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.4);
+  padding: 14px 16px;
+  min-width: 200px;
+  flex-direction: column;
+  gap: 14px;
+}
+.pg-filter-panel.open { display: flex; }
+.pg-filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.pg-filter-group-label {
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 2px;
+}
 .pg-filters {
   display: inline-flex;
   gap: 8px;

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -199,6 +199,7 @@
 .cta-btn:hover {
   filter: brightness(1.08);
   box-shadow: 0 0 16px var(--accent-glow);
+  text-decoration: none; /* override global a:hover underline */
 }
 .cta-btn:active { transform: translateY(1px); }
 .cta-primary {

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -245,6 +245,11 @@
 }
 .pg-card:hover { border-color: var(--accent); }
 .pg-card:active { transform: translateY(1px); }
+.pg-thumb-wrap {
+  position: relative;
+  flex-shrink: 0;
+  line-height: 0;
+}
 .pg-thumb {
   width: 92px;
   height: 43px;

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -269,10 +269,13 @@
 }
 .pg-right {
   display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 4px;
+  flex-direction: row;
+  align-items: center;
+  gap: 6px;
   flex-shrink: 0;
+}
+@media (max-width: 600px) {
+  .pg-right { flex-direction: column; align-items: flex-end; gap: 4px; }
 }
 .pg-badge {
   flex-shrink: 0;

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -294,9 +294,9 @@
   align-items: center;
   gap: 14px;
   flex-wrap: wrap;
-  margin-bottom: 4px;
+  margin-bottom: 10px;
 }
-.pg-head .section-label { margin-bottom: 0; }
+.pg-section-heading { margin: 6px 0 2px; }
 /* Unified Filters popover for the popular section */
 .pg-filter-wrap { position: relative; }
 .pg-filter-toggle-btn {

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -267,6 +267,13 @@
   margin-top: 2px;
   font-family: var(--mono);
 }
+.pg-right {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+  flex-shrink: 0;
+}
 .pg-badge {
   flex-shrink: 0;
   font-size: 0.7rem;

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -321,64 +321,8 @@
 @media (min-width: 601px) {
   .pg-filter-panel.open { flex-direction: row; gap: 24px; }
 }
-.pg-filter-group {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-.pg-filter-group-label {
-  font-size: 0.68rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--muted);
-  margin-bottom: 2px;
-}
-.pg-filters {
-  display: inline-flex;
-  gap: 8px;
-}
-.pg-filter {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  padding: 6px 14px;
-  background: var(--card);
-  border: 1.5px solid var(--border);
-  color: var(--muted);
-  font-size: 0.8rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  cursor: pointer;
-  border-radius: 999px;
-  white-space: nowrap;
-  transition: border-color 0.15s, color 0.15s, background 0.15s, box-shadow 0.15s;
-}
-.pg-filter:hover { border-color: var(--accent); color: var(--strong); }
-.pg-filter--active {
-  border-color: var(--accent);
-  color: #0a0c10;
-  background: var(--accent);
-  box-shadow: 0 0 0 1px var(--accent), 0 0 12px rgba(190,238,17,0.25);
-}
-.pg-filter-count {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 20px;
-  height: 18px;
-  padding: 0 5px;
-  border-radius: 999px;
-  background: var(--border);
-  color: var(--muted);
-  font-size: 0.7rem;
-  font-weight: 800;
-}
-.pg-filter--active .pg-filter-count {
-  background: rgba(10,12,16,0.22);
-  color: #0a0c10;
-}
+/* .pg-filter-group, .pg-filter-group-label, .pg-filter, .pg-filter--active,
+   .pg-filter-count -- all in css/shared/filters.css */
 /* View controls: S/M/L size + Grid/List toggle */
 .pg-view-controls { display: flex; align-items: center; gap: 10px; margin-left: auto; }
 .pg-size-toggle { display: flex; gap: 4px; }

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -357,6 +357,13 @@
   gap: 14px;
 }
 .pg-filter-panel.open { display: flex; }
+@media (min-width: 601px) {
+  .pg-filter-panel.open {
+    flex-direction: row;
+    gap: 24px;
+    min-width: 420px;
+  }
+}
 .pg-filter-group {
   display: flex;
   flex-direction: column;
@@ -448,7 +455,7 @@
 .pg-layout-btn:hover { background: var(--s2); color: var(--text); }
 .pg-layout-btn.active { color: var(--accent); border-color: var(--accent); background: rgba(74,159,208,0.08); }
 
-/* S/M/L card sizes */
+/* S/M/L/XL card sizes */
 .pg-list--sm .pg-thumb { width: 68px; height: 32px; }
 .pg-list--sm .pg-card { gap: 10px; padding: 6px 10px 6px 6px; }
 .pg-list--sm .pg-title { font-size: 0.85rem; }
@@ -457,6 +464,13 @@
 .pg-list--lg .pg-card { gap: 18px; padding: 10px 16px 10px 10px; }
 .pg-list--lg .pg-title { font-size: 1.05rem; }
 .pg-list--lg .pg-sub { font-size: 0.82rem; }
+.pg-list--xl .pg-thumb { width: 184px; height: 86px; }
+.pg-list--xl .pg-card { gap: 20px; padding: 12px 18px 12px 12px; }
+.pg-list--xl .pg-title { font-size: 1.15rem; }
+.pg-list--xl .pg-sub { font-size: 0.88rem; }
+/* XL only makes sense on wider screens */
+.pg-size-btn--desktop-only { display: none; }
+@media (min-width: 760px) { .pg-size-btn--desktop-only { display: inline-flex; } }
 @media (max-width: 600px) {
   .pg-list--lg .pg-thumb { width: 100px; height: 47px; }
 }

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -314,60 +314,12 @@
 .pg-section-heading { margin: 6px 0 2px; }
 /* Unified Filters popover for the popular section */
 .pg-filter-wrap { position: relative; }
-.pg-filter-toggle-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 14px;
-  background: var(--s1);
-  border: 1.5px solid var(--border);
-  color: var(--muted);
-  font-size: 0.8rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  cursor: pointer;
-  border-radius: 999px;
-  white-space: nowrap;
-  transition: border-color 0.15s, color 0.15s, background 0.15s;
-}
-.pg-filter-toggle-btn:hover { border-color: var(--accent); color: var(--strong); }
-.pg-filter-toggle-btn.has-filters { color: var(--accent); border-color: var(--accent); background: rgba(74,159,208,0.08); }
-.pg-filter-badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 18px;
-  height: 16px;
-  padding: 0 4px;
-  border-radius: 999px;
-  background: var(--accent);
-  color: #0a0c10;
-  font-size: 0.65rem;
-  font-weight: 800;
-}
-.pg-filter-panel {
-  display: none;
-  position: absolute;
-  top: calc(100% + 6px);
-  left: 0;
-  z-index: 200;
-  background: var(--s1);
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  box-shadow: 0 8px 24px rgba(0,0,0,0.4);
-  padding: 14px 16px;
-  min-width: 200px;
-  flex-direction: column;
-  gap: 14px;
-}
+/* .pg-filter-toggle-btn, .pg-filter-badge -- base styles in css/shared/filters.css */
+/* .pg-filter-panel base -- in css/shared/filters.css */
+.pg-filter-panel { display: none; flex-direction: column; gap: 14px; }
 .pg-filter-panel.open { display: flex; }
 @media (min-width: 601px) {
-  .pg-filter-panel.open {
-    flex-direction: row;
-    gap: 24px;
-    min-width: 420px;
-  }
+  .pg-filter-panel.open { flex-direction: row; gap: 24px; }
 }
 .pg-filter-group {
   display: flex;

--- a/css/options/options.css
+++ b/css/options/options.css
@@ -64,3 +64,19 @@
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
+.option-row--block { align-items: flex-start; flex-direction: column; gap: 12px; }
+.option-radio-group { display: flex; gap: 10px; flex-wrap: wrap; }
+.option-radio {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  font-size: 0.88rem;
+  color: var(--text);
+  padding: 6px 14px;
+  border: 1.5px solid var(--border);
+  border-radius: 999px;
+  transition: border-color 0.12s, color 0.12s;
+}
+.option-radio:has(input:checked) { border-color: var(--accent); color: var(--accent); }
+.option-radio input { display: none; }

--- a/css/shared/cards.css
+++ b/css/shared/cards.css
@@ -127,13 +127,16 @@
   padding: 4px 10px;
   border-radius: 999px;
   white-space: nowrap;
-  background: #2a3f5a;
-  color: #cfe0f0;
+  background: #1689d0;
+  color: #fff;
 }
-.game-card-store-pill--steam { background: #2a3f5a; color: #cfe0f0; }
+.game-card-store-pill--steam { background: #1689d0; color: #fff; }
 .game-card-store-pill--gog   { background: #7a3fcf; color: #fff; }
-.game-card-store-pill--epic  { background: #3a3a3a; color: #fff; }
+.game-card-store-pill--epic  { background: #555; color: #eee; }
 .game-card-store-pill--non-steam { background: #444; color: #ddd; }
+@media (max-width: 600px) {
+  .game-card-pills { flex-direction: column; align-items: flex-end; gap: 4px; }
+}
 .game-card-source {
   font-size: 0.65rem;
   color: var(--muted);

--- a/css/shared/cards.css
+++ b/css/shared/cards.css
@@ -17,6 +17,11 @@
 }
 .game-card:hover { border-color: var(--accent); text-decoration: none; }
 .game-card:active { transform: translateY(1px); }
+.game-card-thumb-wrap {
+  position: relative;
+  flex-shrink: 0;
+  line-height: 0;
+}
 .game-card-thumb {
   width: 92px;
   height: 43px;
@@ -25,6 +30,21 @@
   background: var(--s2);
   flex-shrink: 0;
 }
+/* Store tag overlaid on the artwork's bottom-right corner. Frees the right
+   column for the rating pill alone, so titles get more width on mobile. */
+.game-card-store-tag {
+  position: absolute;
+  right: 4px;
+  bottom: 4px;
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  padding: 1px 5px;
+  border-radius: 4px;
+  line-height: 1.25;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.55);
+}
 /* Desktop: give the report rows more presence with a bigger boxart and
    roomier padding. Steam header ratio (~2.14:1) is preserved. */
 @media (min-width: 760px) {
@@ -32,6 +52,7 @@
   .game-card-thumb { width: 138px; height: 64px; border-radius: 8px; }
   .game-card-title { font-size: 1.04rem; }
   .game-card-sub { font-size: 0.82rem; }
+  .game-card-store-tag { font-size: 0.64rem; right: 6px; bottom: 6px; padding: 2px 7px; }
 }
 .game-card-thumb--missing {
   display: flex;

--- a/css/shared/filters.css
+++ b/css/shared/filters.css
@@ -100,3 +100,64 @@
   }
   .filter-panel-summary { column-span: all; }
 }
+
+/* ── Pill filter group ────────────────────────────────────────────────────── */
+/* Shared across index.html, app.html (home), and stats.html. A group is a
+   label row followed by a horizontal row of pills that wraps on overflow. */
+.pg-filter-group {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+.pg-filter-group-label {
+  flex-basis: 100%;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.pg-filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 6px 14px;
+  background: var(--card);
+  border: 1.5px solid var(--border);
+  color: var(--muted);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  cursor: pointer;
+  border-radius: 999px;
+  white-space: nowrap;
+  font-family: inherit;
+  transition: border-color 0.15s, color 0.15s, background 0.15s, box-shadow 0.15s;
+}
+.pg-filter:hover { border-color: var(--accent); color: var(--strong); }
+.pg-filter--active {
+  border-color: var(--accent);
+  color: #0a0c10;
+  background: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent), 0 0 12px rgba(190,238,17,0.25);
+}
+.pg-filter-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 999px;
+  background: var(--border);
+  color: var(--muted);
+  font-size: 0.7rem;
+  font-weight: 800;
+}
+.pg-filter--active .pg-filter-count {
+  background: rgba(10,12,16,0.22);
+  color: #0a0c10;
+}

--- a/css/shared/filters.css
+++ b/css/shared/filters.css
@@ -63,7 +63,7 @@
 /* ── Panel container ──────────────────────────────────────────────────── */
 /* app.html and stats.html use .filter-panel; index uses .pg-filter-panel.
    Both are absolutely-positioned dropdowns anchored to their toggle button. */
-.filter-panel:not(.filter-panel--stack),
+.filter-panel,
 .pg-filter-panel {
   position: absolute;
   top: calc(100% + 6px);

--- a/css/shared/filters.css
+++ b/css/shared/filters.css
@@ -1,0 +1,102 @@
+/* Shared filter UI: toggle button, badge, and panel container.
+   Applied across index.html, app.html, and stats.html so all filter controls
+   share the same visual language and responsive behaviour.
+
+   Each page keeps its own scoped selectors for layout specifics (grid columns,
+   inner control types), but these base rules enforce the consistent shell. */
+
+/* ── Toggle button ────────────────────────────────────────────────────── */
+.filter-toggle-btn,
+.pg-filter-toggle-btn,
+.filter-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  background: var(--s1);
+  border: 1.5px solid var(--border);
+  border-radius: 999px;
+  color: var(--muted);
+  font-size: 0.8rem;
+  font-weight: 600;
+  font-family: inherit;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s, background 0.15s, box-shadow 0.15s;
+}
+.filter-toggle-btn:hover,
+.pg-filter-toggle-btn:hover,
+.filter-button:hover {
+  border-color: var(--accent);
+  color: var(--strong);
+}
+.filter-toggle-btn.has-filters,
+.filter-toggle-btn.is-active,
+.pg-filter-toggle-btn.has-filters,
+.filter-button.is-active {
+  color: var(--accent-hi);
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  box-shadow: 0 0 16px -6px var(--accent-glow);
+}
+
+/* ── Badge (count on button) ──────────────────────────────────────────── */
+.filter-badge,
+.pg-filter-badge,
+.filter-btn-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 16px;
+  padding: 0 5px;
+  background: var(--accent);
+  color: var(--bg);
+  font-size: 0.65rem;
+  font-weight: 700;
+  border-radius: 999px;
+  line-height: 1;
+}
+
+/* ── Panel container ──────────────────────────────────────────────────── */
+/* app.html and stats.html use .filter-panel; index uses .pg-filter-panel.
+   Both are absolutely-positioned dropdowns anchored to their toggle button. */
+.filter-panel,
+.pg-filter-panel {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 200;
+  background: var(--s1);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 14px 16px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+  min-width: 260px;
+  max-width: 96vw;
+}
+
+/* ── Responsive ───────────────────────────────────────────────────────── */
+@media (min-width: 601px) {
+  .filter-panel,
+  .pg-filter-panel {
+    min-width: 480px;
+  }
+}
+
+/* Stats page: per-dimension dropdown panels are narrow by design (single dim).
+   Override back to a sensible compact width and use 2-column on desktop. */
+.filter-dropdown .filter-panel {
+  min-width: 220px;
+  max-width: 420px;
+}
+@media (min-width: 601px) {
+  .filter-dropdown.is-open .filter-panel {
+    column-count: 2;
+    column-gap: 0;
+    min-width: 340px;
+  }
+  .filter-panel-summary { column-span: all; }
+}

--- a/css/shared/filters.css
+++ b/css/shared/filters.css
@@ -63,7 +63,7 @@
 /* ── Panel container ──────────────────────────────────────────────────── */
 /* app.html and stats.html use .filter-panel; index uses .pg-filter-panel.
    Both are absolutely-positioned dropdowns anchored to their toggle button. */
-.filter-panel,
+.filter-panel:not(.filter-panel--stack),
 .pg-filter-panel {
   position: absolute;
   top: calc(100% + 6px);
@@ -80,7 +80,7 @@
 
 /* ── Responsive ───────────────────────────────────────────────────────── */
 @media (min-width: 601px) {
-  .filter-panel,
+  .filter-panel:not(.filter-panel--stack),
   .pg-filter-panel {
     min-width: 480px;
   }

--- a/css/shared/site.css
+++ b/css/shared/site.css
@@ -427,3 +427,6 @@
   .sidebar-nav-block { display: none; }
   .sidebar-about-block { display: none; }
 }
+
+/* Store pill site preference: set by topbar.js from pp:store-pill localStorage key */
+[data-store-pill="off"] .game-card-store-pill { display: none; }

--- a/css/shared/site.css
+++ b/css/shared/site.css
@@ -428,5 +428,9 @@
   .sidebar-about-block { display: none; }
 }
 
-/* Store pill site preference: set by topbar.js from pp:store-pill localStorage key */
-[data-store-pill="off"] .game-card-store-pill { display: none; }
+/* Store pill position preference (pp:store-pill-pos).
+   Default ('right'): pill in the rating column, overlay hidden.
+   'art': overlay on the thumbnail, right-column pill hidden. */
+.game-card-store-tag { display: none; }
+[data-store-pill-pos="art"] .game-card-store-tag { display: inline; }
+[data-store-pill-pos="art"] .game-card-store-pill { display: none; }

--- a/game-stats.html
+++ b/game-stats.html
@@ -15,7 +15,7 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=51e901fe">
+<link rel="stylesheet" href="css/app/reports.css?v=7c356ffd">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
 <link rel="stylesheet" href="css/app/home.css?v=d8aa3fe5">
 <style>

--- a/game-stats.html
+++ b/game-stats.html
@@ -15,7 +15,7 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=1f1ae6cf">
+<link rel="stylesheet" href="css/app/reports.css?v=2f616c56">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
 <link rel="stylesheet" href="css/app/home.css?v=bc0c5cd8">
 <style>

--- a/game-stats.html
+++ b/game-stats.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=86052a10">
-<link rel="stylesheet" href="css/shared/cards.css?v=eab020ab">
+<link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=51e901fe">

--- a/game-stats.html
+++ b/game-stats.html
@@ -11,8 +11,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
-<link rel="stylesheet" href="css/shared/site.css?v=86052a10">
-<link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
+<link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
+<link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=51e901fe">
@@ -309,7 +309,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=46cb7ea1"></script>
+<script src="js/lib/topbar.js?v=50b75e70"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/game-stats.html
+++ b/game-stats.html
@@ -15,7 +15,7 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=2f616c56">
+<link rel="stylesheet" href="css/app/reports.css?v=f47a36cc">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
 <link rel="stylesheet" href="css/app/home.css?v=bc0c5cd8">
 <style>

--- a/game-stats.html
+++ b/game-stats.html
@@ -15,7 +15,7 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=f4016583">
+<link rel="stylesheet" href="css/app/reports.css?v=cd9a2e42">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
 <link rel="stylesheet" href="css/app/home.css?v=bc0c5cd8">
 <style>

--- a/game-stats.html
+++ b/game-stats.html
@@ -17,7 +17,7 @@
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=f4016583">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
-<link rel="stylesheet" href="css/app/home.css?v=d8aa3fe5">
+<link rel="stylesheet" href="css/app/home.css?v=bc0c5cd8">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/game-stats.html
+++ b/game-stats.html
@@ -15,9 +15,9 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=f47a36cc">
+<link rel="stylesheet" href="css/app/reports.css?v=80a67287">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
-<link rel="stylesheet" href="css/app/home.css?v=bc0c5cd8">
+<link rel="stylesheet" href="css/app/home.css?v=f48067b5">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/game-stats.html
+++ b/game-stats.html
@@ -15,7 +15,7 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=cd9a2e42">
+<link rel="stylesheet" href="css/app/reports.css?v=1f1ae6cf">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
 <link rel="stylesheet" href="css/app/home.css?v=bc0c5cd8">
 <style>

--- a/game-stats.html
+++ b/game-stats.html
@@ -15,7 +15,7 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=7c356ffd">
+<link rel="stylesheet" href="css/app/reports.css?v=f4016583">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
 <link rel="stylesheet" href="css/app/home.css?v=d8aa3fe5">
 <style>

--- a/gh-pages-manifest.txt
+++ b/gh-pages-manifest.txt
@@ -39,6 +39,7 @@ css/shared/base.css
 css/shared/topbar.css
 css/shared/site.css
 css/shared/cards.css
+css/shared/filters.css
 about.html
 options.html
 js/options/main.js

--- a/index.html
+++ b/index.html
@@ -14,9 +14,9 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
-<link rel="stylesheet" href="css/shared/site.css?v=86052a10">
-<link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
-<link rel="stylesheet" href="css/index/index.css?v=9500e654">
+<link rel="stylesheet" href="css/shared/site.css?v=2b59a85c">
+<link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
+<link rel="stylesheet" href="css/index/index.css?v=7c9c47a4">
 </head>
 <body>
 
@@ -215,7 +215,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=46cb7ea1"></script>
+<script src="js/lib/topbar.js?v=1f85d476"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/index/main.js?v=2612aab7"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=86052a10">
 <link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
-<link rel="stylesheet" href="css/index/index.css?v=67a48c61">
+<link rel="stylesheet" href="css/index/index.css?v=9500e654">
 </head>
 <body>
 
@@ -217,6 +217,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=46cb7ea1"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/index/main.js?v=198239c2"></script>
+<script type="module" src="js/index/main.js?v=2612aab7"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=86052a10">
 <link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
-<link rel="stylesheet" href="css/index/index.css?v=ca1427ec">
+<link rel="stylesheet" href="css/index/index.css?v=67a48c61">
 </head>
 <body>
 
@@ -217,6 +217,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=46cb7ea1"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/index/main.js?v=c16e1bb5"></script>
+<script type="module" src="js/index/main.js?v=198239c2"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/filters.css?v=4e3a1985">
+<link rel="stylesheet" href="css/shared/filters.css?v=cfea13a2">
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/index/index.css?v=ca60e7d4">
 </head>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
-<link rel="stylesheet" href="css/index/index.css?v=7b320670">
+<link rel="stylesheet" href="css/index/index.css?v=07446e4c">
 </head>
 <body>
 
@@ -218,6 +218,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=50b75e70"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/index/main.js?v=044a8704"></script>
+<script type="module" src="js/index/main.js?v=4a357f20"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -217,6 +217,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=46cb7ea1"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/index/main.js?v=8fc32f4e"></script>
+<script type="module" src="js/index/main.js?v=c16e1bb5"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=86052a10">
 <link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
-<link rel="stylesheet" href="css/index/index.css?v=0bdafa7e">
+<link rel="stylesheet" href="css/index/index.css?v=ff4b9357">
 </head>
 <body>
 
@@ -167,14 +167,23 @@
     <section class="popular-games" id="popular-games" hidden>
       <div class="pg-head">
         <div class="section-label" id="pg-section-label">Popular on Steam</div>
-        <div class="pg-store-filters" role="group" aria-label="Filter by store">
-          <button class="pg-filter pg-filter--active pg-store-btn" data-store="steam" id="pg-store-steam" type="button">Steam</button>
-          <button class="pg-filter pg-store-btn" data-store="gog" id="pg-store-gog" type="button">GOG</button>
-          <button class="pg-filter pg-store-btn" data-store="epic" id="pg-store-epic" type="button">Epic</button>
-        </div>
-        <div class="pg-filters" id="pg-rating-filters" role="group" aria-label="Filter popular games by rating">
-          <button class="pg-filter pg-filter--active" id="pg-filter-rated" type="button" aria-pressed="true">Rated <span class="pg-filter-count" id="pg-rated-count">0</span></button>
-          <button class="pg-filter" id="pg-filter-unrated" type="button" aria-pressed="false">Not Rated <span class="pg-filter-count" id="pg-unrated-count">0</span></button>
+        <div class="pg-filter-wrap" id="pg-filter-wrap">
+          <button class="pg-filter-toggle-btn" id="pg-filter-toggle" type="button" aria-expanded="false">
+            Filters<span class="pg-filter-badge" id="pg-filter-badge" hidden></span>
+          </button>
+          <div class="pg-filter-panel" id="pg-filter-panel">
+            <div class="pg-filter-group">
+              <span class="pg-filter-group-label">Store</span>
+              <button class="pg-filter pg-filter--active pg-store-btn" data-store="steam" id="pg-store-steam" type="button">Steam</button>
+              <button class="pg-filter pg-store-btn" data-store="gog" id="pg-store-gog" type="button">GOG</button>
+              <button class="pg-filter pg-store-btn" data-store="epic" id="pg-store-epic" type="button">Epic</button>
+            </div>
+            <div class="pg-filter-group">
+              <span class="pg-filter-group-label">Rating</span>
+              <button class="pg-filter pg-filter--active" id="pg-filter-rated" type="button" aria-pressed="true">Rated <span class="pg-filter-count" id="pg-rated-count">0</span></button>
+              <button class="pg-filter" id="pg-filter-unrated" type="button" aria-pressed="false">Not Rated <span class="pg-filter-count" id="pg-unrated-count">0</span></button>
+            </div>
+          </div>
         </div>
         <div class="pg-view-controls">
           <div class="pg-size-toggle" id="pg-size-toggle" title="Card size">
@@ -208,6 +217,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=46cb7ea1"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/index/main.js?v=514076f1"></script>
+<script type="module" src="js/index/main.js?v=8fc32f4e"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=86052a10">
-<link rel="stylesheet" href="css/shared/cards.css?v=eab020ab">
+<link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
 <link rel="stylesheet" href="css/index/index.css?v=0bdafa7e">
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=86052a10">
 <link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
-<link rel="stylesheet" href="css/index/index.css?v=ff4b9357">
+<link rel="stylesheet" href="css/index/index.css?v=ca1427ec">
 </head>
 <body>
 
@@ -166,7 +166,6 @@
          the pipeline). Hidden until data loads so the section never shows empty. -->
     <section class="popular-games" id="popular-games" hidden>
       <div class="pg-head">
-        <div class="section-label" id="pg-section-label">Popular on Steam</div>
         <div class="pg-filter-wrap" id="pg-filter-wrap">
           <button class="pg-filter-toggle-btn" id="pg-filter-toggle" type="button" aria-expanded="false">
             Filters<span class="pg-filter-badge" id="pg-filter-badge" hidden></span>
@@ -197,6 +196,7 @@
           </div>
         </div>
       </div>
+      <div class="section-label pg-section-heading" id="pg-section-label">Popular on Steam</div>
       <p class="popular-games-sub" id="pg-sub">Steam's most-played games and how they run on Linux through Proton.</p>
       <div class="pg-list" id="pg-list"></div>
       <div class="pg-load-more-row" id="pg-load-more"></div>

--- a/index.html
+++ b/index.html
@@ -166,8 +166,13 @@
          the pipeline). Hidden until data loads so the section never shows empty. -->
     <section class="popular-games" id="popular-games" hidden>
       <div class="pg-head">
-        <div class="section-label">Popular games on Steam</div>
-        <div class="pg-filters" role="group" aria-label="Filter popular games by rating">
+        <div class="section-label" id="pg-section-label">Popular on Steam</div>
+        <div class="pg-store-filters" role="group" aria-label="Filter by store">
+          <button class="pg-filter pg-filter--active pg-store-btn" data-store="steam" id="pg-store-steam" type="button">Steam</button>
+          <button class="pg-filter pg-store-btn" data-store="gog" id="pg-store-gog" type="button">GOG</button>
+          <button class="pg-filter pg-store-btn" data-store="epic" id="pg-store-epic" type="button">Epic</button>
+        </div>
+        <div class="pg-filters" id="pg-rating-filters" role="group" aria-label="Filter popular games by rating">
           <button class="pg-filter pg-filter--active" id="pg-filter-rated" type="button" aria-pressed="true">Rated <span class="pg-filter-count" id="pg-rated-count">0</span></button>
           <button class="pg-filter" id="pg-filter-unrated" type="button" aria-pressed="false">Not Rated <span class="pg-filter-count" id="pg-unrated-count">0</span></button>
         </div>
@@ -183,7 +188,7 @@
           </div>
         </div>
       </div>
-      <p class="popular-games-sub">Steam's most-played games and how they run on Linux through Proton.</p>
+      <p class="popular-games-sub" id="pg-sub">Steam's most-played games and how they run on Linux through Proton.</p>
       <div class="pg-list" id="pg-list"></div>
       <div class="pg-load-more-row" id="pg-load-more"></div>
     </section>
@@ -203,6 +208,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=46cb7ea1"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/index/main.js?v=4c1581c6"></script>
+<script type="module" src="js/index/main.js?v=514076f1"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
-<link rel="stylesheet" href="css/index/index.css?v=96c3d47b">
+<link rel="stylesheet" href="css/index/index.css?v=d6d74d80">
 </head>
 <body>
 
@@ -175,6 +175,7 @@
           <div class="pg-filter-panel" id="pg-filter-panel">
             <div class="pg-filter-group">
               <span class="pg-filter-group-label">Store</span>
+              <button class="pg-filter pg-store-btn" data-store="all" id="pg-store-all" type="button">All</button>
               <button class="pg-filter pg-filter--active pg-store-btn" data-store="steam" id="pg-store-steam" type="button">Steam</button>
               <button class="pg-filter pg-store-btn" data-store="gog" id="pg-store-gog" type="button">GOG</button>
               <button class="pg-filter pg-store-btn" data-store="epic" id="pg-store-epic" type="button">Epic</button>
@@ -220,6 +221,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=50b75e70"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/index/main.js?v=3018042b"></script>
+<script type="module" src="js/index/main.js?v=f9fd8171"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -169,6 +169,7 @@
       <div class="pg-head">
         <div class="pg-filter-wrap" id="pg-filter-wrap">
           <button class="pg-filter-toggle-btn" id="pg-filter-toggle" type="button" aria-expanded="false">
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M4.25 5.61C6.27 8.2 10 13 10 13v6c0 .55.45 1 1 1h2c.55 0 1-.45 1-1v-6s3.72-4.8 5.74-7.39C20.25 4.95 19.8 4 18.95 4H5.04C4.2 4 3.74 4.95 4.25 5.61z"/></svg>
             Filters<span class="pg-filter-badge" id="pg-filter-badge" hidden></span>
           </button>
           <div class="pg-filter-panel" id="pg-filter-panel">
@@ -219,6 +220,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=50b75e70"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/index/main.js?v=4a357f20"></script>
+<script type="module" src="js/index/main.js?v=3018042b"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -15,9 +15,9 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/filters.css?v=cfea13a2">
+<link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
-<link rel="stylesheet" href="css/index/index.css?v=ca60e7d4">
+<link rel="stylesheet" href="css/index/index.css?v=96c3d47b">
 </head>
 <body>
 

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/filters.css?v=3b0c60ff">
+<link rel="stylesheet" href="css/shared/filters.css?v=4e3a1985">
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/index/index.css?v=ca60e7d4">
 </head>

--- a/index.html
+++ b/index.html
@@ -14,9 +14,9 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
-<link rel="stylesheet" href="css/shared/site.css?v=2b59a85c">
+<link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
-<link rel="stylesheet" href="css/index/index.css?v=7c9c47a4">
+<link rel="stylesheet" href="css/index/index.css?v=7b320670">
 </head>
 <body>
 
@@ -189,6 +189,7 @@
             <button class="pg-size-btn" data-size="sm" type="button" title="Small cards">S</button>
             <button class="pg-size-btn" data-size="md" type="button" title="Medium cards">M</button>
             <button class="pg-size-btn" data-size="lg" type="button" title="Large cards">L</button>
+            <button class="pg-size-btn pg-size-btn--desktop-only" data-size="xl" type="button" title="Extra large cards">XL</button>
           </div>
           <div class="pg-layout-toggle">
             <button class="pg-layout-btn active" data-layout="grid" title="Grid view">Grid</button>
@@ -215,8 +216,8 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=1f85d476"></script>
+<script src="js/lib/topbar.js?v=50b75e70"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/index/main.js?v=2612aab7"></script>
+<script type="module" src="js/index/main.js?v=044a8704"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -15,8 +15,9 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
+<link rel="stylesheet" href="css/shared/filters.css?v=3b0c60ff">
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
-<link rel="stylesheet" href="css/index/index.css?v=07446e4c">
+<link rel="stylesheet" href="css/index/index.css?v=ca60e7d4">
 </head>
 <body>
 

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=df5b5024';
-import { route } from '../router.js?v=f2b11b5f';
+import { route } from '../router.js?v=fa2370ef';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=df5b5024';
-import { route } from '../router.js?v=3127acdd';
+import { route } from '../router.js?v=db5d8fb3';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=df5b5024';
-import { route } from '../router.js?v=11e31e2a';
+import { route } from '../router.js?v=a6c798ca';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=df5b5024';
-import { route } from '../router.js?v=a8289cc2';
+import { route } from '../router.js?v=422a5ed0';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=df5b5024';
-import { route } from '../router.js?v=a6c798ca';
+import { route } from '../router.js?v=9ac23f21';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=df5b5024';
-import { route } from '../router.js?v=fa2370ef';
+import { route } from '../router.js?v=f312cb82';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=df5b5024';
-import { route } from '../router.js?v=db5d8fb3';
+import { route } from '../router.js?v=8b262bc5';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=df5b5024';
-import { route } from '../router.js?v=71691aaa';
+import { route } from '../router.js?v=4333c4c2';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=df5b5024';
-import { route } from '../router.js?v=9e04acb6';
+import { route } from '../router.js?v=f2b11b5f';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=df5b5024';
-import { route } from '../router.js?v=84618449';
+import { route } from '../router.js?v=11e31e2a';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=df5b5024';
-import { route } from '../router.js?v=a0ec2a77';
+import { route } from '../router.js?v=559d0c95';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=df5b5024';
-import { route } from '../router.js?v=fa3f2f3a';
+import { route } from '../router.js?v=4f2ac3a6';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=df5b5024';
-import { route } from '../router.js?v=c7f18ac0';
+import { route } from '../router.js?v=71691aaa';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=df5b5024';
-import { route } from '../router.js?v=f312cb82';
+import { route } from '../router.js?v=c7f18ac0';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=df5b5024';
-import { route } from '../router.js?v=559d0c95';
+import { route } from '../router.js?v=9e04acb6';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=df5b5024';
-import { route } from '../router.js?v=422a5ed0';
+import { route } from '../router.js?v=fa3f2f3a';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=df5b5024';
-import { route } from '../router.js?v=f6ca009b';
+import { route } from '../router.js?v=3127acdd';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=df5b5024';
-import { route } from '../router.js?v=1e460a38';
+import { route } from '../router.js?v=84618449';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=df5b5024';
-import { route } from '../router.js?v=4f2ac3a6';
+import { route } from '../router.js?v=f6ca009b';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=df5b5024';
-import { route } from '../router.js?v=4333c4c2';
+import { route } from '../router.js?v=a8289cc2';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -2,7 +2,7 @@
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=df5b5024';
-import { route } from '../router.js?v=8b262bc5';
+import { route } from '../router.js?v=1e460a38';
 import { esc } from '../utils.js?v=f5dda5b6';
 
 export const ATOM_ICON_SVG = `

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=bac2f4eb';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=ac040be6';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=220e13ea';
-import { enhanceAuthorBlocks } from './author.js?v=7376ae0a';
+import { enhanceAuthorBlocks } from './author.js?v=acd3e167';
 import { renderConfigCard } from './config-cards.js?v=473be757';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=3d873bb3';
-import { renderCard } from './report-card.js?v=14f73a05';
-import { loadSearchIndex, searchIndex } from './search.js?v=37a03e4e';
+import { renderCard } from './report-card.js?v=09e7eaca';
+import { loadSearchIndex, searchIndex } from './search.js?v=a30bff33';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=3e345596';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=bac2f4eb';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=ac040be6';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=220e13ea';
-import { enhanceAuthorBlocks } from './author.js?v=2ee6f936';
+import { enhanceAuthorBlocks } from './author.js?v=0730c36c';
 import { renderConfigCard } from './config-cards.js?v=473be757';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=3d873bb3';
-import { renderCard } from './report-card.js?v=1134e3c7';
-import { loadSearchIndex, searchIndex } from './search.js?v=f56dd455';
+import { renderCard } from './report-card.js?v=623197f8';
+import { loadSearchIndex, searchIndex } from './search.js?v=53fee6c7';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=3e345596';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=bac2f4eb';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=ac040be6';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=220e13ea';
-import { enhanceAuthorBlocks } from './author.js?v=f08315eb';
+import { enhanceAuthorBlocks } from './author.js?v=dd00c654';
 import { renderConfigCard } from './config-cards.js?v=473be757';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=3d873bb3';
-import { renderCard } from './report-card.js?v=937d82d9';
-import { loadSearchIndex, searchIndex } from './search.js?v=b25846ac';
+import { renderCard } from './report-card.js?v=d1a519db';
+import { loadSearchIndex, searchIndex } from './search.js?v=9be7632d';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=3e345596';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=bac2f4eb';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=ac040be6';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=220e13ea';
-import { enhanceAuthorBlocks } from './author.js?v=0730c36c';
+import { enhanceAuthorBlocks } from './author.js?v=f08315eb';
 import { renderConfigCard } from './config-cards.js?v=473be757';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=3d873bb3';
-import { renderCard } from './report-card.js?v=623197f8';
-import { loadSearchIndex, searchIndex } from './search.js?v=53fee6c7';
+import { renderCard } from './report-card.js?v=937d82d9';
+import { loadSearchIndex, searchIndex } from './search.js?v=b25846ac';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=3e345596';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=bac2f4eb';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=ac040be6';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=220e13ea';
-import { enhanceAuthorBlocks } from './author.js?v=adb6c0ae';
+import { enhanceAuthorBlocks } from './author.js?v=56f63efc';
 import { renderConfigCard } from './config-cards.js?v=473be757';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=3d873bb3';
-import { renderCard } from './report-card.js?v=3ab69454';
-import { loadSearchIndex, searchIndex } from './search.js?v=8264f8ee';
+import { renderCard } from './report-card.js?v=8f6659f1';
+import { loadSearchIndex, searchIndex } from './search.js?v=2403e109';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=3e345596';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=bac2f4eb';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=ac040be6';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=220e13ea';
-import { enhanceAuthorBlocks } from './author.js?v=0c0fbb43';
+import { enhanceAuthorBlocks } from './author.js?v=82cc12ae';
 import { renderConfigCard } from './config-cards.js?v=473be757';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=3d873bb3';
-import { renderCard } from './report-card.js?v=e6a2e9e5';
-import { loadSearchIndex, searchIndex } from './search.js?v=594f0fc3';
+import { renderCard } from './report-card.js?v=ab7356fb';
+import { loadSearchIndex, searchIndex } from './search.js?v=3e4b5a09';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=3e345596';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=bac2f4eb';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=ac040be6';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=220e13ea';
-import { enhanceAuthorBlocks } from './author.js?v=03330fa3';
+import { enhanceAuthorBlocks } from './author.js?v=0c0fbb43';
 import { renderConfigCard } from './config-cards.js?v=473be757';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=3d873bb3';
-import { renderCard } from './report-card.js?v=a68befaf';
-import { loadSearchIndex, searchIndex } from './search.js?v=69369686';
+import { renderCard } from './report-card.js?v=e6a2e9e5';
+import { loadSearchIndex, searchIndex } from './search.js?v=594f0fc3';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=3e345596';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=bac2f4eb';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=ac040be6';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=220e13ea';
-import { enhanceAuthorBlocks } from './author.js?v=55177972';
+import { enhanceAuthorBlocks } from './author.js?v=2ee6f936';
 import { renderConfigCard } from './config-cards.js?v=473be757';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=3d873bb3';
-import { renderCard } from './report-card.js?v=1fd22d95';
-import { loadSearchIndex, searchIndex } from './search.js?v=0e76ead0';
+import { renderCard } from './report-card.js?v=1134e3c7';
+import { loadSearchIndex, searchIndex } from './search.js?v=f56dd455';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=3e345596';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=bac2f4eb';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=ac040be6';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=220e13ea';
-import { enhanceAuthorBlocks } from './author.js?v=7e410a15';
+import { enhanceAuthorBlocks } from './author.js?v=a12fb8d1';
 import { renderConfigCard } from './config-cards.js?v=473be757';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=3d873bb3';
-import { renderCard } from './report-card.js?v=f3245fa9';
-import { loadSearchIndex, searchIndex } from './search.js?v=b2d692f6';
+import { renderCard } from './report-card.js?v=dbe3b88c';
+import { loadSearchIndex, searchIndex } from './search.js?v=5001df13';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=3e345596';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=bac2f4eb';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=ac040be6';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=220e13ea';
-import { enhanceAuthorBlocks } from './author.js?v=cf23b4e6';
+import { enhanceAuthorBlocks } from './author.js?v=5591d38b';
 import { renderConfigCard } from './config-cards.js?v=473be757';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=3d873bb3';
-import { renderCard } from './report-card.js?v=3d2959ab';
-import { loadSearchIndex, searchIndex } from './search.js?v=36738329';
+import { renderCard } from './report-card.js?v=2d649463';
+import { loadSearchIndex, searchIndex } from './search.js?v=9b8500d5';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=3e345596';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=bac2f4eb';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=ac040be6';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=220e13ea';
-import { enhanceAuthorBlocks } from './author.js?v=a12fb8d1';
+import { enhanceAuthorBlocks } from './author.js?v=c086dc45';
 import { renderConfigCard } from './config-cards.js?v=473be757';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=3d873bb3';
-import { renderCard } from './report-card.js?v=dbe3b88c';
-import { loadSearchIndex, searchIndex } from './search.js?v=5001df13';
+import { renderCard } from './report-card.js?v=47449c60';
+import { loadSearchIndex, searchIndex } from './search.js?v=6a0124d8';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=3e345596';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=bac2f4eb';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=ac040be6';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=220e13ea';
-import { enhanceAuthorBlocks } from './author.js?v=f9c8a583';
+import { enhanceAuthorBlocks } from './author.js?v=684796fb';
 import { renderConfigCard } from './config-cards.js?v=473be757';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=3d873bb3';
-import { renderCard } from './report-card.js?v=3496cd57';
-import { loadSearchIndex, searchIndex } from './search.js?v=fdc451a3';
+import { renderCard } from './report-card.js?v=3c4f8bfd';
+import { loadSearchIndex, searchIndex } from './search.js?v=50308c43';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=3e345596';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=bac2f4eb';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=ac040be6';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=220e13ea';
-import { enhanceAuthorBlocks } from './author.js?v=acd3e167';
+import { enhanceAuthorBlocks } from './author.js?v=f9c8a583';
 import { renderConfigCard } from './config-cards.js?v=473be757';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=3d873bb3';
-import { renderCard } from './report-card.js?v=09e7eaca';
-import { loadSearchIndex, searchIndex } from './search.js?v=a30bff33';
+import { renderCard } from './report-card.js?v=3496cd57';
+import { loadSearchIndex, searchIndex } from './search.js?v=fdc451a3';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=3e345596';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=bac2f4eb';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=ac040be6';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=220e13ea';
-import { enhanceAuthorBlocks } from './author.js?v=ce03b00d';
+import { enhanceAuthorBlocks } from './author.js?v=7e410a15';
 import { renderConfigCard } from './config-cards.js?v=473be757';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=3d873bb3';
-import { renderCard } from './report-card.js?v=ec52319e';
-import { loadSearchIndex, searchIndex } from './search.js?v=a2fdfd30';
+import { renderCard } from './report-card.js?v=f3245fa9';
+import { loadSearchIndex, searchIndex } from './search.js?v=b2d692f6';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=3e345596';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=bac2f4eb';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=ac040be6';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=220e13ea';
-import { enhanceAuthorBlocks } from './author.js?v=c086dc45';
+import { enhanceAuthorBlocks } from './author.js?v=55177972';
 import { renderConfigCard } from './config-cards.js?v=473be757';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=3d873bb3';
-import { renderCard } from './report-card.js?v=47449c60';
-import { loadSearchIndex, searchIndex } from './search.js?v=6a0124d8';
+import { renderCard } from './report-card.js?v=1fd22d95';
+import { loadSearchIndex, searchIndex } from './search.js?v=0e76ead0';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=3e345596';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=bac2f4eb';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=ac040be6';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=220e13ea';
-import { enhanceAuthorBlocks } from './author.js?v=56f63efc';
+import { enhanceAuthorBlocks } from './author.js?v=cf23b4e6';
 import { renderConfigCard } from './config-cards.js?v=473be757';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=3d873bb3';
-import { renderCard } from './report-card.js?v=8f6659f1';
-import { loadSearchIndex, searchIndex } from './search.js?v=2403e109';
+import { renderCard } from './report-card.js?v=3d2959ab';
+import { loadSearchIndex, searchIndex } from './search.js?v=36738329';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=3e345596';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=bac2f4eb';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=ac040be6';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=220e13ea';
-import { enhanceAuthorBlocks } from './author.js?v=82cc12ae';
+import { enhanceAuthorBlocks } from './author.js?v=dbbbf35c';
 import { renderConfigCard } from './config-cards.js?v=473be757';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=3d873bb3';
-import { renderCard } from './report-card.js?v=ab7356fb';
-import { loadSearchIndex, searchIndex } from './search.js?v=3e4b5a09';
+import { renderCard } from './report-card.js?v=fb6aa649';
+import { loadSearchIndex, searchIndex } from './search.js?v=644d8996';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=3e345596';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=bac2f4eb';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=ac040be6';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=220e13ea';
-import { enhanceAuthorBlocks } from './author.js?v=42bf8b9d';
+import { enhanceAuthorBlocks } from './author.js?v=03330fa3';
 import { renderConfigCard } from './config-cards.js?v=473be757';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=3d873bb3';
-import { renderCard } from './report-card.js?v=d37f8a4a';
-import { loadSearchIndex, searchIndex } from './search.js?v=f68f83d2';
+import { renderCard } from './report-card.js?v=a68befaf';
+import { loadSearchIndex, searchIndex } from './search.js?v=69369686';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=3e345596';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=bac2f4eb';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=ac040be6';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=220e13ea';
-import { enhanceAuthorBlocks } from './author.js?v=5591d38b';
+import { enhanceAuthorBlocks } from './author.js?v=42bf8b9d';
 import { renderConfigCard } from './config-cards.js?v=473be757';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=3d873bb3';
-import { renderCard } from './report-card.js?v=2d649463';
-import { loadSearchIndex, searchIndex } from './search.js?v=9b8500d5';
+import { renderCard } from './report-card.js?v=d37f8a4a';
+import { loadSearchIndex, searchIndex } from './search.js?v=f68f83d2';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=3e345596';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=bac2f4eb';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=ac040be6';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=220e13ea';
-import { enhanceAuthorBlocks } from './author.js?v=dd00c654';
+import { enhanceAuthorBlocks } from './author.js?v=adb6c0ae';
 import { renderConfigCard } from './config-cards.js?v=473be757';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=3d873bb3';
-import { renderCard } from './report-card.js?v=d1a519db';
-import { loadSearchIndex, searchIndex } from './search.js?v=9be7632d';
+import { renderCard } from './report-card.js?v=3ab69454';
+import { loadSearchIndex, searchIndex } from './search.js?v=8264f8ee';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=3e345596';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -7,11 +7,11 @@ import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=bac2f4eb';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=ac040be6';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=220e13ea';
-import { enhanceAuthorBlocks } from './author.js?v=dbbbf35c';
+import { enhanceAuthorBlocks } from './author.js?v=7376ae0a';
 import { renderConfigCard } from './config-cards.js?v=473be757';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=3d873bb3';
-import { renderCard } from './report-card.js?v=fb6aa649';
-import { loadSearchIndex, searchIndex } from './search.js?v=644d8996';
+import { renderCard } from './report-card.js?v=14f73a05';
+import { loadSearchIndex, searchIndex } from './search.js?v=37a03e4e';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=3e345596';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=30cf98fd';
-import { loadSearchIndex, searchIndex } from './search.js?v=37a03e4e';
+import { loadSearchIndex, searchIndex } from './search.js?v=a30bff33';
 import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '../config.js?v=df5b5024';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=de2b700a';
@@ -166,16 +166,13 @@ export async function renderHomePage() {
 
     el.innerHTML = `
       <div class="home-filter-bar">
+        <div class="home-filter-left">
         <div class="filter-wrap" id="home-filter-wrap">
           <button class="filter-toggle-btn" id="home-filter-toggle" type="button" aria-expanded="false">
             <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M4.25 5.61C6.27 8.2 10 13 10 13v6c0 .55.45 1 1 1h2c.55 0 1-.45 1-1v-6s3.72-4.8 5.74-7.39C20.25 4.95 19.8 4 18.95 4H5.04C4.2 4 3.74 4.95 4.25 5.61z"/></svg>
             Filters<span class="filter-badge" id="home-filter-badge" hidden></span>
           </button>
           <div class="filter-panel filter-panel--stack" id="home-filter-panel">
-            <div class="filter-item">
-              <label class="home-filter-label" for="home-text-filter">Filter</label>
-              <input id="home-text-filter" class="home-filter-text" type="search" placeholder="Filter text" autocomplete="off" />
-            </div>
             <div class="filter-item">
               <label class="home-filter-label" for="home-sort-select">Sort</label>
               <select id="home-sort-select" class="home-filter-select">
@@ -210,9 +207,12 @@ export async function renderHomePage() {
               <button class="pg-filter" type="button" data-value="pulse">Pulse</button>
             </div>
             <div class="filter-panel-footer filter-panel-footer--stack">
+              <label class="filter-persist"><input type="checkbox" id="home-filter-persist" /> Save filters</label>
               <button class="filter-clear-btn" id="home-filter-clear" type="button">Clear filters</button>
             </div>
           </div>
+        </div>
+        <input id="home-text-filter" class="home-filter-text" type="search" placeholder="Filter text" autocomplete="off" />
         </div>
         <div class="home-view-controls">
           <div class="home-size-toggle" id="home-size-toggle" title="Card size">
@@ -379,6 +379,7 @@ export async function renderHomePage() {
     document.getElementById('home-sort-select')?.addEventListener('change', e => {
       currentSort = e.target.value;
       applyRecentFilters();
+      _saveFiltersIfEnabled();
     });
 
     // Text filter: filters both sections by title substring as the user types.
@@ -387,6 +388,7 @@ export async function renderHomePage() {
       updateFilterBadge();
       applyRecentFilters();
       applyPopularFilters();
+      _saveFiltersIfEnabled();
     });
 
     // Filters popover: toggle open, close on outside click.
@@ -406,6 +408,59 @@ export async function renderHomePage() {
       }
     });
 
+    // Save filters: when the "Save filters" box is checked, persist the full
+    // filter state to localStorage and restore it on the next visit. Unchecking
+    // clears the saved state. The box itself reflects whether a save is active.
+    const FILTERS_KEY = 'pp:browse-filters';
+    function _persistOn() { return !!document.getElementById('home-filter-persist')?.checked; }
+    function _saveFilters() {
+      try {
+        localStorage.setItem(FILTERS_KEY, JSON.stringify({
+          sort: currentSort, text: textFilter,
+          tier: [...tierSel], source: [...sourceSel], store: [...storeSel],
+        }));
+      } catch { /* ignore */ }
+    }
+    // Call after any filter change; only writes when the box is checked.
+    function _saveFiltersIfEnabled() { if (_persistOn()) _saveFilters(); }
+    function _applyPillSelection(groupEl, values) {
+      if (!groupEl) return;
+      groupEl.querySelectorAll('.pg-filter').forEach(b => b.classList.remove('pg-filter--active'));
+      const set = new Set(values || []);
+      if (set.size === 0) {
+        groupEl.querySelector('.pg-filter[data-value="all"]')?.classList.add('pg-filter--active');
+      } else {
+        set.forEach(v => groupEl.querySelector(`.pg-filter[data-value="${v}"]`)?.classList.add('pg-filter--active'));
+      }
+    }
+    // Restore a previously saved filter set on load. Returns true if restored.
+    function _restoreFilters() {
+      let saved = null;
+      try { saved = JSON.parse(localStorage.getItem(FILTERS_KEY) || 'null'); } catch { saved = null; }
+      if (!saved) return false;
+      const persistBox = document.getElementById('home-filter-persist');
+      if (persistBox) persistBox.checked = true;
+      currentSort = saved.sort || 'recent';
+      const sortSel = document.getElementById('home-sort-select');
+      if (sortSel) sortSel.value = currentSort;
+      textFilter = saved.text || '';
+      const textInput = document.getElementById('home-text-filter');
+      if (textInput) textInput.value = textFilter;
+      tierSel = new Set(saved.tier || []);
+      sourceSel = new Set(saved.source || []);
+      storeSel = new Set(saved.store || []);
+      _applyPillSelection(tierGroup, saved.tier);
+      _applyPillSelection(sourceGroup, saved.source);
+      _applyPillSelection(storeGroup, saved.store);
+      updateFilterBadge();
+      console.debug('[browse-filters] restored saved filters', { source: FILTERS_KEY, sort: currentSort, tiers: [...tierSel], sources: [...sourceSel], stores: [...storeSel], text: textFilter });
+      return true;
+    }
+    document.getElementById('home-filter-persist')?.addEventListener('change', e => {
+      if (e.target.checked) _saveFilters();
+      else { try { localStorage.removeItem(FILTERS_KEY); } catch { /* ignore */ } }
+    });
+
     // Active-filter badge: count specific tier + source + store selections.
     function updateFilterBadge() {
       const n = tierSel.size + sourceSel.size + storeSel.size + (textFilter.trim() ? 1 : 0);
@@ -420,13 +475,13 @@ export async function renderHomePage() {
     const sourceGroup = document.getElementById('home-source-checks');
     const storeGroup = document.getElementById('home-store-checks');
     if (tierGroup) _wirePillGroup(tierGroup, sel => {
-      tierSel = sel; updateFilterBadge(); applyRecentFilters(); applyPopularFilters();
+      tierSel = sel; updateFilterBadge(); applyRecentFilters(); applyPopularFilters(); _saveFiltersIfEnabled();
     });
     if (sourceGroup) _wirePillGroup(sourceGroup, sel => {
-      sourceSel = sel; updateFilterBadge(); applyRecentFilters(); applyPopularFilters();
+      sourceSel = sel; updateFilterBadge(); applyRecentFilters(); applyPopularFilters(); _saveFiltersIfEnabled();
     });
     if (storeGroup) _wirePillGroup(storeGroup, sel => {
-      storeSel = sel; updateFilterBadge(); applyRecentFilters(); applyPopularFilters();
+      storeSel = sel; updateFilterBadge(); applyRecentFilters(); applyPopularFilters(); _saveFiltersIfEnabled();
     });
 
     // Clear filters: reset every group back to "All", sort back to Recent.
@@ -449,6 +504,8 @@ export async function renderHomePage() {
       updateFilterBadge();
       applyRecentFilters();
       applyPopularFilters();
+      // Persist the cleared state too so a saved set does not come back on reload.
+      _saveFiltersIfEnabled();
     });
 
     // S/M/L only make sense for the card (grid) view; disable them in list mode.
@@ -504,6 +561,7 @@ export async function renderHomePage() {
     applyGridSize(_savedSize());
     applyLayout(_savedLayout()); // restore saved list/grid before first render
 
+    _restoreFilters(); // re-apply a saved filter set (if any) before first render
     applyRecentFilters();
     applyPopularFilters();
   } catch {

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=30cf98fd';
-import { loadSearchIndex, searchIndex } from './search.js?v=0e76ead0';
+import { loadSearchIndex, searchIndex } from './search.js?v=f56dd455';
 import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '../config.js?v=df5b5024';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=8f45a69a';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,10 +1,10 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=30cf98fd';
-import { loadSearchIndex, searchIndex } from './search.js?v=a2fdfd30';
+import { loadSearchIndex, searchIndex } from './search.js?v=b2d692f6';
 import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '../config.js?v=df5b5024';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
-import { renderGameCard } from '../lib/card.js?v=633df5fd';
+import { renderGameCard } from '../lib/card.js?v=8f45a69a';
 
 const PAGE_SIZE = 10;
 const KNOWN_TIERS = new Set(['platinum', 'gold', 'silver', 'bronze', 'borked']);
@@ -213,7 +213,7 @@ export async function renderHomePage() {
       <div class="cards" id="cards-recent"></div>
       <div id="load-more-recent"></div>
       <div class="section-label-row" style="margin-top:24px;margin-bottom:10px">
-        <span class="section-label" style="margin:0">Popular on Steam</span>
+        <span class="section-label" id="popular-section-label" style="margin:0">Popular on Steam</span>
       </div>
       <div class="cards" id="cards-popular"></div>
       <div id="load-more-popular"></div>`;
@@ -237,22 +237,50 @@ export async function renderHomePage() {
       </a>`;
     }
 
+    function _popularSectionLabel(sel) {
+      if (!sel || sel.size === 0 || sel.has('all') || sel.has('steam')) return 'Popular on Steam';
+      if (sel.size === 1 && sel.has('gog')) return 'Popular GOG Games';
+      if (sel.size === 1 && sel.has('epic')) return 'Popular Epic Games';
+      return 'Popular Games';
+    }
+
     function applyPopularFilters() {
-      // Build the candidate pool from the tier selection. Rated games show by
-      // default; the unrated catalog games (no reports yet) only appear when
-      // "Not Rated Yet" (or "All") is selected, so they stay hidden otherwise.
-      const wantUnrated = tierSel.has('all') || tierSel.has('unrated');
-      const onlyUnrated = tierSel.size === 1 && tierSel.has('unrated');
-      const pool = [
-        ...(onlyUnrated ? [] : ratedGames),
-        ...(wantUnrated ? unratedGames : []),
-      ];
-      // Map rating -> tier ('pending' for unrated) so the shared Set-based tier
-      // filter treats them consistently with recent reports.
-      const asReports = pool.map(g => {
-        const t = String(g.rating || '').toLowerCase();
-        return { ...g, tier: KNOWN_TIERS.has(t) ? t : 'pending' };
-      });
+      const labelEl = document.getElementById('popular-section-label');
+      if (labelEl) labelEl.textContent = _popularSectionLabel(storeSel);
+
+      // When filtering to non-Steam stores only, pull from the search index (which
+      // covers GOG/Epic catalog entries) instead of most_played.json (Steam only).
+      const wantNonSteamOnly = storeSel.size > 0 && !storeSel.has('all') && !storeSel.has('steam');
+      let asReports;
+      if (wantNonSteamOnly) {
+        asReports = (searchIndex || [])
+          .filter(row => row[5] && storeSel.has(row[5]))
+          .sort((a, b) => (a[1] || '').localeCompare(b[1] || ''))
+          .map(row => {
+            const t = String(row[2] || '').toLowerCase();
+            return {
+              appId: row[0], title: row[1],
+              tier: KNOWN_TIERS.has(t) ? t : 'pending',
+              protondbCount: row[3] || 0, pulseCount: row[4] || 0, appType: row[5],
+            };
+          });
+      } else {
+        // Build the candidate pool from the tier selection. Rated games show by
+        // default; the unrated catalog games (no reports yet) only appear when
+        // "Not Rated Yet" (or "All") is selected, so they stay hidden otherwise.
+        const wantUnrated = tierSel.has('all') || tierSel.has('unrated');
+        const onlyUnrated = tierSel.size === 1 && tierSel.has('unrated');
+        const pool = [
+          ...(onlyUnrated ? [] : ratedGames),
+          ...(wantUnrated ? unratedGames : []),
+        ];
+        // Map rating -> tier ('pending' for unrated) so the shared Set-based tier
+        // filter treats them consistently with recent reports.
+        asReports = pool.map(g => {
+          const t = String(g.rating || '').toLowerCase();
+          return { ...g, tier: KNOWN_TIERS.has(t) ? t : 'pending' };
+        });
+      }
       const filtered = _filterByStore(_filterByType(_filterByTier(asReports, tierSel), sourceSel), storeSel);
       const cardsEl = document.getElementById('cards-popular');
       const loadMoreEl = document.getElementById('load-more-popular');

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=30cf98fd';
-import { loadSearchIndex, searchIndex } from './search.js?v=b2d692f6';
+import { loadSearchIndex, searchIndex } from './search.js?v=5001df13';
 import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '../config.js?v=df5b5024';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=8f45a69a';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,12 +1,19 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=30cf98fd';
-import { loadSearchIndex, searchIndex } from './search.js?v=fdc451a3';
+import { loadSearchIndex, searchIndex } from './search.js?v=50308c43';
 import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '../config.js?v=df5b5024';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=de2b700a';
 
-const PAGE_SIZE = 10;
+const LOAD_COUNT_KEY = 'pp:load-count';
+const LOAD_COUNTS = [50, 100, 150, 200];
+// How many report cards to preload per section before "Load more". Set on the
+// site options (gear) page; defaults to 50.
+function _loadCount() {
+  const n = parseInt(localStorage.getItem(LOAD_COUNT_KEY) || '', 10);
+  return LOAD_COUNTS.includes(n) ? n : 50;
+}
 const KNOWN_TIERS = new Set(['platinum', 'gold', 'silver', 'bronze', 'borked']);
 const TIER_SCORE = { platinum: 5, gold: 4, silver: 3, bronze: 2, borked: 1 };
 
@@ -151,6 +158,8 @@ function _recentCardHtml(r) {
 export async function renderHomePage() {
   const el = document.getElementById('content');
   el.innerHTML = '<div class="state-box">Loading recent reports...</div>';
+  const PAGE_SIZE = _loadCount(); // user-set preload count (50/100/150/200)
+  console.debug('[browse] preload count', { count: PAGE_SIZE, source: LOAD_COUNT_KEY });
   try {
     const [recentResp, mostPlayedResp] = await Promise.all([
       fetch('recent-reports.json').catch(() => null),
@@ -235,12 +244,16 @@ export async function renderHomePage() {
         </div>
       </div>
       <div id="recent-section">
-        <p class="section-label" style="margin-bottom:10px">Recent Reports</p>
+        <div class="section-label-row" style="margin-bottom:10px">
+          <span class="section-label" style="margin:0">Recent Reports</span>
+          <span class="section-count" id="recent-count"></span>
+        </div>
         <div class="cards" id="cards-recent"></div>
         <div id="load-more-recent"></div>
       </div>
       <div class="section-label-row" style="margin-top:24px;margin-bottom:10px">
         <span class="section-label" id="popular-section-label" style="margin:0">Popular on Steam</span>
+        <span class="section-count" id="popular-count"></span>
       </div>
       <div class="cards" id="cards-popular"></div>
       <div id="load-more-popular"></div>`;
@@ -330,12 +343,14 @@ export async function renderHomePage() {
       const queue = filtered.slice(PAGE_SIZE);
       cardsEl.innerHTML = initial.map(_popularItemHtml).join('')
         || '<div class="state-box">No games match the current filters.</div>';
+      _updateShownCount('popular-count', cardsEl, initial.length ? filtered.length : 0);
       if (loadMoreEl) {
         if (queue.length) {
           loadMoreEl.innerHTML = _loadMoreBtn('popular');
           loadMoreEl.querySelector('button').addEventListener('click', () => {
             const batch = queue.splice(0, PAGE_SIZE);
             cardsEl.insertAdjacentHTML('beforeend', batch.map(_popularItemHtml).join(''));
+            _updateShownCount('popular-count', cardsEl, filtered.length);
             if (!queue.length) loadMoreEl.innerHTML = '';
           });
         } else {
@@ -356,6 +371,15 @@ export async function renderHomePage() {
       });
     }
 
+    // Show how many cards are currently loaded vs how many match the filters,
+    // e.g. "50 of 132". Reads the live card count so it stays right after
+    // load-more appends. Hidden when there is nothing to show.
+    function _updateShownCount(countId, cardsEl, total) {
+      const c = document.getElementById(countId);
+      if (!c) return;
+      c.textContent = total ? `${cardsEl.children.length} of ${total} loaded` : '';
+    }
+
     function applyRecentFilters() {
       const filtered = _filterByText(_filterByStore(_filterByType(_filterByTier(_sortReports(allRecentReports, currentSort), tierSel), sourceSel), storeSel), textFilter);
       const sectionEl = document.getElementById('recent-section');
@@ -366,8 +390,9 @@ export async function renderHomePage() {
       const initial = filtered.slice(0, PAGE_SIZE);
       // Hide the whole recent section when empty so there's no blank state box.
       if (sectionEl) sectionEl.hidden = !filtered.length;
-      if (!filtered.length) { if (cardsEl) cardsEl.innerHTML = ''; return; }
+      if (!filtered.length) { if (cardsEl) cardsEl.innerHTML = ''; _updateShownCount('recent-count', cardsEl, 0); return; }
       cardsEl.innerHTML = initial.map(renderFn).join('');
+      _updateShownCount('recent-count', cardsEl, filtered.length);
       if (loadMoreEl) {
         if (queue.length) {
           loadMoreEl.innerHTML = _loadMoreBtn('recent');
@@ -375,6 +400,7 @@ export async function renderHomePage() {
           loadMoreEl.querySelector('button').addEventListener('click', () => {
             const batch = queue.splice(0, PAGE_SIZE);
             cardsEl.insertAdjacentHTML('beforeend', batch.map(renderFn).join(''));
+            _updateShownCount('recent-count', cardsEl, filtered.length);
             if (!queue.length) loadMoreEl.innerHTML = '';
           });
         } else {

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=30cf98fd';
-import { loadSearchIndex, searchIndex } from './search.js?v=6a0124d8';
+import { loadSearchIndex, searchIndex } from './search.js?v=0e76ead0';
 import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '../config.js?v=df5b5024';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=8f45a69a';
@@ -9,6 +9,10 @@ import { renderGameCard } from '../lib/card.js?v=8f45a69a';
 const PAGE_SIZE = 10;
 const KNOWN_TIERS = new Set(['platinum', 'gold', 'silver', 'bronze', 'borked']);
 const TIER_SCORE = { platinum: 5, gold: 4, silver: 3, bronze: 2, borked: 1 };
+
+function normTitle(s) {
+  return String(s || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+}
 
 function _sortReports(reports, sort) {
   const copy = [...reports];
@@ -253,9 +257,22 @@ export async function renderHomePage() {
       const wantNonSteamOnly = storeSel.size > 0 && !storeSel.has('all') && !storeSel.has('steam');
       let asReports;
       if (wantNonSteamOnly) {
+        // Build a title->peak map from the Steam most-played list so we can rank
+        // non-Steam titles by Steam popularity when the name matches.
+        const steamPeakByTitle = new Map(
+          [...ratedGames, ...unratedGames].map(g => [normTitle(g.title), g.peak || 0])
+        );
         asReports = (searchIndex || [])
           .filter(row => row[5] && storeSel.has(row[5]))
-          .sort((a, b) => (a[1] || '').localeCompare(b[1] || ''))
+          .sort((a, b) => {
+            const peakA = steamPeakByTitle.get(normTitle(a[1])) || 0;
+            const peakB = steamPeakByTitle.get(normTitle(b[1])) || 0;
+            if (peakB !== peakA) return peakB - peakA;
+            const countA = (a[3] || 0) + (a[4] || 0);
+            const countB = (b[3] || 0) + (b[4] || 0);
+            if (countB !== countA) return countB - countA;
+            return (a[1] || '').localeCompare(b[1] || '');
+          })
           .map(row => {
             const t = String(row[2] || '').toLowerCase();
             return {

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=30cf98fd';
-import { loadSearchIndex, searchIndex } from './search.js?v=5001df13';
+import { loadSearchIndex, searchIndex } from './search.js?v=6a0124d8';
 import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '../config.js?v=df5b5024';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=8f45a69a';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=30cf98fd';
-import { loadSearchIndex, searchIndex } from './search.js?v=69369686';
+import { loadSearchIndex, searchIndex } from './search.js?v=594f0fc3';
 import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '../config.js?v=df5b5024';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=de2b700a';
@@ -206,6 +206,7 @@ export async function renderHomePage() {
             <button class="home-size-btn" data-size="sm" type="button" title="Small cards">S</button>
             <button class="home-size-btn" data-size="md" type="button" title="Medium cards">M</button>
             <button class="home-size-btn" data-size="lg" type="button" title="Large cards">L</button>
+            <button class="home-size-btn home-size-btn--desktop-only" data-size="xl" type="button" title="Extra large cards">XL</button>
           </div>
           <div class="home-layout-toggle">
             <button class="home-layout-btn active" data-layout="grid" title="Grid view">Grid</button>
@@ -455,7 +456,7 @@ export async function renderHomePage() {
     // Card size (S/M/L) is a saved user preference. Applies the cards--<size>
     // class to both card lists; default medium.
     const SIZE_KEY = 'pp:grid-size';
-    const SIZES = ['sm', 'md', 'lg'];
+    const SIZES = ['sm', 'md', 'lg', 'xl'];
     function _savedSize() {
       try { const s = localStorage.getItem(SIZE_KEY); return SIZES.includes(s) ? s : 'md'; } catch { return 'md'; }
     }

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=30cf98fd';
-import { loadSearchIndex, searchIndex } from './search.js?v=f56dd455';
+import { loadSearchIndex, searchIndex } from './search.js?v=53fee6c7';
 import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '../config.js?v=df5b5024';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=8f45a69a';
@@ -213,9 +213,11 @@ export async function renderHomePage() {
           </div>
         </div>
       </div>
-      <p class="section-label" style="margin-bottom:10px">Recent Reports</p>
-      <div class="cards" id="cards-recent"></div>
-      <div id="load-more-recent"></div>
+      <div id="recent-section">
+        <p class="section-label" style="margin-bottom:10px">Recent Reports</p>
+        <div class="cards" id="cards-recent"></div>
+        <div id="load-more-recent"></div>
+      </div>
       <div class="section-label-row" style="margin-top:24px;margin-bottom:10px">
         <span class="section-label" id="popular-section-label" style="margin:0">Popular on Steam</span>
       </div>
@@ -334,12 +336,16 @@ export async function renderHomePage() {
 
     function applyRecentFilters() {
       const filtered = _filterByStore(_filterByType(_filterByTier(_sortReports(allRecentReports, currentSort), tierSel), sourceSel), storeSel);
+      const sectionEl = document.getElementById('recent-section');
       const cardsEl = document.getElementById('cards-recent');
       const loadMoreEl = document.getElementById('load-more-recent');
       const renderFn = currentLayout === 'list' ? _listRowHtml : _recentCardHtml;
       const queue = filtered.slice(PAGE_SIZE);
       const initial = filtered.slice(0, PAGE_SIZE);
-      cardsEl.innerHTML = initial.map(renderFn).join('') || '<div class="state-box">No reports found.</div>';
+      // Hide the whole recent section when empty so there's no blank state box.
+      if (sectionEl) sectionEl.hidden = !filtered.length;
+      if (!filtered.length) { if (cardsEl) cardsEl.innerHTML = ''; return; }
+      cardsEl.innerHTML = initial.map(renderFn).join('');
       if (loadMoreEl) {
         if (queue.length) {
           loadMoreEl.innerHTML = _loadMoreBtn('recent');

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,10 +1,10 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=30cf98fd';
-import { loadSearchIndex, searchIndex } from './search.js?v=b25846ac';
+import { loadSearchIndex, searchIndex } from './search.js?v=9be7632d';
 import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '../config.js?v=df5b5024';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
-import { renderGameCard } from '../lib/card.js?v=8f45a69a';
+import { renderGameCard } from '../lib/card.js?v=4b671fab';
 
 const PAGE_SIZE = 10;
 const KNOWN_TIERS = new Set(['platinum', 'gold', 'silver', 'bronze', 'borked']);

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=30cf98fd';
-import { loadSearchIndex, searchIndex } from './search.js?v=53fee6c7';
+import { loadSearchIndex, searchIndex } from './search.js?v=b25846ac';
 import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '../config.js?v=df5b5024';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=8f45a69a';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=30cf98fd';
-import { loadSearchIndex, searchIndex } from './search.js?v=36738329';
+import { loadSearchIndex, searchIndex } from './search.js?v=9b8500d5';
 import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '../config.js?v=df5b5024';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=de2b700a';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=30cf98fd';
-import { loadSearchIndex, searchIndex } from './search.js?v=8264f8ee';
+import { loadSearchIndex, searchIndex } from './search.js?v=2403e109';
 import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '../config.js?v=df5b5024';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=de2b700a';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=30cf98fd';
-import { loadSearchIndex, searchIndex } from './search.js?v=a30bff33';
+import { loadSearchIndex, searchIndex } from './search.js?v=fdc451a3';
 import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '../config.js?v=df5b5024';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=de2b700a';
@@ -12,6 +12,13 @@ const TIER_SCORE = { platinum: 5, gold: 4, silver: 3, bronze: 2, borked: 1 };
 
 function normTitle(s) {
   return String(s || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+// Card tier prop: only pass a real rated tier. Unrated/pending returns undefined
+// so the card shows the "No Rating" badge instead of an ugly "PENDING" pill.
+function _cardTier(t) {
+  const x = String(t || '').toLowerCase();
+  return KNOWN_TIERS.has(x) ? x : undefined;
 }
 
 function _sortReports(reports, sort) {
@@ -136,7 +143,7 @@ function _recentCardHtml(r) {
     appId: r.appId,
     title: r.title,
     sub: _popularSub(r),
-    tier: String(r.tier || '').toLowerCase() || undefined,
+    tier: _cardTier(r.tier),
     storePill: storeLabel(appType),
   });
 }
@@ -207,12 +214,12 @@ export async function renderHomePage() {
               <button class="pg-filter" type="button" data-value="pulse">Pulse</button>
             </div>
             <div class="filter-panel-footer filter-panel-footer--stack">
-              <label class="filter-persist"><input type="checkbox" id="home-filter-persist" /> Save filters</label>
+              <button class="filter-save-btn" id="home-filter-persist" type="button" aria-pressed="false">Save filters</button>
               <button class="filter-clear-btn" id="home-filter-clear" type="button">Clear filters</button>
             </div>
           </div>
         </div>
-        <input id="home-text-filter" class="home-filter-text" type="search" placeholder="Filter text" autocomplete="off" />
+        <input id="home-text-filter" class="home-filter-text" type="search" placeholder="Filter loaded list" autocomplete="off" />
         </div>
         <div class="home-view-controls">
           <div class="home-size-toggle" id="home-size-toggle" title="Card size">
@@ -345,7 +352,7 @@ export async function renderHomePage() {
         href: `#/app/${g.appId}`, appId: g.appId, imgUrl: g.headerImage || undefined,
         title: g.title,
         sub: g.tier === 'pending' ? 'No reports yet · be the first' : _popularSub(g),
-        tier: g.tier || undefined, storePill: storeLabel(g.appType || appTypeFromAppId(g.appId)),
+        tier: _cardTier(g.tier), storePill: storeLabel(g.appType || appTypeFromAppId(g.appId)),
       });
     }
 
@@ -412,7 +419,13 @@ export async function renderHomePage() {
     // filter state to localStorage and restore it on the next visit. Unchecking
     // clears the saved state. The box itself reflects whether a save is active.
     const FILTERS_KEY = 'pp:browse-filters';
-    function _persistOn() { return !!document.getElementById('home-filter-persist')?.checked; }
+    function _persistOn() { return document.getElementById('home-filter-persist')?.getAttribute('aria-pressed') === 'true'; }
+    function _setPersist(on) {
+      const btn = document.getElementById('home-filter-persist');
+      if (!btn) return;
+      btn.setAttribute('aria-pressed', String(on));
+      btn.classList.toggle('is-active', on);
+    }
     function _saveFilters() {
       try {
         localStorage.setItem(FILTERS_KEY, JSON.stringify({
@@ -438,8 +451,7 @@ export async function renderHomePage() {
       let saved = null;
       try { saved = JSON.parse(localStorage.getItem(FILTERS_KEY) || 'null'); } catch { saved = null; }
       if (!saved) return false;
-      const persistBox = document.getElementById('home-filter-persist');
-      if (persistBox) persistBox.checked = true;
+      _setPersist(true);
       currentSort = saved.sort || 'recent';
       const sortSel = document.getElementById('home-sort-select');
       if (sortSel) sortSel.value = currentSort;
@@ -456,8 +468,10 @@ export async function renderHomePage() {
       console.debug('[browse-filters] restored saved filters', { source: FILTERS_KEY, sort: currentSort, tiers: [...tierSel], sources: [...sourceSel], stores: [...storeSel], text: textFilter });
       return true;
     }
-    document.getElementById('home-filter-persist')?.addEventListener('change', e => {
-      if (e.target.checked) _saveFilters();
+    document.getElementById('home-filter-persist')?.addEventListener('click', () => {
+      const on = !_persistOn();
+      _setPersist(on);
+      if (on) _saveFilters();
       else { try { localStorage.removeItem(FILTERS_KEY); } catch { /* ignore */ } }
     });
 

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=30cf98fd';
-import { loadSearchIndex, searchIndex } from './search.js?v=594f0fc3';
+import { loadSearchIndex, searchIndex } from './search.js?v=3e4b5a09';
 import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '../config.js?v=df5b5024';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=de2b700a';
@@ -72,33 +72,33 @@ function _filterByStore(reports, sel) {
   return reports.filter(r => sel.has(r.appType || appTypeFromAppId(r.appId)));
 }
 
-// Read the checked values (excluding 'all') from a checkbox filter group.
-function _readCheckGroup(groupEl) {
+// Read the active (non-all) pill values from a pg-filter-group element.
+function _readPillGroup(groupEl) {
   const set = new Set();
-  groupEl.querySelectorAll('input[type="checkbox"]').forEach(cb => {
-    if (cb.value !== 'all' && cb.checked) set.add(cb.value);
+  groupEl.querySelectorAll('.pg-filter').forEach(btn => {
+    if (btn.dataset.value !== 'all' && btn.classList.contains('pg-filter--active')) {
+      set.add(btn.dataset.value);
+    }
   });
   return set;
 }
 
-// Wire an "All + specific values" checkbox group. Checking "All" clears the
-// specifics; checking a specific clears "All"; unchecking the last specific
-// re-checks "All". Calls onChange with the resulting Set after every change.
-function _wireCheckGroup(groupEl, onChange) {
-  const allCb = groupEl.querySelector('input[value="all"]');
-  groupEl.querySelectorAll('input[type="checkbox"]').forEach(cb => {
-    cb.addEventListener('change', () => {
-      if (cb.value === 'all') {
-        if (cb.checked) {
-          groupEl.querySelectorAll('input[type="checkbox"]').forEach(o => { if (o !== cb) o.checked = false; });
-        } else if (_readCheckGroup(groupEl).size === 0) {
-          cb.checked = true; // never leave the whole group empty
-        }
+// Wire an "All + specific values" pill group. Clicking All deactivates
+// specifics; clicking a specific deactivates All; deactivating the last
+// specific re-activates All. Calls onChange after every click.
+function _wirePillGroup(groupEl, onChange) {
+  const allBtn = groupEl.querySelector('.pg-filter[data-value="all"]');
+  groupEl.querySelectorAll('.pg-filter').forEach(btn => {
+    btn.addEventListener('click', () => {
+      if (btn.dataset.value === 'all') {
+        groupEl.querySelectorAll('.pg-filter').forEach(b => b.classList.remove('pg-filter--active'));
+        btn.classList.add('pg-filter--active');
       } else {
-        if (cb.checked && allCb) allCb.checked = false;
-        if (_readCheckGroup(groupEl).size === 0 && allCb) allCb.checked = true;
+        btn.classList.toggle('pg-filter--active');
+        if (allBtn) allBtn.classList.remove('pg-filter--active');
+        if (_readPillGroup(groupEl).size === 0 && allBtn) allBtn.classList.add('pg-filter--active');
       }
-      onChange(_readCheckGroup(groupEl));
+      onChange(_readPillGroup(groupEl));
     });
   });
 }
@@ -172,29 +172,29 @@ export async function renderHomePage() {
                 <option value="count">Most Reported</option>
               </select>
             </div>
-            <div class="filter-checks" id="home-store-checks" data-group="store">
-              <span class="filter-checks-label">Store</span>
-              <label class="filter-check"><input type="checkbox" value="all" checked><span>All</span></label>
-              <label class="filter-check"><input type="checkbox" value="steam"><span>Steam</span></label>
-              <label class="filter-check"><input type="checkbox" value="gog"><span>GOG</span></label>
-              <label class="filter-check"><input type="checkbox" value="epic"><span>Epic</span></label>
+            <div class="pg-filter-group" id="home-store-checks">
+              <span class="pg-filter-group-label">Store</span>
+              <button class="pg-filter pg-filter--active" type="button" data-value="all">All</button>
+              <button class="pg-filter" type="button" data-value="steam">Steam</button>
+              <button class="pg-filter" type="button" data-value="gog">GOG</button>
+              <button class="pg-filter" type="button" data-value="epic">Epic</button>
             </div>
-            <div class="filter-checks" id="home-tier-checks" data-group="tier">
-              <span class="filter-checks-label">Tier</span>
-              <label class="filter-check"><input type="checkbox" value="all" checked><span>All</span></label>
-              <label class="filter-check"><input type="checkbox" value="rated"><span>Rated</span></label>
-              <label class="filter-check"><input type="checkbox" value="unrated"><span>Not Rated Yet</span></label>
-              <label class="filter-check"><input type="checkbox" value="platinum"><span>Platinum</span></label>
-              <label class="filter-check"><input type="checkbox" value="gold"><span>Gold</span></label>
-              <label class="filter-check"><input type="checkbox" value="silver"><span>Silver</span></label>
-              <label class="filter-check"><input type="checkbox" value="bronze"><span>Bronze</span></label>
-              <label class="filter-check"><input type="checkbox" value="borked"><span>Borked</span></label>
+            <div class="pg-filter-group" id="home-tier-checks">
+              <span class="pg-filter-group-label">Tier</span>
+              <button class="pg-filter pg-filter--active" type="button" data-value="all">All</button>
+              <button class="pg-filter" type="button" data-value="rated">Rated</button>
+              <button class="pg-filter" type="button" data-value="unrated">Not Rated Yet</button>
+              <button class="pg-filter" type="button" data-value="platinum">Platinum</button>
+              <button class="pg-filter" type="button" data-value="gold">Gold</button>
+              <button class="pg-filter" type="button" data-value="silver">Silver</button>
+              <button class="pg-filter" type="button" data-value="bronze">Bronze</button>
+              <button class="pg-filter" type="button" data-value="borked">Borked</button>
             </div>
-            <div class="filter-checks" id="home-source-checks" data-group="source">
-              <span class="filter-checks-label">Source</span>
-              <label class="filter-check"><input type="checkbox" value="all" checked><span>All</span></label>
-              <label class="filter-check"><input type="checkbox" value="protondb"><span>ProtonDB</span></label>
-              <label class="filter-check"><input type="checkbox" value="pulse"><span>Pulse</span></label>
+            <div class="pg-filter-group" id="home-source-checks">
+              <span class="pg-filter-group-label">Source</span>
+              <button class="pg-filter pg-filter--active" type="button" data-value="all">All</button>
+              <button class="pg-filter" type="button" data-value="protondb">ProtonDB</button>
+              <button class="pg-filter" type="button" data-value="pulse">Pulse</button>
             </div>
             <div class="filter-panel-footer filter-panel-footer--stack">
               <button class="filter-clear-btn" id="home-filter-clear" type="button">Clear filters</button>
@@ -397,13 +397,13 @@ export async function renderHomePage() {
     const tierGroup = document.getElementById('home-tier-checks');
     const sourceGroup = document.getElementById('home-source-checks');
     const storeGroup = document.getElementById('home-store-checks');
-    if (tierGroup) _wireCheckGroup(tierGroup, sel => {
+    if (tierGroup) _wirePillGroup(tierGroup, sel => {
       tierSel = sel; updateFilterBadge(); applyRecentFilters(); applyPopularFilters();
     });
-    if (sourceGroup) _wireCheckGroup(sourceGroup, sel => {
+    if (sourceGroup) _wirePillGroup(sourceGroup, sel => {
       sourceSel = sel; updateFilterBadge(); applyRecentFilters(); applyPopularFilters();
     });
-    if (storeGroup) _wireCheckGroup(storeGroup, sel => {
+    if (storeGroup) _wirePillGroup(storeGroup, sel => {
       storeSel = sel; updateFilterBadge(); applyRecentFilters(); applyPopularFilters();
     });
 
@@ -411,7 +411,9 @@ export async function renderHomePage() {
     document.getElementById('home-filter-clear')?.addEventListener('click', () => {
       [tierGroup, sourceGroup, storeGroup].forEach(g => {
         if (!g) return;
-        g.querySelectorAll('input[type="checkbox"]').forEach(cb => { cb.checked = cb.value === 'all'; });
+        g.querySelectorAll('.pg-filter').forEach(b => b.classList.remove('pg-filter--active'));
+        const allBtn = g.querySelector('.pg-filter[data-value="all"]');
+        if (allBtn) allBtn.classList.add('pg-filter--active');
       });
       const sortSel = document.getElementById('home-sort-select');
       if (sortSel) sortSel.value = 'recent';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=30cf98fd';
-import { loadSearchIndex, searchIndex } from './search.js?v=9b8500d5';
+import { loadSearchIndex, searchIndex } from './search.js?v=f68f83d2';
 import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '../config.js?v=df5b5024';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=de2b700a';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=30cf98fd';
-import { loadSearchIndex, searchIndex } from './search.js?v=f68f83d2';
+import { loadSearchIndex, searchIndex } from './search.js?v=69369686';
 import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '../config.js?v=df5b5024';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=de2b700a';
@@ -172,6 +172,13 @@ export async function renderHomePage() {
                 <option value="count">Most Reported</option>
               </select>
             </div>
+            <div class="filter-checks" id="home-store-checks" data-group="store">
+              <span class="filter-checks-label">Store</span>
+              <label class="filter-check"><input type="checkbox" value="all" checked><span>All</span></label>
+              <label class="filter-check"><input type="checkbox" value="steam"><span>Steam</span></label>
+              <label class="filter-check"><input type="checkbox" value="gog"><span>GOG</span></label>
+              <label class="filter-check"><input type="checkbox" value="epic"><span>Epic</span></label>
+            </div>
             <div class="filter-checks" id="home-tier-checks" data-group="tier">
               <span class="filter-checks-label">Tier</span>
               <label class="filter-check"><input type="checkbox" value="all" checked><span>All</span></label>
@@ -188,13 +195,6 @@ export async function renderHomePage() {
               <label class="filter-check"><input type="checkbox" value="all" checked><span>All</span></label>
               <label class="filter-check"><input type="checkbox" value="protondb"><span>ProtonDB</span></label>
               <label class="filter-check"><input type="checkbox" value="pulse"><span>Pulse</span></label>
-            </div>
-            <div class="filter-checks" id="home-store-checks" data-group="store">
-              <span class="filter-checks-label">Store</span>
-              <label class="filter-check"><input type="checkbox" value="all" checked><span>All</span></label>
-              <label class="filter-check"><input type="checkbox" value="steam"><span>Steam</span></label>
-              <label class="filter-check"><input type="checkbox" value="gog"><span>GOG</span></label>
-              <label class="filter-check"><input type="checkbox" value="epic"><span>Epic</span></label>
             </div>
             <div class="filter-panel-footer filter-panel-footer--stack">
               <button class="filter-clear-btn" id="home-filter-clear" type="button">Clear filters</button>

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=30cf98fd';
-import { loadSearchIndex, searchIndex } from './search.js?v=3e4b5a09';
+import { loadSearchIndex, searchIndex } from './search.js?v=644d8996';
 import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '../config.js?v=df5b5024';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=de2b700a';
@@ -140,6 +140,7 @@ export async function renderHomePage() {
     const [recentResp, mostPlayedResp] = await Promise.all([
       fetch('recent-reports.json').catch(() => null),
       fetch('most_played.json').catch(() => null),
+      loadSearchIndex().catch(() => null),
     ]);
 
     let allRecentReports = [];

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=30cf98fd';
-import { loadSearchIndex, searchIndex } from './search.js?v=2403e109';
+import { loadSearchIndex, searchIndex } from './search.js?v=36738329';
 import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '../config.js?v=df5b5024';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=de2b700a';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,7 +1,7 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=30cf98fd';
-import { loadSearchIndex, searchIndex } from './search.js?v=644d8996';
+import { loadSearchIndex, searchIndex } from './search.js?v=37a03e4e';
 import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '../config.js?v=df5b5024';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=de2b700a';
@@ -70,6 +70,14 @@ function _filterByType(reports, sel) {
 function _filterByStore(reports, sel) {
   if (!sel || sel.size === 0 || sel.has('all')) return reports;
   return reports.filter(r => sel.has(r.appType || appTypeFromAppId(r.appId)));
+}
+
+// Text filter: case-insensitive substring match on the game title. Empty/blank
+// text means no filtering. Trims so a stray space does not hide everything.
+function _filterByText(reports, text) {
+  const q = String(text || '').trim().toLowerCase();
+  if (!q) return reports;
+  return reports.filter(r => String(r.title || '').toLowerCase().includes(q));
 }
 
 // Read the active (non-all) pill values from a pg-filter-group element.
@@ -165,6 +173,10 @@ export async function renderHomePage() {
           </button>
           <div class="filter-panel filter-panel--stack" id="home-filter-panel">
             <div class="filter-item">
+              <label class="home-filter-label" for="home-text-filter">Filter</label>
+              <input id="home-text-filter" class="home-filter-text" type="search" placeholder="Filter text" autocomplete="off" />
+            </div>
+            <div class="filter-item">
               <label class="home-filter-label" for="home-sort-select">Sort</label>
               <select id="home-sort-select" class="home-filter-select">
                 <option value="recent">Recent</option>
@@ -227,6 +239,7 @@ export async function renderHomePage() {
       <div id="load-more-popular"></div>`;
 
     let currentSort = 'recent';
+    let textFilter = '';       // title substring filter; '' => no text filtering
     let tierSel = new Set();   // empty => all tiers
     let sourceSel = new Set(); // empty => all sources
     let storeSel = new Set();  // empty => all stores
@@ -302,7 +315,7 @@ export async function renderHomePage() {
           return { ...g, tier: KNOWN_TIERS.has(t) ? t : 'pending' };
         });
       }
-      const filtered = _filterByStore(_filterByType(_filterByTier(asReports, tierSel), sourceSel), storeSel);
+      const filtered = _filterByText(_filterByStore(_filterByType(_filterByTier(asReports, tierSel), sourceSel), storeSel), textFilter);
       const cardsEl = document.getElementById('cards-popular');
       const loadMoreEl = document.getElementById('load-more-popular');
       if (!cardsEl) return;
@@ -337,7 +350,7 @@ export async function renderHomePage() {
     }
 
     function applyRecentFilters() {
-      const filtered = _filterByStore(_filterByType(_filterByTier(_sortReports(allRecentReports, currentSort), tierSel), sourceSel), storeSel);
+      const filtered = _filterByText(_filterByStore(_filterByType(_filterByTier(_sortReports(allRecentReports, currentSort), tierSel), sourceSel), storeSel), textFilter);
       const sectionEl = document.getElementById('recent-section');
       const cardsEl = document.getElementById('cards-recent');
       const loadMoreEl = document.getElementById('load-more-recent');
@@ -368,6 +381,14 @@ export async function renderHomePage() {
       applyRecentFilters();
     });
 
+    // Text filter: filters both sections by title substring as the user types.
+    document.getElementById('home-text-filter')?.addEventListener('input', e => {
+      textFilter = e.target.value;
+      updateFilterBadge();
+      applyRecentFilters();
+      applyPopularFilters();
+    });
+
     // Filters popover: toggle open, close on outside click.
     const filterWrap = document.getElementById('home-filter-wrap');
     const filterToggle = document.getElementById('home-filter-toggle');
@@ -387,7 +408,7 @@ export async function renderHomePage() {
 
     // Active-filter badge: count specific tier + source + store selections.
     function updateFilterBadge() {
-      const n = tierSel.size + sourceSel.size + storeSel.size;
+      const n = tierSel.size + sourceSel.size + storeSel.size + (textFilter.trim() ? 1 : 0);
       filterToggle?.classList.toggle('has-filters', n > 0);
       if (filterBadge) {
         filterBadge.textContent = String(n);
@@ -419,6 +440,9 @@ export async function renderHomePage() {
       const sortSel = document.getElementById('home-sort-select');
       if (sortSel) sortSel.value = 'recent';
       currentSort = 'recent';
+      const textInput = document.getElementById('home-text-filter');
+      if (textInput) textInput.value = '';
+      textFilter = '';
       tierSel = new Set();
       sourceSel = new Set();
       storeSel = new Set();

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,10 +1,10 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=30cf98fd';
-import { loadSearchIndex, searchIndex } from './search.js?v=9be7632d';
+import { loadSearchIndex, searchIndex } from './search.js?v=8264f8ee';
 import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '../config.js?v=df5b5024';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
-import { renderGameCard } from '../lib/card.js?v=4b671fab';
+import { renderGameCard } from '../lib/card.js?v=de2b700a';
 
 const PAGE_SIZE = 10;
 const KNOWN_TIERS = new Set(['platinum', 'gold', 'silver', 'bronze', 'borked']);

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=0730c36c';
+import { renderAuthorBlock } from './author.js?v=f08315eb';
 import { buildFormRows } from './config-cards.js?v=473be757';
 import { renderSignalStrip } from './signals.js?v=2980c285';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=df5b5024';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=03330fa3';
+import { renderAuthorBlock } from './author.js?v=0c0fbb43';
 import { buildFormRows } from './config-cards.js?v=473be757';
 import { renderSignalStrip } from './signals.js?v=2980c285';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=df5b5024';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=a12fb8d1';
+import { renderAuthorBlock } from './author.js?v=c086dc45';
 import { buildFormRows } from './config-cards.js?v=473be757';
 import { renderSignalStrip } from './signals.js?v=2980c285';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=df5b5024';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=7376ae0a';
+import { renderAuthorBlock } from './author.js?v=acd3e167';
 import { buildFormRows } from './config-cards.js?v=473be757';
 import { renderSignalStrip } from './signals.js?v=2980c285';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=df5b5024';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=f9c8a583';
+import { renderAuthorBlock } from './author.js?v=684796fb';
 import { buildFormRows } from './config-cards.js?v=473be757';
 import { renderSignalStrip } from './signals.js?v=2980c285';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=df5b5024';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=ce03b00d';
+import { renderAuthorBlock } from './author.js?v=7e410a15';
 import { buildFormRows } from './config-cards.js?v=473be757';
 import { renderSignalStrip } from './signals.js?v=2980c285';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=df5b5024';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=2ee6f936';
+import { renderAuthorBlock } from './author.js?v=0730c36c';
 import { buildFormRows } from './config-cards.js?v=473be757';
 import { renderSignalStrip } from './signals.js?v=2980c285';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=df5b5024';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=adb6c0ae';
+import { renderAuthorBlock } from './author.js?v=56f63efc';
 import { buildFormRows } from './config-cards.js?v=473be757';
 import { renderSignalStrip } from './signals.js?v=2980c285';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=df5b5024';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=f08315eb';
+import { renderAuthorBlock } from './author.js?v=dd00c654';
 import { buildFormRows } from './config-cards.js?v=473be757';
 import { renderSignalStrip } from './signals.js?v=2980c285';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=df5b5024';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=cf23b4e6';
+import { renderAuthorBlock } from './author.js?v=5591d38b';
 import { buildFormRows } from './config-cards.js?v=473be757';
 import { renderSignalStrip } from './signals.js?v=2980c285';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=df5b5024';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=acd3e167';
+import { renderAuthorBlock } from './author.js?v=f9c8a583';
 import { buildFormRows } from './config-cards.js?v=473be757';
 import { renderSignalStrip } from './signals.js?v=2980c285';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=df5b5024';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=7e410a15';
+import { renderAuthorBlock } from './author.js?v=a12fb8d1';
 import { buildFormRows } from './config-cards.js?v=473be757';
 import { renderSignalStrip } from './signals.js?v=2980c285';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=df5b5024';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=0c0fbb43';
+import { renderAuthorBlock } from './author.js?v=82cc12ae';
 import { buildFormRows } from './config-cards.js?v=473be757';
 import { renderSignalStrip } from './signals.js?v=2980c285';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=df5b5024';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=55177972';
+import { renderAuthorBlock } from './author.js?v=2ee6f936';
 import { buildFormRows } from './config-cards.js?v=473be757';
 import { renderSignalStrip } from './signals.js?v=2980c285';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=df5b5024';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=c086dc45';
+import { renderAuthorBlock } from './author.js?v=55177972';
 import { buildFormRows } from './config-cards.js?v=473be757';
 import { renderSignalStrip } from './signals.js?v=2980c285';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=df5b5024';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=dd00c654';
+import { renderAuthorBlock } from './author.js?v=adb6c0ae';
 import { buildFormRows } from './config-cards.js?v=473be757';
 import { renderSignalStrip } from './signals.js?v=2980c285';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=df5b5024';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=56f63efc';
+import { renderAuthorBlock } from './author.js?v=cf23b4e6';
 import { buildFormRows } from './config-cards.js?v=473be757';
 import { renderSignalStrip } from './signals.js?v=2980c285';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=df5b5024';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=42bf8b9d';
+import { renderAuthorBlock } from './author.js?v=03330fa3';
 import { buildFormRows } from './config-cards.js?v=473be757';
 import { renderSignalStrip } from './signals.js?v=2980c285';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=df5b5024';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=82cc12ae';
+import { renderAuthorBlock } from './author.js?v=dbbbf35c';
 import { buildFormRows } from './config-cards.js?v=473be757';
 import { renderSignalStrip } from './signals.js?v=2980c285';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=df5b5024';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=dbbbf35c';
+import { renderAuthorBlock } from './author.js?v=7376ae0a';
 import { buildFormRows } from './config-cards.js?v=473be757';
 import { renderSignalStrip } from './signals.js?v=2980c285';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=df5b5024';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -3,7 +3,7 @@
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=c57cb3d6';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
-import { renderAuthorBlock } from './author.js?v=5591d38b';
+import { renderAuthorBlock } from './author.js?v=42bf8b9d';
 import { buildFormRows } from './config-cards.js?v=473be757';
 import { renderSignalStrip } from './signals.js?v=2980c285';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=df5b5024';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,10 +2,10 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=30cf98fd';
-import { renderGamePage } from './game-page.js?v=9161b3cf';
+import { renderGamePage } from './game-page.js?v=f006e909';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
-import { renderGameCard } from '../lib/card.js?v=633df5fd';
+import { renderGameCard } from '../lib/card.js?v=8f45a69a';
 
 // Search index + results UX -- factored out of app.js.
 // Loaded as a classic script BEFORE app.js so its globals

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=30cf98fd';
-import { renderGamePage } from './game-page.js?v=643e40eb';
+import { renderGamePage } from './game-page.js?v=300e09eb';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=de2b700a';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=30cf98fd';
-import { renderGamePage } from './game-page.js?v=2423f888';
+import { renderGamePage } from './game-page.js?v=11f879e9';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=8f45a69a';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=30cf98fd';
-import { renderGamePage } from './game-page.js?v=6a6e3da7';
+import { renderGamePage } from './game-page.js?v=1f92f53e';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=8f45a69a';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=30cf98fd';
-import { renderGamePage } from './game-page.js?v=b931d9d1';
+import { renderGamePage } from './game-page.js?v=742a5b4d';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=de2b700a';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=30cf98fd';
-import { renderGamePage } from './game-page.js?v=fd4f2e3a';
+import { renderGamePage } from './game-page.js?v=03531fdb';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=de2b700a';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=30cf98fd';
-import { renderGamePage } from './game-page.js?v=03531fdb';
+import { renderGamePage } from './game-page.js?v=be247d3b';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=de2b700a';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=30cf98fd';
-import { renderGamePage } from './game-page.js?v=2726c9c9';
+import { renderGamePage } from './game-page.js?v=2423f888';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=8f45a69a';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=30cf98fd';
-import { renderGamePage } from './game-page.js?v=9db37d6c';
+import { renderGamePage } from './game-page.js?v=cfe9a4ee';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=de2b700a';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=30cf98fd';
-import { renderGamePage } from './game-page.js?v=1f92f53e';
+import { renderGamePage } from './game-page.js?v=d46bf179';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=8f45a69a';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=30cf98fd';
-import { renderGamePage } from './game-page.js?v=f006e909';
+import { renderGamePage } from './game-page.js?v=6a6e3da7';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=8f45a69a';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,10 +2,10 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=30cf98fd';
-import { renderGamePage } from './game-page.js?v=11f879e9';
+import { renderGamePage } from './game-page.js?v=60bd0329';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
-import { renderGameCard } from '../lib/card.js?v=8f45a69a';
+import { renderGameCard } from '../lib/card.js?v=4b671fab';
 
 // Search index + results UX -- factored out of app.js.
 // Loaded as a classic script BEFORE app.js so its globals

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=30cf98fd';
-import { renderGamePage } from './game-page.js?v=5c1d4494';
+import { renderGamePage } from './game-page.js?v=fd4f2e3a';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=de2b700a';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=30cf98fd';
-import { renderGamePage } from './game-page.js?v=300e09eb';
+import { renderGamePage } from './game-page.js?v=549f10f9';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=de2b700a';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=30cf98fd';
-import { renderGamePage } from './game-page.js?v=d46bf179';
+import { renderGamePage } from './game-page.js?v=2726c9c9';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=8f45a69a';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=30cf98fd';
-import { renderGamePage } from './game-page.js?v=549f10f9';
+import { renderGamePage } from './game-page.js?v=96e2a103';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=de2b700a';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,10 +2,10 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=30cf98fd';
-import { renderGamePage } from './game-page.js?v=60bd0329';
+import { renderGamePage } from './game-page.js?v=b931d9d1';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
-import { renderGameCard } from '../lib/card.js?v=4b671fab';
+import { renderGameCard } from '../lib/card.js?v=de2b700a';
 
 // Search index + results UX -- factored out of app.js.
 // Loaded as a classic script BEFORE app.js so its globals

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=30cf98fd';
-import { renderGamePage } from './game-page.js?v=cfe9a4ee';
+import { renderGamePage } from './game-page.js?v=c5c859b7';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=de2b700a';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=30cf98fd';
-import { renderGamePage } from './game-page.js?v=c5c859b7';
+import { renderGamePage } from './game-page.js?v=643e40eb';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=de2b700a';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=30cf98fd';
-import { renderGamePage } from './game-page.js?v=742a5b4d';
+import { renderGamePage } from './game-page.js?v=9db37d6c';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=de2b700a';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=30cf98fd';
-import { renderGamePage } from './game-page.js?v=96e2a103';
+import { renderGamePage } from './game-page.js?v=5c1d4494';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=de2b700a';

--- a/js/app/lib/card.js
+++ b/js/app/lib/card.js
@@ -26,12 +26,7 @@ export function renderGameCard({ href, appId, title, sub, tier, badge, badgeBg, 
   const thumbInner = primarySrc
     ? `<img class="game-card-thumb" src="${primarySrc}" data-appid="${aid}" alt="" loading="lazy" onerror="window.__steamImgLoad(this)">`
     : `<div class="game-card-thumb game-card-thumb--missing">Box art missing</div>`;
-  // Store tag overlays the artwork corner instead of taking a slot in the right
-  // column. Scales with the thumbnail (small on mobile, larger on desktop).
-  const storeOverlayHtml = storePill
-    ? `<span class="game-card-store-tag game-card-store-pill--${esc(String(storePill).toLowerCase())}">${esc(storePill)}</span>`
-    : '';
-  const thumbHtml = `<div class="game-card-thumb-wrap">${thumbInner}${storeOverlayHtml}</div>`;
+  const thumbHtml = `<div class="game-card-thumb-wrap">${thumbInner}</div>`;
 
   // Rating pill. A real tier colours the pill; an explicit badge (e.g. "Pulse")
   // is shown as-is; otherwise fall back to a muted "No Rating" pill so every
@@ -46,7 +41,12 @@ export function renderGameCard({ href, appId, title, sub, tier, badge, badgeBg, 
     badgeStyle = `style="background:${badgeBg};color:${badgeColor || '#fff'}"`;
   }
   const badgeHtml = `<span class="game-card-badge${isNoRating ? ' game-card-badge--unrated' : ''}" ${badgeStyle}>${esc(label)}</span>`;
-  const pillsRowHtml = `<div class="game-card-pills">${badgeHtml}</div>`;
+  // Store pill sits inline with the rating on desktop; drops to row 2 on mobile
+  // via the @media rule on .game-card-pills in cards.css.
+  const storePillHtml = storePill
+    ? `<span class="game-card-store-pill game-card-store-pill--${esc(String(storePill).toLowerCase())}">${esc(storePill)}</span>`
+    : '';
+  const pillsRowHtml = `<div class="game-card-pills">${badgeHtml}${storePillHtml}</div>`;
   const sourceLabelHtml = sourceLabel
     ? `<span class="game-card-source">${esc(sourceLabel)}</span>`
     : '';

--- a/js/app/lib/card.js
+++ b/js/app/lib/card.js
@@ -16,14 +16,22 @@ const TIER_COLORS = {
 // imgUrl: pre-resolved Steam image URL (bypasses CDN guessing entirely)
 // tier: one of platinum/gold/silver/bronze/borked - auto-colours the badge
 // badge: raw label string - used when tier is not applicable
-// storePill: store name shown as a coloured pill next to the rating pill (e.g. "Steam", "GOG", "Epic")
+// storePill: store name shown as a small coloured tag in the bottom-right corner
+//   of the artwork (e.g. "Steam", "GOG", "Epic"), keeping the right column free
+//   for just the rating pill so titles get more width on mobile.
 // sourceLabel: plain muted text shown below the pills (legacy; prefer storePill)
 export function renderGameCard({ href, appId, title, sub, tier, badge, badgeBg, badgeColor, imgUrl, sourceLabel, storePill }) {
   const primarySrc = imgUrl || (appId ? STEAM_IMG(appId) : '');
   const aid = appId != null ? String(appId) : '';
-  const thumbHtml = primarySrc
+  const thumbInner = primarySrc
     ? `<img class="game-card-thumb" src="${primarySrc}" data-appid="${aid}" alt="" loading="lazy" onerror="window.__steamImgLoad(this)">`
     : `<div class="game-card-thumb game-card-thumb--missing">Box art missing</div>`;
+  // Store tag overlays the artwork corner instead of taking a slot in the right
+  // column. Scales with the thumbnail (small on mobile, larger on desktop).
+  const storeOverlayHtml = storePill
+    ? `<span class="game-card-store-tag game-card-store-pill--${esc(String(storePill).toLowerCase())}">${esc(storePill)}</span>`
+    : '';
+  const thumbHtml = `<div class="game-card-thumb-wrap">${thumbInner}${storeOverlayHtml}</div>`;
 
   // Rating pill. A real tier colours the pill; an explicit badge (e.g. "Pulse")
   // is shown as-is; otherwise fall back to a muted "No Rating" pill so every
@@ -38,18 +46,11 @@ export function renderGameCard({ href, appId, title, sub, tier, badge, badgeBg, 
     badgeStyle = `style="background:${badgeBg};color:${badgeColor || '#fff'}"`;
   }
   const badgeHtml = `<span class="game-card-badge${isNoRating ? ' game-card-badge--unrated' : ''}" ${badgeStyle}>${esc(label)}</span>`;
-  const storePillHtml = storePill
-    ? `<span class="game-card-store-pill game-card-store-pill--${esc(String(storePill).toLowerCase())}">${esc(storePill)}</span>`
-    : '';
-  const pillsRowHtml = (badgeHtml || storePillHtml)
-    ? `<div class="game-card-pills">${badgeHtml}${storePillHtml}</div>`
-    : '';
+  const pillsRowHtml = `<div class="game-card-pills">${badgeHtml}</div>`;
   const sourceLabelHtml = sourceLabel
     ? `<span class="game-card-source">${esc(sourceLabel)}</span>`
     : '';
-  const rightHtml = (pillsRowHtml || sourceLabelHtml)
-    ? `<div class="game-card-right">${pillsRowHtml}${sourceLabelHtml}</div>`
-    : '';
+  const rightHtml = `<div class="game-card-right">${pillsRowHtml}${sourceLabelHtml}</div>`;
 
   return `<a class="game-card" href="${href}">${thumbHtml}<div class="game-card-body"><div class="game-card-title">${esc(title)}</div><div class="game-card-sub">${sub}</div></div>${rightHtml}</a>`;
 }

--- a/js/app/lib/card.js
+++ b/js/app/lib/card.js
@@ -26,11 +26,14 @@ export function renderGameCard({ href, appId, title, sub, tier, badge, badgeBg, 
   const thumbInner = primarySrc
     ? `<img class="game-card-thumb" src="${primarySrc}" data-appid="${aid}" alt="" loading="lazy" onerror="window.__steamImgLoad(this)">`
     : `<div class="game-card-thumb game-card-thumb--missing">Box art missing</div>`;
-  const thumbHtml = `<div class="game-card-thumb-wrap">${thumbInner}</div>`;
+  // Both positions are rendered; CSS (driven by data-store-pill-pos on <html>)
+  // shows one and hides the other based on the site preference.
+  const storeKey = storePill ? esc(String(storePill).toLowerCase()) : '';
+  const storeTag = storePill
+    ? `<span class="game-card-store-tag game-card-store-pill--${storeKey}">${esc(storePill)}</span>`
+    : '';
+  const thumbHtml = `<div class="game-card-thumb-wrap">${thumbInner}${storeTag}</div>`;
 
-  // Rating pill. A real tier colours the pill; an explicit badge (e.g. "Pulse")
-  // is shown as-is; otherwise fall back to a muted "No Rating" pill so every
-  // card carries a rating slot, including not-yet-rated catalog games.
   const label = tier ? tier.toUpperCase() : (badge || 'No Rating');
   const isNoRating = !tier && !badge;
   let badgeStyle = '';
@@ -41,10 +44,8 @@ export function renderGameCard({ href, appId, title, sub, tier, badge, badgeBg, 
     badgeStyle = `style="background:${badgeBg};color:${badgeColor || '#fff'}"`;
   }
   const badgeHtml = `<span class="game-card-badge${isNoRating ? ' game-card-badge--unrated' : ''}" ${badgeStyle}>${esc(label)}</span>`;
-  // Store pill sits inline with the rating on desktop; drops to row 2 on mobile
-  // via the @media rule on .game-card-pills in cards.css.
   const storePillHtml = storePill
-    ? `<span class="game-card-store-pill game-card-store-pill--${esc(String(storePill).toLowerCase())}">${esc(storePill)}</span>`
+    ? `<span class="game-card-store-pill game-card-store-pill--${storeKey}">${esc(storePill)}</span>`
     : '';
   const pillsRowHtml = `<div class="game-card-pills">${badgeHtml}${storePillHtml}</div>`;
   const sourceLabelHtml = sourceLabel

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=c7f18ac0';
-import { wireSearch } from './components/search.js?v=b25846ac';
+import { route } from './router.js?v=71691aaa';
+import { wireSearch } from './components/search.js?v=a5543ec5';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=559d0c95';
-import { wireSearch } from './components/search.js?v=20c19bef';
+import { route } from './router.js?v=9e04acb6';
+import { wireSearch } from './components/search.js?v=6a0124d8';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=fa3f2f3a';
-import { wireSearch } from './components/search.js?v=9b8500d5';
+import { route } from './router.js?v=4f2ac3a6';
+import { wireSearch } from './components/search.js?v=f68f83d2';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=a8289cc2';
-import { wireSearch } from './components/search.js?v=2403e109';
+import { route } from './router.js?v=422a5ed0';
+import { wireSearch } from './components/search.js?v=36738329';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=11e31e2a';
-import { wireSearch } from './components/search.js?v=fdc451a3';
+import { route } from './router.js?v=a6c798ca';
+import { wireSearch } from './components/search.js?v=50308c43';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=f312cb82';
-import { wireSearch } from './components/search.js?v=53fee6c7';
+import { route } from './router.js?v=c7f18ac0';
+import { wireSearch } from './components/search.js?v=b25846ac';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=a6c798ca';
-import { wireSearch } from './components/search.js?v=50308c43';
+import { route } from './router.js?v=9ac23f21';
+import { wireSearch } from './components/search.js?v=e85ca635';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=84618449';
-import { wireSearch } from './components/search.js?v=a30bff33';
+import { route } from './router.js?v=11e31e2a';
+import { wireSearch } from './components/search.js?v=fdc451a3';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=db5d8fb3';
-import { wireSearch } from './components/search.js?v=c1e710d6';
+import { route } from './router.js?v=8b262bc5';
+import { wireSearch } from './components/search.js?v=644d8996';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=a0ec2a77';
-import { wireSearch } from './components/search.js?v=b2d692f6';
+import { route } from './router.js?v=559d0c95';
+import { wireSearch } from './components/search.js?v=20c19bef';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=3127acdd';
-import { wireSearch } from './components/search.js?v=594f0fc3';
+import { route } from './router.js?v=db5d8fb3';
+import { wireSearch } from './components/search.js?v=c1e710d6';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=9e04acb6';
-import { wireSearch } from './components/search.js?v=6a0124d8';
+import { route } from './router.js?v=f2b11b5f';
+import { wireSearch } from './components/search.js?v=0e76ead0';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=71691aaa';
-import { wireSearch } from './components/search.js?v=a5543ec5';
+import { route } from './router.js?v=4333c4c2';
+import { wireSearch } from './components/search.js?v=ecdd5455';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=fa2370ef';
-import { wireSearch } from './components/search.js?v=f56dd455';
+import { route } from './router.js?v=f312cb82';
+import { wireSearch } from './components/search.js?v=53fee6c7';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=f2b11b5f';
-import { wireSearch } from './components/search.js?v=0e76ead0';
+import { route } from './router.js?v=fa2370ef';
+import { wireSearch } from './components/search.js?v=f56dd455';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=8b262bc5';
-import { wireSearch } from './components/search.js?v=644d8996';
+import { route } from './router.js?v=1e460a38';
+import { wireSearch } from './components/search.js?v=ed9fc30e';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=1e460a38';
-import { wireSearch } from './components/search.js?v=ed9fc30e';
+import { route } from './router.js?v=84618449';
+import { wireSearch } from './components/search.js?v=a30bff33';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=f6ca009b';
-import { wireSearch } from './components/search.js?v=69369686';
+import { route } from './router.js?v=3127acdd';
+import { wireSearch } from './components/search.js?v=594f0fc3';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=422a5ed0';
-import { wireSearch } from './components/search.js?v=36738329';
+import { route } from './router.js?v=fa3f2f3a';
+import { wireSearch } from './components/search.js?v=9b8500d5';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=4f2ac3a6';
-import { wireSearch } from './components/search.js?v=f68f83d2';
+import { route } from './router.js?v=f6ca009b';
+import { wireSearch } from './components/search.js?v=69369686';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
-import { route } from './router.js?v=4333c4c2';
-import { wireSearch } from './components/search.js?v=ecdd5455';
+import { route } from './router.js?v=a8289cc2';
+import { wireSearch } from './components/search.js?v=2403e109';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=d46bf179';
-import { renderHomePage } from './components/home.js?v=3f82beae';
-import { renderSearchPage } from './components/search.js?v=f56dd455';
+import { renderGamePage } from './components/game-page.js?v=2726c9c9';
+import { renderHomePage } from './components/home.js?v=3c822bd9';
+import { renderSearchPage } from './components/search.js?v=53fee6c7';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=b931d9d1';
-import { renderHomePage } from './components/home.js?v=43a207f0';
-import { renderSearchPage } from './components/search.js?v=2403e109';
+import { renderGamePage } from './components/game-page.js?v=742a5b4d';
+import { renderHomePage } from './components/home.js?v=4f9ad0e8';
+import { renderSearchPage } from './components/search.js?v=36738329';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=300e09eb';
-import { renderHomePage } from './components/home.js?v=c2226995';
-import { renderSearchPage } from './components/search.js?v=c1e710d6';
+import { renderGamePage } from './components/game-page.js?v=549f10f9';
+import { renderHomePage } from './components/home.js?v=ef38a3eb';
+import { renderSearchPage } from './components/search.js?v=644d8996';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=6a6e3da7';
-import { renderHomePage } from './components/home.js?v=dafde13d';
-import { renderSearchPage } from './components/search.js?v=6a0124d8';
+import { renderGamePage } from './components/game-page.js?v=1f92f53e';
+import { renderHomePage } from './components/home.js?v=502622b3';
+import { renderSearchPage } from './components/search.js?v=0e76ead0';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=1f92f53e';
-import { renderHomePage } from './components/home.js?v=502622b3';
-import { renderSearchPage } from './components/search.js?v=0e76ead0';
+import { renderGamePage } from './components/game-page.js?v=d46bf179';
+import { renderHomePage } from './components/home.js?v=3f82beae';
+import { renderSearchPage } from './components/search.js?v=f56dd455';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=2726c9c9';
-import { renderHomePage } from './components/home.js?v=3c822bd9';
-import { renderSearchPage } from './components/search.js?v=53fee6c7';
+import { renderGamePage } from './components/game-page.js?v=2423f888';
+import { renderHomePage } from './components/home.js?v=505387b0';
+import { renderSearchPage } from './components/search.js?v=b25846ac';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=fd4f2e3a';
-import { renderHomePage } from './components/home.js?v=6d131a85';
-import { renderSearchPage } from './components/search.js?v=fdc451a3';
+import { renderGamePage } from './components/game-page.js?v=03531fdb';
+import { renderHomePage } from './components/home.js?v=1c0762cf';
+import { renderSearchPage } from './components/search.js?v=50308c43';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=11f879e9';
-import { renderHomePage } from './components/home.js?v=02b99377';
-import { renderSearchPage } from './components/search.js?v=a5543ec5';
+import { renderGamePage } from './components/game-page.js?v=60bd0329';
+import { renderHomePage } from './components/home.js?v=1a4e5c00';
+import { renderSearchPage } from './components/search.js?v=ecdd5455';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=5c1d4494';
-import { renderHomePage } from './components/home.js?v=230e8f57';
-import { renderSearchPage } from './components/search.js?v=a30bff33';
+import { renderGamePage } from './components/game-page.js?v=fd4f2e3a';
+import { renderHomePage } from './components/home.js?v=6d131a85';
+import { renderSearchPage } from './components/search.js?v=fdc451a3';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=f006e909';
-import { renderHomePage } from './components/home.js?v=1d05180d';
-import { renderSearchPage } from './components/search.js?v=20c19bef';
+import { renderGamePage } from './components/game-page.js?v=6a6e3da7';
+import { renderHomePage } from './components/home.js?v=dafde13d';
+import { renderSearchPage } from './components/search.js?v=6a0124d8';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=2423f888';
-import { renderHomePage } from './components/home.js?v=505387b0';
-import { renderSearchPage } from './components/search.js?v=b25846ac';
+import { renderGamePage } from './components/game-page.js?v=11f879e9';
+import { renderHomePage } from './components/home.js?v=02b99377';
+import { renderSearchPage } from './components/search.js?v=a5543ec5';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=643e40eb';
-import { renderHomePage } from './components/home.js?v=0853de8c';
-import { renderSearchPage } from './components/search.js?v=594f0fc3';
+import { renderGamePage } from './components/game-page.js?v=300e09eb';
+import { renderHomePage } from './components/home.js?v=c2226995';
+import { renderSearchPage } from './components/search.js?v=c1e710d6';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=9db37d6c';
-import { renderHomePage } from './components/home.js?v=14eed411';
-import { renderSearchPage } from './components/search.js?v=9b8500d5';
+import { renderGamePage } from './components/game-page.js?v=cfe9a4ee';
+import { renderHomePage } from './components/home.js?v=b9fcb08d';
+import { renderSearchPage } from './components/search.js?v=f68f83d2';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=03531fdb';
-import { renderHomePage } from './components/home.js?v=1c0762cf';
-import { renderSearchPage } from './components/search.js?v=50308c43';
+import { renderGamePage } from './components/game-page.js?v=be247d3b';
+import { renderHomePage } from './components/home.js?v=8ade6d9d';
+import { renderSearchPage } from './components/search.js?v=e85ca635';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=9161b3cf';
-import { renderHomePage } from './components/home.js?v=a3a93306';
-import { renderSearchPage } from './components/search.js?v=b2d692f6';
+import { renderGamePage } from './components/game-page.js?v=f006e909';
+import { renderHomePage } from './components/home.js?v=1d05180d';
+import { renderSearchPage } from './components/search.js?v=20c19bef';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=60bd0329';
-import { renderHomePage } from './components/home.js?v=1a4e5c00';
-import { renderSearchPage } from './components/search.js?v=ecdd5455';
+import { renderGamePage } from './components/game-page.js?v=b931d9d1';
+import { renderHomePage } from './components/home.js?v=43a207f0';
+import { renderSearchPage } from './components/search.js?v=2403e109';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=549f10f9';
-import { renderHomePage } from './components/home.js?v=ef38a3eb';
-import { renderSearchPage } from './components/search.js?v=644d8996';
+import { renderGamePage } from './components/game-page.js?v=96e2a103';
+import { renderHomePage } from './components/home.js?v=0e6c76c2';
+import { renderSearchPage } from './components/search.js?v=ed9fc30e';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=c5c859b7';
-import { renderHomePage } from './components/home.js?v=0b704f24';
-import { renderSearchPage } from './components/search.js?v=69369686';
+import { renderGamePage } from './components/game-page.js?v=643e40eb';
+import { renderHomePage } from './components/home.js?v=0853de8c';
+import { renderSearchPage } from './components/search.js?v=594f0fc3';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=742a5b4d';
-import { renderHomePage } from './components/home.js?v=4f9ad0e8';
-import { renderSearchPage } from './components/search.js?v=36738329';
+import { renderGamePage } from './components/game-page.js?v=9db37d6c';
+import { renderHomePage } from './components/home.js?v=14eed411';
+import { renderSearchPage } from './components/search.js?v=9b8500d5';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=96e2a103';
-import { renderHomePage } from './components/home.js?v=0e6c76c2';
-import { renderSearchPage } from './components/search.js?v=ed9fc30e';
+import { renderGamePage } from './components/game-page.js?v=5c1d4494';
+import { renderHomePage } from './components/home.js?v=230e8f57';
+import { renderSearchPage } from './components/search.js?v=a30bff33';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=cfe9a4ee';
-import { renderHomePage } from './components/home.js?v=b9fcb08d';
-import { renderSearchPage } from './components/search.js?v=f68f83d2';
+import { renderGamePage } from './components/game-page.js?v=c5c859b7';
+import { renderHomePage } from './components/home.js?v=0b704f24';
+import { renderSearchPage } from './components/search.js?v=69369686';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/index/main.js
+++ b/js/index/main.js
@@ -93,9 +93,21 @@ import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=3e34559
   const KNOWN_TIERS = new Set(['platinum', 'gold', 'silver', 'bronze', 'borked']);
   const STORE_LABEL = { gog: 'GOG', epic: 'Epic', steam: 'Steam' };
   const STORE_PILL_CLASS = { gog: 'game-card-store-pill--gog', epic: 'game-card-store-pill--epic', steam: 'game-card-store-pill--steam' };
+  function storeColorClass(appType) {
+    const t = appType || 'steam';
+    return STORE_PILL_CLASS[t] || 'game-card-store-pill--steam';
+  }
   function storePill(appType) {
     const t = appType || 'steam';
-    return `<span class="game-card-store-pill ${STORE_PILL_CLASS[t] || 'game-card-store-pill--steam'}">${STORE_LABEL[t] || 'Steam'}</span>`;
+    const label = STORE_LABEL[t] || 'Steam';
+    const cls = storeColorClass(t);
+    return `<span class="game-card-store-pill ${cls}">${label}</span>`;
+  }
+  function storeTag(appType) {
+    const t = appType || 'steam';
+    const label = STORE_LABEL[t] || 'Steam';
+    const cls = storeColorClass(t);
+    return `<span class="game-card-store-tag ${cls}">${label}</span>`;
   }
   const SECTION_LABEL = { steam: 'Popular on Steam', gog: 'Popular GOG Games', epic: 'Popular Epic Games' };
   const SECTION_SUB = {
@@ -132,7 +144,10 @@ import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=3e34559
     const rLabel = rated ? RATING_LABEL[rating] : 'Unrated';
     return `
       <a class="pg-card" href="app.html#/app/${encodeURIComponent(g.appId)}">
-        <img class="pg-thumb" src="${img}" data-appid="${g.appId}" alt="" loading="lazy" onerror="window.__steamImgLoad(this)">
+        <div class="pg-thumb-wrap">
+          <img class="pg-thumb" src="${img}" data-appid="${g.appId}" alt="" loading="lazy" onerror="window.__steamImgLoad(this)">
+          ${storeTag(g.appType)}
+        </div>
         <div class="pg-info">
           <div class="pg-title">${esc(g.title)}</div>
           ${peak ? `<div class="pg-sub">${peak} peak players</div>` : ''}

--- a/js/index/main.js
+++ b/js/index/main.js
@@ -90,11 +90,26 @@ import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=3e34559
   }
 
   const RATING_LABEL = { platinum: 'Platinum', gold: 'Gold', silver: 'Silver', bronze: 'Bronze', borked: 'Borked' };
-  // Tiers that count as a real compatibility rating. Anything else (catalog,
-  // pending, empty) is a title we list but have no reports for yet.
   const KNOWN_TIERS = new Set(['platinum', 'gold', 'silver', 'bronze', 'borked']);
+  const SECTION_LABEL = { steam: 'Popular on Steam', gog: 'Popular GOG Games', epic: 'Popular Epic Games' };
+  const SECTION_SUB = {
+    steam: "Steam's most-played games and how they run on Linux through Proton.",
+    gog: 'GOG catalog games and how they run on Linux.',
+    epic: 'Epic Games Store titles and how they run on Linux.',
+  };
 
   let currentLayout = 'grid';
+  let currentStore = 'steam';
+  let searchIndexCache = null;
+
+  async function loadSearchIndex() {
+    if (searchIndexCache) return searchIndexCache;
+    try {
+      const resp = await fetch('search-index.json');
+      if (resp.ok) searchIndexCache = await resp.json();
+    } catch (_) {}
+    return searchIndexCache || [];
+  }
 
   function pgCardHtml(g) {
     if (currentLayout === 'list') return pgListRowHtml(g);
@@ -139,10 +154,6 @@ import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=3e34559
       return;
     }
 
-    // Split into rated games and unrated titles that lack reports
-    // (catalog/pending). Two independent filter buttons drive the view:
-    // "Rated" (on by default) and "Not Rated" (off by default). Any
-    // combination is allowed, including both on or both off.
     const ratedGames = games.filter((g) => KNOWN_TIERS.has(String(g.rating || '').toLowerCase()));
     const unratedGames = games.filter((g) => !KNOWN_TIERS.has(String(g.rating || '').toLowerCase()));
     console.debug('[popular-games] loaded most_played.json', {
@@ -163,12 +174,27 @@ import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=3e34559
     const state = { rated: true, unrated: false };
     let shownCount = PAGE_SIZE;
 
-    // The combined list of games to show for the current filter state.
+    // Build the game list for the current store + rating filter state.
+    // Steam uses most_played.json. GOG/Epic use the search index filtered by
+    // appType so all catalog stubs show, including games with 0 reports.
     function currentList() {
-      return [
-        ...(state.rated ? ratedGames : []),
-        ...(state.unrated ? unratedGames : []),
-      ];
+      if (currentStore === 'steam') {
+        return [
+          ...(state.rated ? ratedGames : []),
+          ...(state.unrated ? unratedGames : []),
+        ];
+      }
+      return (searchIndexCache || [])
+        .filter(row => row[5] === currentStore)
+        .filter(row => {
+          const tier = String(row[2] || '').toLowerCase();
+          const rated = KNOWN_TIERS.has(tier);
+          if (state.rated && !state.unrated) return rated;
+          if (state.unrated && !state.rated) return !rated;
+          return true; // both or neither -> show all
+        })
+        .sort((a, b) => (a[1] || '').localeCompare(b[1] || ''))
+        .map(row => ({ appId: row[0], title: row[1], rating: row[2] || '', appType: row[5] }));
     }
 
     function renderPopular() {
@@ -189,8 +215,7 @@ import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=3e34559
       }
     }
 
-    // Rated / Not Rated are mutually exclusive (either-or): selecting one
-    // deselects the other, and exactly one is always active.
+    // Rated / Not Rated are mutually exclusive (either-or).
     function selectFilter(key) {
       state.rated = key === 'rated';
       state.unrated = key === 'unrated';
@@ -198,11 +223,33 @@ import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=3e34559
       unratedBtn?.classList.toggle('pg-filter--active', state.unrated);
       ratedBtn?.setAttribute('aria-pressed', String(state.rated));
       unratedBtn?.setAttribute('aria-pressed', String(state.unrated));
-      shownCount = PAGE_SIZE; // restart paging when the filter changes
+      shownCount = PAGE_SIZE;
       renderPopular();
     }
     ratedBtn?.addEventListener('click', () => selectFilter('rated'));
     unratedBtn?.addEventListener('click', () => selectFilter('unrated'));
+
+    // Store filter: Steam uses most_played; GOG/Epic lazy-load the search index.
+    async function selectStore(store) {
+      currentStore = store;
+      document.querySelectorAll('.pg-store-btn').forEach(b => {
+        b.classList.toggle('pg-filter--active', b.dataset.store === store);
+      });
+      const labelEl = document.getElementById('pg-section-label');
+      const subEl = document.getElementById('pg-sub');
+      if (labelEl) labelEl.textContent = SECTION_LABEL[store] || 'Popular Games';
+      if (subEl) subEl.textContent = SECTION_SUB[store] || '';
+      if (store !== 'steam') {
+        list.innerHTML = '<div class="pg-empty">Loading...</div>';
+        await loadSearchIndex();
+        console.debug('[popular-games] search-index loaded for store', { store, entries: (searchIndexCache || []).length });
+      }
+      shownCount = PAGE_SIZE;
+      renderPopular();
+    }
+    document.querySelectorAll('.pg-store-btn').forEach(btn => {
+      btn.addEventListener('click', () => selectStore(btn.dataset.store));
+    });
 
     // S/M/L card size (saved preference, shared key with app page)
     const SIZE_KEY = 'pp:grid-size';

--- a/js/index/main.js
+++ b/js/index/main.js
@@ -91,6 +91,12 @@ import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=3e34559
 
   const RATING_LABEL = { platinum: 'Platinum', gold: 'Gold', silver: 'Silver', bronze: 'Bronze', borked: 'Borked' };
   const KNOWN_TIERS = new Set(['platinum', 'gold', 'silver', 'bronze', 'borked']);
+  const STORE_LABEL = { gog: 'GOG', epic: 'Epic', steam: 'Steam' };
+  const STORE_PILL_CLASS = { gog: 'game-card-store-pill--gog', epic: 'game-card-store-pill--epic', steam: 'game-card-store-pill--steam' };
+  function storePill(appType) {
+    const t = appType || 'steam';
+    return `<span class="game-card-store-pill ${STORE_PILL_CLASS[t] || 'game-card-store-pill--steam'}">${STORE_LABEL[t] || 'Steam'}</span>`;
+  }
   const SECTION_LABEL = { steam: 'Popular on Steam', gog: 'Popular GOG Games', epic: 'Popular Epic Games' };
   const SECTION_SUB = {
     steam: "Steam's most-played games and how they run on Linux through Proton.",
@@ -131,7 +137,10 @@ import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=3e34559
           <div class="pg-title">${esc(g.title)}</div>
           ${peak ? `<div class="pg-sub">${peak} peak players</div>` : ''}
         </div>
-        <span class="pg-badge ${badgeClass}">${rLabel}</span>
+        <div class="pg-right">
+          <span class="pg-badge ${badgeClass}">${rLabel}</span>
+          ${storePill(g.appType)}
+        </div>
       </a>`;
   }
 
@@ -143,7 +152,7 @@ import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=3e34559
     return `<a class="pg-list-row" href="app.html#/app/${encodeURIComponent(g.appId)}">
       <span class="pg-list-tier pg-badge ${rated ? `pg-${rating}` : 'pg-unrated'}">${rLabel}</span>
       <span class="pg-list-title">${esc(g.title)}</span>
-      <span class="pg-list-meta">${peak ? peak + ' peak' : ''}</span>
+      <span class="pg-list-meta">${storePill(g.appType)}${peak ? ' ' + peak + ' peak' : ''}</span>
     </a>`;
   }
 

--- a/js/index/main.js
+++ b/js/index/main.js
@@ -224,10 +224,37 @@ import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=3e34559
       ratedBtn?.setAttribute('aria-pressed', String(state.rated));
       unratedBtn?.setAttribute('aria-pressed', String(state.unrated));
       shownCount = PAGE_SIZE;
+      updateFilterBadge();
       renderPopular();
     }
     ratedBtn?.addEventListener('click', () => selectFilter('rated'));
     unratedBtn?.addEventListener('click', () => selectFilter('unrated'));
+
+    // Filters popover toggle.
+    const filterWrap = document.getElementById('pg-filter-wrap');
+    const filterToggle = document.getElementById('pg-filter-toggle');
+    const filterPanel = document.getElementById('pg-filter-panel');
+    if (filterToggle && filterPanel) {
+      filterToggle.addEventListener('click', (e) => {
+        e.stopPropagation();
+        const open = filterPanel.classList.toggle('open');
+        filterToggle.setAttribute('aria-expanded', String(open));
+      });
+      document.addEventListener('click', (e) => {
+        if (filterWrap && !filterWrap.contains(e.target)) {
+          filterPanel.classList.remove('open');
+          filterToggle.setAttribute('aria-expanded', 'false');
+        }
+      });
+    }
+
+    function updateFilterBadge() {
+      const badge = document.getElementById('pg-filter-badge');
+      const btn = document.getElementById('pg-filter-toggle');
+      const nonDefault = (currentStore !== 'steam' ? 1 : 0) + (state.unrated ? 1 : 0);
+      if (badge) { badge.textContent = String(nonDefault); badge.hidden = nonDefault === 0; }
+      btn?.classList.toggle('has-filters', nonDefault > 0);
+    }
 
     // Store filter: Steam uses most_played; GOG/Epic lazy-load the search index.
     async function selectStore(store) {
@@ -244,6 +271,7 @@ import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=3e34559
         await loadSearchIndex();
         console.debug('[popular-games] search-index loaded for store', { store, entries: (searchIndexCache || []).length });
       }
+      updateFilterBadge();
       shownCount = PAGE_SIZE;
       renderPopular();
     }

--- a/js/index/main.js
+++ b/js/index/main.js
@@ -101,6 +101,11 @@ import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=3e34559
   let currentLayout = 'grid';
   let currentStore = 'steam';
   let searchIndexCache = null;
+  let steamPeakByTitle = new Map();
+
+  function normTitle(s) {
+    return String(s || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+  }
 
   async function loadSearchIndex() {
     if (searchIndexCache) return searchIndexCache;
@@ -156,6 +161,7 @@ import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=3e34559
 
     const ratedGames = games.filter((g) => KNOWN_TIERS.has(String(g.rating || '').toLowerCase()));
     const unratedGames = games.filter((g) => !KNOWN_TIERS.has(String(g.rating || '').toLowerCase()));
+    steamPeakByTitle = new Map(games.map(g => [normTitle(g.title), g.peak || 0]));
     console.debug('[popular-games] loaded most_played.json', {
       total: games.length, rated: ratedGames.length, unrated: unratedGames.length, source: 'most_played.json',
     });
@@ -193,7 +199,16 @@ import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=3e34559
           if (state.unrated && !state.rated) return !rated;
           return true; // both or neither -> show all
         })
-        .sort((a, b) => (a[1] || '').localeCompare(b[1] || ''))
+        .sort((a, b) => {
+          // prefer Steam title match (borrows peak player rank), then report count, then alpha
+          const peakA = steamPeakByTitle.get(normTitle(a[1])) || 0;
+          const peakB = steamPeakByTitle.get(normTitle(b[1])) || 0;
+          if (peakB !== peakA) return peakB - peakA;
+          const countA = (a[3] || 0) + (a[4] || 0);
+          const countB = (b[3] || 0) + (b[4] || 0);
+          if (countB !== countA) return countB - countA;
+          return (a[1] || '').localeCompare(b[1] || '');
+        })
         .map(row => ({ appId: row[0], title: row[1], rating: row[2] || '', appType: row[5] }));
     }
 

--- a/js/index/main.js
+++ b/js/index/main.js
@@ -117,7 +117,7 @@ import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=3e34559
   };
 
   let currentLayout = 'grid';
-  let currentStore = 'steam';
+  let storeSel = new Set(['steam']); // multi-select store filter; defaults to Steam
   let searchIndexCache = null;
   let steamPeakByTitle = new Map();
 
@@ -204,36 +204,40 @@ import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=3e34559
     const state = { rated: true, unrated: false };
     let shownCount = PAGE_SIZE;
 
-    // Build the game list for the current store + rating filter state.
-    // Steam uses most_played.json. GOG/Epic use the search index filtered by
-    // appType so all catalog stubs show, including games with 0 reports.
+    // Build the game list for the selected stores + rating filter state. Store
+    // is multi-select: Steam pulls from most_played.json, GOG/Epic pull from the
+    // search index filtered by appType (so catalog stubs with 0 reports show).
+    // Results from all selected stores are merged and ranked together.
+    function ratingPasses(rated) {
+      // Both selected or neither selected -> show all; otherwise honor the one.
+      if (state.rated && !state.unrated) return rated;
+      if (state.unrated && !state.rated) return !rated;
+      return true;
+    }
     function currentList() {
-      if (currentStore === 'steam') {
-        return [
-          ...(state.rated ? ratedGames : []),
-          ...(state.unrated ? unratedGames : []),
-        ];
+      const out = [];
+      if (storeSel.has('steam')) {
+        if (state.rated || (!state.rated && !state.unrated)) out.push(...ratedGames);
+        if (state.unrated || (!state.rated && !state.unrated)) out.push(...unratedGames);
       }
-      return (searchIndexCache || [])
-        .filter(row => row[5] === currentStore)
-        .filter(row => {
-          const tier = String(row[2] || '').toLowerCase();
-          const rated = KNOWN_TIERS.has(tier);
-          if (state.rated && !state.unrated) return rated;
-          if (state.unrated && !state.rated) return !rated;
-          return true; // both or neither -> show all
-        })
-        .sort((a, b) => {
-          // prefer Steam title match (borrows peak player rank), then report count, then alpha
-          const peakA = steamPeakByTitle.get(normTitle(a[1])) || 0;
-          const peakB = steamPeakByTitle.get(normTitle(b[1])) || 0;
-          if (peakB !== peakA) return peakB - peakA;
-          const countA = (a[3] || 0) + (a[4] || 0);
-          const countB = (b[3] || 0) + (b[4] || 0);
-          if (countB !== countA) return countB - countA;
-          return (a[1] || '').localeCompare(b[1] || '');
-        })
-        .map(row => ({ appId: row[0], title: row[1], rating: row[2] || '', appType: row[5] }));
+      const nonSteam = [...storeSel].filter(s => s !== 'steam');
+      if (nonSteam.length) {
+        const rows = (searchIndexCache || [])
+          .filter(row => nonSteam.includes(row[5]))
+          .filter(row => ratingPasses(KNOWN_TIERS.has(String(row[2] || '').toLowerCase())))
+          .map(row => ({
+            appId: row[0], title: row[1], rating: row[2] || '', appType: row[5],
+            protondbCount: row[3] || 0, pulseCount: row[4] || 0,
+          }));
+        out.push(...rows);
+      }
+      // Rank the merged list: Steam peak-player rank first, then report count,
+      // then alphabetical. Steam games carry peak directly; non-Steam borrow it
+      // from a title match in the Steam most-played map.
+      const peakOf = g => g.peak || steamPeakByTitle.get(normTitle(g.title)) || 0;
+      const countOf = g => (g.protondbCount || 0) + (g.pulseCount || 0);
+      return out.sort((a, b) =>
+        peakOf(b) - peakOf(a) || countOf(b) - countOf(a) || (a.title || '').localeCompare(b.title || ''));
     }
 
     function renderPopular() {
@@ -254,20 +258,23 @@ import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=3e34559
       }
     }
 
-    // Rated / Not Rated are mutually exclusive (either-or).
-    function selectFilter(key) {
-      state.rated = key === 'rated';
-      state.unrated = key === 'unrated';
+    // Rated / Not Rated are independent toggles (multi-select). Both on or both
+    // off both mean "show all", matching the browse page tier behavior.
+    function syncRatingButtons() {
       ratedBtn?.classList.toggle('pg-filter--active', state.rated);
       unratedBtn?.classList.toggle('pg-filter--active', state.unrated);
       ratedBtn?.setAttribute('aria-pressed', String(state.rated));
       unratedBtn?.setAttribute('aria-pressed', String(state.unrated));
+    }
+    function toggleRating(key) {
+      state[key] = !state[key];
+      syncRatingButtons();
       shownCount = PAGE_SIZE;
       updateFilterBadge();
       renderPopular();
     }
-    ratedBtn?.addEventListener('click', () => selectFilter('rated'));
-    unratedBtn?.addEventListener('click', () => selectFilter('unrated'));
+    ratedBtn?.addEventListener('click', () => toggleRating('rated'));
+    unratedBtn?.addEventListener('click', () => toggleRating('unrated'));
 
     // Filters popover toggle.
     const filterWrap = document.getElementById('pg-filter-wrap');
@@ -290,43 +297,44 @@ import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=3e34559
     function updateFilterBadge() {
       const badge = document.getElementById('pg-filter-badge');
       const btn = document.getElementById('pg-filter-toggle');
-      const nonDefault = (currentStore !== 'steam' ? 1 : 0) + (state.unrated ? 1 : 0);
+      // Store deviates from the default (Steam only); rating deviates when it is
+      // not the default "Rated only".
+      const storeDev = (storeSel.size === 1 && storeSel.has('steam')) ? 0 : storeSel.size;
+      const ratingDev = (state.unrated ? 1 : 0) + (state.rated ? 0 : 1);
+      const nonDefault = storeDev + ratingDev;
       if (badge) { badge.textContent = String(nonDefault); badge.hidden = nonDefault === 0; }
       btn?.classList.toggle('has-filters', nonDefault > 0);
     }
 
-    // Store filter: Steam uses most_played; GOG/Epic lazy-load the search index.
-    async function selectStore(store) {
-      currentStore = store;
-      document.querySelectorAll('.pg-store-btn').forEach(b => {
-        b.classList.toggle('pg-filter--active', b.dataset.store === store);
-      });
+    // Label/sub reflect a single selected store; multi-select shows a generic title.
+    function syncSectionLabel() {
       const labelEl = document.getElementById('pg-section-label');
       const subEl = document.getElementById('pg-sub');
-      if (labelEl) labelEl.textContent = SECTION_LABEL[store] || 'Popular Games';
-      if (subEl) subEl.textContent = SECTION_SUB[store] || '';
-      // Non-Steam catalog stubs are mostly unrated -- default to showing all
-      // so the section isn't empty; Steam keeps the "Rated only" default.
-      if (store !== 'steam') {
-        state.rated = true;
-        state.unrated = true;
+      const only = storeSel.size === 1 ? [...storeSel][0] : null;
+      if (labelEl) labelEl.textContent = (only && SECTION_LABEL[only]) || 'Popular Games';
+      if (subEl) subEl.textContent = (only && SECTION_SUB[only]) || '';
+    }
+
+    // Store filter is multi-select. Steam uses most_played; GOG/Epic lazy-load
+    // the search index. Selecting any non-Steam store loads the index once.
+    async function toggleStore(store) {
+      if (storeSel.has(store)) storeSel.delete(store);
+      else storeSel.add(store);
+      document.querySelectorAll('.pg-store-btn').forEach(b => {
+        b.classList.toggle('pg-filter--active', storeSel.has(b.dataset.store));
+      });
+      syncSectionLabel();
+      if ([...storeSel].some(s => s !== 'steam') && !searchIndexCache) {
         list.innerHTML = '<div class="pg-empty">Loading...</div>';
         await loadSearchIndex();
-        console.debug('[popular-games] search-index loaded for store', { store, entries: (searchIndexCache || []).length });
-      } else {
-        state.rated = true;
-        state.unrated = false;
+        console.debug('[popular-games] search-index loaded', { stores: [...storeSel], entries: (searchIndexCache || []).length });
       }
-      ratedBtn?.classList.toggle('pg-filter--active', state.rated);
-      unratedBtn?.classList.toggle('pg-filter--active', state.unrated);
-      ratedBtn?.setAttribute('aria-pressed', String(state.rated));
-      unratedBtn?.setAttribute('aria-pressed', String(state.unrated));
       updateFilterBadge();
       shownCount = PAGE_SIZE;
       renderPopular();
     }
     document.querySelectorAll('.pg-store-btn').forEach(btn => {
-      btn.addEventListener('click', () => selectStore(btn.dataset.store));
+      btn.addEventListener('click', () => toggleStore(btn.dataset.store));
     });
 
     // S/M/L card size (saved preference, shared key with app page)

--- a/js/index/main.js
+++ b/js/index/main.js
@@ -281,11 +281,22 @@ import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=3e34559
       const subEl = document.getElementById('pg-sub');
       if (labelEl) labelEl.textContent = SECTION_LABEL[store] || 'Popular Games';
       if (subEl) subEl.textContent = SECTION_SUB[store] || '';
+      // Non-Steam catalog stubs are mostly unrated -- default to showing all
+      // so the section isn't empty; Steam keeps the "Rated only" default.
       if (store !== 'steam') {
+        state.rated = true;
+        state.unrated = true;
         list.innerHTML = '<div class="pg-empty">Loading...</div>';
         await loadSearchIndex();
         console.debug('[popular-games] search-index loaded for store', { store, entries: (searchIndexCache || []).length });
+      } else {
+        state.rated = true;
+        state.unrated = false;
       }
+      ratedBtn?.classList.toggle('pg-filter--active', state.rated);
+      unratedBtn?.classList.toggle('pg-filter--active', state.unrated);
+      ratedBtn?.setAttribute('aria-pressed', String(state.rated));
+      unratedBtn?.setAttribute('aria-pressed', String(state.unrated));
       updateFilterBadge();
       shownCount = PAGE_SIZE;
       renderPopular();

--- a/js/index/main.js
+++ b/js/index/main.js
@@ -197,8 +197,6 @@ import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=3e34559
     const ratedCountEl = document.getElementById('pg-rated-count');
     const unratedCountEl = document.getElementById('pg-unrated-count');
     const loadMoreEl = document.getElementById('pg-load-more');
-    if (ratedCountEl) ratedCountEl.textContent = String(ratedGames.length);
-    if (unratedCountEl) unratedCountEl.textContent = String(unratedGames.length);
 
     const PAGE_SIZE = 12;
     const state = { rated: true, unrated: false };
@@ -214,13 +212,18 @@ import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=3e34559
       if (state.unrated && !state.rated) return !rated;
       return true;
     }
+    // An empty selection means "All" -> every store.
+    function effectiveStores() {
+      return storeSel.size === 0 ? ['steam', 'gog', 'epic'] : [...storeSel];
+    }
     function currentList() {
+      const stores = effectiveStores();
       const out = [];
-      if (storeSel.has('steam')) {
+      if (stores.includes('steam')) {
         if (state.rated || (!state.rated && !state.unrated)) out.push(...ratedGames);
         if (state.unrated || (!state.rated && !state.unrated)) out.push(...unratedGames);
       }
-      const nonSteam = [...storeSel].filter(s => s !== 'steam');
+      const nonSteam = stores.filter(s => s !== 'steam');
       if (nonSteam.length) {
         const rows = (searchIndexCache || [])
           .filter(row => nonSteam.includes(row[5]))
@@ -238,6 +241,24 @@ import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=3e34559
       const countOf = g => (g.protondbCount || 0) + (g.pulseCount || 0);
       return out.sort((a, b) =>
         peakOf(b) - peakOf(a) || countOf(b) - countOf(a) || (a.title || '').localeCompare(b.title || ''));
+    }
+
+    // Rated / Not Rated chip counts reflect the currently selected stores, not
+    // just Steam. Steam counts come from most_played; GOG/Epic from the index.
+    function updateRatingCounts() {
+      const stores = effectiveStores();
+      let rated = 0, unrated = 0;
+      if (stores.includes('steam')) { rated += ratedGames.length; unrated += unratedGames.length; }
+      const nonSteam = stores.filter(s => s !== 'steam');
+      if (nonSteam.length && searchIndexCache) {
+        for (const row of searchIndexCache) {
+          if (!nonSteam.includes(row[5])) continue;
+          if (KNOWN_TIERS.has(String(row[2] || '').toLowerCase())) rated++; else unrated++;
+        }
+      }
+      if (ratedCountEl) ratedCountEl.textContent = String(rated);
+      if (unratedCountEl) unratedCountEl.textContent = String(unrated);
+      console.debug('[popular-games] rating counts updated', { stores, rated, unrated, source: nonSteam.length ? 'most_played+search-index' : 'most_played' });
     }
 
     function renderPopular() {
@@ -318,17 +339,27 @@ import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=3e34559
     // Store filter is multi-select. Steam uses most_played; GOG/Epic lazy-load
     // the search index. Selecting any non-Steam store loads the index once.
     async function toggleStore(store) {
-      if (storeSel.has(store)) storeSel.delete(store);
-      else storeSel.add(store);
+      // "All" clears the specific selections (empty set == all stores). Picking a
+      // specific store clears All; deselecting the last specific falls back to All.
+      if (store === 'all') {
+        storeSel.clear();
+      } else if (storeSel.has(store)) {
+        storeSel.delete(store);
+      } else {
+        storeSel.add(store);
+      }
+      const allActive = storeSel.size === 0;
       document.querySelectorAll('.pg-store-btn').forEach(b => {
-        b.classList.toggle('pg-filter--active', storeSel.has(b.dataset.store));
+        const v = b.dataset.store;
+        b.classList.toggle('pg-filter--active', v === 'all' ? allActive : storeSel.has(v));
       });
       syncSectionLabel();
-      if ([...storeSel].some(s => s !== 'steam') && !searchIndexCache) {
+      if (effectiveStores().some(s => s !== 'steam') && !searchIndexCache) {
         list.innerHTML = '<div class="pg-empty">Loading...</div>';
         await loadSearchIndex();
-        console.debug('[popular-games] search-index loaded', { stores: [...storeSel], entries: (searchIndexCache || []).length });
+        console.debug('[popular-games] search-index loaded', { stores: effectiveStores(), entries: (searchIndexCache || []).length });
       }
+      updateRatingCounts();
       updateFilterBadge();
       shownCount = PAGE_SIZE;
       renderPopular();
@@ -379,6 +410,7 @@ import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=3e34559
       });
     });
 
+    updateRatingCounts(); // seed the rating chip counts for the default (Steam)
     applySize(savedSize());
     applyLayout(savedLayout());
   } catch (err) {

--- a/js/index/main.js
+++ b/js/index/main.js
@@ -316,7 +316,7 @@ import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=3e34559
 
     // S/M/L card size (saved preference, shared key with app page)
     const SIZE_KEY = 'pp:grid-size';
-    const SIZES = ['sm', 'md', 'lg'];
+    const SIZES = ['sm', 'md', 'lg', 'xl'];
     function savedSize() {
       try { const s = localStorage.getItem(SIZE_KEY); return SIZES.includes(s) ? s : 'md'; } catch { return 'md'; }
     }

--- a/js/lib/topbar.js
+++ b/js/lib/topbar.js
@@ -361,6 +361,10 @@
   // (avoids a flash of the wrong mode / running animations).
   initTheme();
   initMotion();
+  // Store pill preference: hide badges globally when turned off in options.
+  if (localStorage.getItem('pp:store-pill') === 'off') {
+    document.documentElement.setAttribute('data-store-pill', 'off');
+  }
 
   // inject favicon if the page doesn't already have one
   if (!document.querySelector('link[rel="icon"]')) {

--- a/js/lib/topbar.js
+++ b/js/lib/topbar.js
@@ -361,9 +361,9 @@
   // (avoids a flash of the wrong mode / running animations).
   initTheme();
   initMotion();
-  // Store pill preference: hide badges globally when turned off in options.
-  if (localStorage.getItem('pp:store-pill') === 'off') {
-    document.documentElement.setAttribute('data-store-pill', 'off');
+  // Store pill position preference: 'art' = thumbnail overlay, 'right' (default) = rating column.
+  if (localStorage.getItem('pp:store-pill-pos') === 'art') {
+    document.documentElement.setAttribute('data-store-pill-pos', 'art');
   }
 
   // inject favicon if the page doesn't already have one

--- a/js/options/main.js
+++ b/js/options/main.js
@@ -41,3 +41,26 @@ if (toggle) {
     console.log('[options] localStorage now:', localStorage.getItem(MOTION_KEY));
   });
 }
+
+// Store pill preference: show/hide the store badge on game cards site-wide.
+const STORE_PILL_KEY = 'pp:store-pill';
+function applyStorePill(on) {
+  if (on) {
+    document.documentElement.removeAttribute('data-store-pill');
+  } else {
+    document.documentElement.setAttribute('data-store-pill', 'off');
+  }
+}
+const storePillToggle = document.getElementById('opt-store-pill');
+if (storePillToggle) {
+  const stored = localStorage.getItem(STORE_PILL_KEY);
+  const on = stored !== 'off';
+  storePillToggle.checked = on;
+  applyStorePill(on);
+  storePillToggle.addEventListener('change', () => {
+    const val = storePillToggle.checked ? 'on' : 'off';
+    localStorage.setItem(STORE_PILL_KEY, val);
+    applyStorePill(storePillToggle.checked);
+    console.log('[options] store-pill:', val);
+  });
+}

--- a/js/options/main.js
+++ b/js/options/main.js
@@ -66,3 +66,21 @@ if (storePillGroup) {
   });
   applyStorePillPos(stored);
 }
+
+// Reports per page: how many cards app.html preloads per section before "Load
+// more". Stored as a string number; app.html reads it on load. Default 50.
+const LOAD_COUNT_KEY = 'pp:load-count';
+const LOAD_COUNTS = ['50', '100', '150', '200'];
+const loadCountGroup = document.getElementById('opt-load-count');
+if (loadCountGroup) {
+  const stored = LOAD_COUNTS.includes(localStorage.getItem(LOAD_COUNT_KEY)) ? localStorage.getItem(LOAD_COUNT_KEY) : '50';
+  loadCountGroup.querySelectorAll('input[type="radio"]').forEach(r => {
+    r.checked = r.value === stored;
+    r.addEventListener('change', () => {
+      if (r.checked) {
+        localStorage.setItem(LOAD_COUNT_KEY, r.value);
+        console.log('[options] load-count:', r.value);
+      }
+    });
+  });
+}

--- a/js/options/main.js
+++ b/js/options/main.js
@@ -42,25 +42,27 @@ if (toggle) {
   });
 }
 
-// Store pill preference: show/hide the store badge on game cards site-wide.
-const STORE_PILL_KEY = 'pp:store-pill';
-function applyStorePill(on) {
-  if (on) {
-    document.documentElement.removeAttribute('data-store-pill');
+// Store pill position: 'right' (inline with rating) or 'art' (thumbnail overlay).
+const STORE_PILL_POS_KEY = 'pp:store-pill-pos';
+function applyStorePillPos(pos) {
+  if (pos === 'art') {
+    document.documentElement.setAttribute('data-store-pill-pos', 'art');
   } else {
-    document.documentElement.setAttribute('data-store-pill', 'off');
+    document.documentElement.removeAttribute('data-store-pill-pos');
   }
 }
-const storePillToggle = document.getElementById('opt-store-pill');
-if (storePillToggle) {
-  const stored = localStorage.getItem(STORE_PILL_KEY);
-  const on = stored !== 'off';
-  storePillToggle.checked = on;
-  applyStorePill(on);
-  storePillToggle.addEventListener('change', () => {
-    const val = storePillToggle.checked ? 'on' : 'off';
-    localStorage.setItem(STORE_PILL_KEY, val);
-    applyStorePill(storePillToggle.checked);
-    console.log('[options] store-pill:', val);
+const storePillGroup = document.getElementById('opt-store-pill-pos');
+if (storePillGroup) {
+  const stored = localStorage.getItem(STORE_PILL_POS_KEY) || 'right';
+  storePillGroup.querySelectorAll('input[type="radio"]').forEach(r => {
+    r.checked = r.value === stored;
+    r.addEventListener('change', () => {
+      if (r.checked) {
+        localStorage.setItem(STORE_PILL_POS_KEY, r.value);
+        applyStorePillPos(r.value);
+        console.log('[options] store-pill-pos:', r.value);
+      }
+    });
   });
+  applyStorePillPos(stored);
 }

--- a/js/stats/charts.js
+++ b/js/stats/charts.js
@@ -1,7 +1,7 @@
 // Stats page chart renderers.
 
 import { label, fmt, niceCeil, formatAxisLabel, vramLabel, TIER_COLORS } from './utils.js?v=9bcdac4f';
-import { getFilter } from './filters.js?v=e2459da3';
+import { getFilter } from './filters.js?v=a9253694';
 
 // Render N horizontal bar rows sorted descending by count.
 // dataAttr is the data-* attribute name (rating, key) for per-row tinting.

--- a/js/stats/charts.js
+++ b/js/stats/charts.js
@@ -1,7 +1,7 @@
 // Stats page chart renderers.
 
-import { label, fmt, niceCeil, formatAxisLabel, vramLabel, TIER_COLORS } from './utils.js?v=ceb23379';
-import { getFilter } from './filters.js?v=bfe27ee2';
+import { label, fmt, niceCeil, formatAxisLabel, vramLabel, TIER_COLORS } from './utils.js?v=9bcdac4f';
+import { getFilter } from './filters.js?v=e2459da3';
 
 // Render N horizontal bar rows sorted descending by count.
 // dataAttr is the data-* attribute name (rating, key) for per-row tinting.

--- a/js/stats/filters.js
+++ b/js/stats/filters.js
@@ -1,6 +1,6 @@
 // Stats page filter state and UI logic.
 
-import { FILTER_DIMS, dimDef, label, fmt, sum } from './utils.js?v=ceb23379';
+import { FILTER_DIMS, dimDef, label, fmt, sum } from './utils.js?v=9bcdac4f';
 
 // Active filter. Only one dim active at a time (because the cross-tabs
 // we ship only key off one dim), but multiple values within that dim.
@@ -35,6 +35,7 @@ export function applyFilter(stats) {
       cpu:    stats.by_cpu_brand || {},
       os:     stats.by_os_family || {},
       proton: stats.by_proton_type || {},
+      store:  stats.by_store || {},
       source: stats.by_source || {},
       device: stats.by_device_family || {},
       total:  stats.total_reports || 0,
@@ -44,7 +45,7 @@ export function applyFilter(stats) {
   // Filtered: cross-tabs let us pivot rating-by-dim or dim-by-rating.
   // For multi-value within a dim, sum across the selected values.
   const out = {
-    rating: {}, gpu: {}, cpu: {}, os: {}, proton: {}, source: {}, device: {},
+    rating: {}, gpu: {}, cpu: {}, os: {}, proton: {}, store: {}, source: {}, device: {},
     total: 0,
   };
   const vals = Array.from(filter.values);

--- a/js/stats/main.js
+++ b/js/stats/main.js
@@ -10,7 +10,7 @@ import {
 import {
   renderBars, renderFreshness, renderFramegen, renderDonut,
   renderSparkline, renderTopGames, renderRatingsTrend,
-} from './charts.js?v=95916069';
+} from './charts.js?v=81765579';
 
 const root = document.getElementById('stats-root');
 const metaEl = document.getElementById('stats-meta');

--- a/js/stats/main.js
+++ b/js/stats/main.js
@@ -1,16 +1,16 @@
 // Entry module for stats.html. Orchestrates data fetch, filter state, and
 // chart rendering by delegating to utils, filters, and charts modules.
 
-import { FILTER_DIMS, dimDef, label, fmt } from './utils.js?v=ceb23379';
+import { FILTER_DIMS, dimDef, label, fmt } from './utils.js?v=9bcdac4f';
 import {
   applyFilter, getFilter, getOpenDropdown, setOpenDropdown,
   renderDropdownButton, toggleFilterValue, clearFilter,
   setFilterChangeCallback, restoreFilterFromUrl,
-} from './filters.js?v=bfe27ee2';
+} from './filters.js?v=a9253694';
 import {
   renderBars, renderFreshness, renderFramegen, renderDonut,
   renderSparkline, renderTopGames, renderRatingsTrend,
-} from './charts.js?v=f5fe3e5f';
+} from './charts.js?v=95916069';
 
 const root = document.getElementById('stats-root');
 const metaEl = document.getElementById('stats-meta');
@@ -113,6 +113,10 @@ function renderAll() {
       </div>
 
       <div class="chart-card">
+        <h3>Store</h3>
+        <div class="bars" id="chart-store"></div>
+      </div>
+      <div class="chart-card">
         <h3>Device family</h3>
         <div class="bars" id="chart-device"></div>
       </div>
@@ -179,6 +183,8 @@ function renderAll() {
     data.os, { limit: 10, filterDim: 'os' });
   renderBars(document.getElementById('chart-proton'),
     data.proton, { limit: 10 });
+  renderBars(document.getElementById('chart-store'),
+    data.store, { filterDim: 'store' });
   renderBars(document.getElementById('chart-device'),
     data.device, { filterDim: 'device' });
 

--- a/js/stats/utils.js
+++ b/js/stats/utils.js
@@ -7,6 +7,7 @@ export const FILTER_DIMS = [
   { id: 'cpu',    label: 'CPU',     statsKey: 'by_cpu_brand',      crossKey: 'by_rating_x_cpu_brand' },
   { id: 'os',     label: 'OS',      statsKey: 'by_os_family',      crossKey: 'by_rating_x_os_family' },
   { id: 'device', label: 'Device',  statsKey: 'by_device_family',  crossKey: 'by_rating_x_device_family' },
+  { id: 'store',  label: 'Store',   statsKey: 'by_store',          crossKey: 'by_rating_x_store' },
   { id: 'source', label: 'Source',  statsKey: 'by_source',         crossKey: 'by_rating_x_source' },
   { id: 'rating', label: 'Rating',  statsKey: 'by_rating',         crossKey: null },
 ];
@@ -26,6 +27,7 @@ const PRETTY = {
   'proton-tkg': 'Proton-TKG', 'proton-next': 'Proton Next',
   'steam-linux-runtime': 'Steam Linux Runtime',
   native: 'Native',
+  steam: 'Steam', gog: 'GOG', epic: 'Epic',
   protondb: 'ProtonDB', pulse: 'Pulse',
   'steam-deck-lcd': 'Steam Deck LCD',
   'steam-deck-oled': 'Steam Deck OLED',

--- a/options.html
+++ b/options.html
@@ -11,8 +11,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
-<link rel="stylesheet" href="css/shared/site.css?v=86052a10">
-<link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
+<link rel="stylesheet" href="css/shared/site.css?v=2b59a85c">
+<link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/options/options.css?v=1df0e588">
 </head>
 <body>
@@ -46,6 +46,20 @@
           <span class="option-switch-track"></span>
         </label>
       </div>
+      <div class="option-row">
+        <div class="option-text">
+          <div class="option-title">Store badges on cards</div>
+          <div class="option-desc">
+            Show a colored pill on each game card indicating the store (Steam, GOG, Epic).
+            On desktop it sits inline with the rating; on mobile it wraps to a second row.
+            Turn off to keep cards compact.
+          </div>
+        </div>
+        <label class="option-switch">
+          <input type="checkbox" id="opt-store-pill" checked>
+          <span class="option-switch-track"></span>
+        </label>
+      </div>
     </div>
 
   </div>
@@ -59,8 +73,8 @@
   <a href="terms.html">Terms</a>
 </footer>
 
-<script src="js/lib/topbar.js?v=46cb7ea1"></script>
+<script src="js/lib/topbar.js?v=1f85d476"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/options/main.js?v=c4413624"></script>
+<script type="module" src="js/options/main.js?v=d894750a"></script>
 </body>
 </html>

--- a/options.html
+++ b/options.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=86052a10">
-<link rel="stylesheet" href="css/shared/cards.css?v=eab020ab">
+<link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
 <link rel="stylesheet" href="css/options/options.css?v=1df0e588">
 </head>
 <body>

--- a/options.html
+++ b/options.html
@@ -66,6 +66,35 @@
           </label>
         </div>
       </div>
+
+      <div class="option-row option-row--block">
+        <div class="option-text">
+          <div class="option-title">Reports per page</div>
+          <div class="option-desc">
+            How many game cards to preload in each section when browsing reports
+            before the "Load more" button. Higher values show more at once but
+            take a little longer to render.
+          </div>
+        </div>
+        <div class="option-radio-group" id="opt-load-count">
+          <label class="option-radio">
+            <input type="radio" name="load-count" value="50" checked>
+            <span>50</span>
+          </label>
+          <label class="option-radio">
+            <input type="radio" name="load-count" value="100">
+            <span>100</span>
+          </label>
+          <label class="option-radio">
+            <input type="radio" name="load-count" value="150">
+            <span>150</span>
+          </label>
+          <label class="option-radio">
+            <input type="radio" name="load-count" value="200">
+            <span>200</span>
+          </label>
+        </div>
+      </div>
     </div>
 
   </div>
@@ -81,6 +110,6 @@
 
 <script src="js/lib/topbar.js?v=50b75e70"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/options/main.js?v=99e9a767"></script>
+<script type="module" src="js/options/main.js?v=fbbb541e"></script>
 </body>
 </html>

--- a/options.html
+++ b/options.html
@@ -11,9 +11,9 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
-<link rel="stylesheet" href="css/shared/site.css?v=2b59a85c">
+<link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
-<link rel="stylesheet" href="css/options/options.css?v=1df0e588">
+<link rel="stylesheet" href="css/options/options.css?v=11d3971b">
 </head>
 <body>
 
@@ -46,19 +46,25 @@
           <span class="option-switch-track"></span>
         </label>
       </div>
-      <div class="option-row">
+      <div class="option-row option-row--block">
         <div class="option-text">
-          <div class="option-title">Store badges on cards</div>
+          <div class="option-title">Store badge position</div>
           <div class="option-desc">
-            Show a colored pill on each game card indicating the store (Steam, GOG, Epic).
-            On desktop it sits inline with the rating; on mobile it wraps to a second row.
-            Turn off to keep cards compact.
+            Where to show the store badge (Steam, GOG, Epic) on game cards.
+            "On artwork" overlays the thumbnail corner. "On right" places it
+            alongside the rating pill.
           </div>
         </div>
-        <label class="option-switch">
-          <input type="checkbox" id="opt-store-pill" checked>
-          <span class="option-switch-track"></span>
-        </label>
+        <div class="option-radio-group" id="opt-store-pill-pos">
+          <label class="option-radio">
+            <input type="radio" name="store-pill-pos" value="right" checked>
+            <span>On right</span>
+          </label>
+          <label class="option-radio">
+            <input type="radio" name="store-pill-pos" value="art">
+            <span>On artwork</span>
+          </label>
+        </div>
       </div>
     </div>
 
@@ -73,8 +79,8 @@
   <a href="terms.html">Terms</a>
 </footer>
 
-<script src="js/lib/topbar.js?v=1f85d476"></script>
+<script src="js/lib/topbar.js?v=50b75e70"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/options/main.js?v=d894750a"></script>
+<script type="module" src="js/options/main.js?v=99e9a767"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.1",
+  "version": "1.3.0",
   "scripts": {
     "test": "jest",
     "dev": "vite --host --port 5173",

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -10,8 +10,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
-<link rel="stylesheet" href="css/shared/site.css?v=86052a10">
-<link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
+<link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
+<link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=86052a10">
-<link rel="stylesheet" href="css/shared/cards.css?v=eab020ab">
+<link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/privacy.html
+++ b/privacy.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=86052a10">
-<link rel="stylesheet" href="css/shared/cards.css?v=eab020ab">
+<link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
 <link rel="stylesheet" href="css/index/index.css?v=0bdafa7e">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }

--- a/privacy.html
+++ b/privacy.html
@@ -10,9 +10,9 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
-<link rel="stylesheet" href="css/shared/site.css?v=86052a10">
-<link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
-<link rel="stylesheet" href="css/index/index.css?v=ca1427ec">
+<link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
+<link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
+<link rel="stylesheet" href="css/index/index.css?v=07446e4c">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }
@@ -87,7 +87,7 @@
 </div>
 </div>
 
-<script src="js/lib/topbar.js?v=46cb7ea1"></script>
+<script src="js/lib/topbar.js?v=50b75e70"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
-<link rel="stylesheet" href="css/index/index.css?v=96c3d47b">
+<link rel="stylesheet" href="css/index/index.css?v=d6d74d80">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/privacy.html
+++ b/privacy.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=86052a10">
 <link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
-<link rel="stylesheet" href="css/index/index.css?v=0bdafa7e">
+<link rel="stylesheet" href="css/index/index.css?v=ff4b9357">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/privacy.html
+++ b/privacy.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=86052a10">
 <link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
-<link rel="stylesheet" href="css/index/index.css?v=ff4b9357">
+<link rel="stylesheet" href="css/index/index.css?v=ca1427ec">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/privacy.html
+++ b/privacy.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
-<link rel="stylesheet" href="css/index/index.css?v=ca60e7d4">
+<link rel="stylesheet" href="css/index/index.css?v=96c3d47b">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/privacy.html
+++ b/privacy.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
-<link rel="stylesheet" href="css/index/index.css?v=07446e4c">
+<link rel="stylesheet" href="css/index/index.css?v=ca60e7d4">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/profile.html
+++ b/profile.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=86052a10">
-<link rel="stylesheet" href="css/shared/cards.css?v=eab020ab">
+<link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/profile.html
+++ b/profile.html
@@ -10,8 +10,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
-<link rel="stylesheet" href="css/shared/site.css?v=86052a10">
-<link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
+<link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
+<link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>
@@ -289,7 +289,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=46cb7ea1"></script>
+<script src="js/lib/topbar.js?v=50b75e70"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/profile/main.js?v=d49f08ab"></script>
 </body>

--- a/scoring.html
+++ b/scoring.html
@@ -11,8 +11,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
-<link rel="stylesheet" href="css/shared/site.css?v=86052a10">
-<link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
+<link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
+<link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <style>
 h1 {
   font-family: var(--font-display);
@@ -490,7 +490,7 @@ h2 small {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=46cb7ea1"></script>
+<script src="js/lib/topbar.js?v=50b75e70"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/scoring.html
+++ b/scoring.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=86052a10">
-<link rel="stylesheet" href="css/shared/cards.css?v=eab020ab">
+<link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/scripts/pipeline/stats.py
+++ b/scripts/pipeline/stats.py
@@ -18,7 +18,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from .common import log
+from .common import app_type_from_id, log
 
 
 # ── Categorical normalizers ────────────────────────────────────────────────
@@ -273,6 +273,7 @@ def compute_stats(data_output_path: Path) -> dict[str, Any]:
     by_cpu: Counter = Counter()
     by_os: Counter = Counter()
     by_proton: Counter = Counter()
+    by_store: Counter = Counter()
     by_device: Counter = Counter()
     by_year: Counter = Counter()
     by_year_source: dict[str, Counter] = defaultdict(Counter)
@@ -283,6 +284,7 @@ def compute_stats(data_output_path: Path) -> dict[str, Any]:
     by_rating_x_cpu: dict[str, Counter] = defaultdict(Counter)
     by_rating_x_os: dict[str, Counter] = defaultdict(Counter)
     by_rating_x_source: dict[str, Counter] = defaultdict(Counter)
+    by_rating_x_store: dict[str, Counter] = defaultdict(Counter)
     by_rating_x_device: dict[str, Counter] = defaultdict(Counter)
     # Year x rating: enables the "ratings shift over time" chart (% borked dropping, etc.)
     # shape: { "2025": Counter(rating -> count), ... }
@@ -340,6 +342,7 @@ def compute_stats(data_output_path: Path) -> dict[str, Any]:
             os_fam = normalize_os_family(r)
             proton = normalize_proton_type(r)
             device = normalize_device_family(r)
+            store = app_type_from_id(app_id)
 
             by_source[src] += 1
             by_rating[rating] += 1
@@ -347,6 +350,7 @@ def compute_stats(data_output_path: Path) -> dict[str, Any]:
             by_cpu[cpu] += 1
             by_os[os_fam] += 1
             by_proton[proton] += 1
+            by_store[store] += 1
             by_device[device] += 1
             if year.isdigit():
                 by_year[year] += 1
@@ -357,6 +361,7 @@ def compute_stats(data_output_path: Path) -> dict[str, Any]:
             by_rating_x_cpu[cpu][rating] += 1
             by_rating_x_os[os_fam][rating] += 1
             by_rating_x_source[src][rating] += 1
+            by_rating_x_store[store][rating] += 1
             by_rating_x_device[device][rating] += 1
 
             # Framegen: count the response across the relevant cross-tabs. Skip
@@ -456,6 +461,7 @@ def compute_stats(data_output_path: Path) -> dict[str, Any]:
         "by_gpu_vendor": dict(by_gpu),
         "by_cpu_brand": dict(by_cpu),
         "by_os_family": dict(by_os),
+        "by_store": dict(by_store),
         "by_proton_type": dict(by_proton),
         "by_device_family": dict(by_device),
         "by_year": dict(by_year),
@@ -465,6 +471,7 @@ def compute_stats(data_output_path: Path) -> dict[str, Any]:
         "by_rating_x_cpu_brand": flatten_cross(by_rating_x_cpu),
         "by_rating_x_os_family": flatten_cross(by_rating_x_os),
         "by_rating_x_source": flatten_cross(by_rating_x_source),
+        "by_rating_x_store": flatten_cross(by_rating_x_store),
         "by_rating_x_device_family": flatten_cross(by_rating_x_device),
         # Rating shift over time: { "2025": { "platinum": N, "gold": N, ... }, ... }
         # Powers the trend chart that shows compatibility improving year-over-year

--- a/stats.html
+++ b/stats.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/filters.css?v=4e3a1985">
+<link rel="stylesheet" href="css/shared/filters.css?v=cfea13a2">
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <style>
 h1 {

--- a/stats.html
+++ b/stats.html
@@ -11,8 +11,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
-<link rel="stylesheet" href="css/shared/site.css?v=86052a10">
-<link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
+<link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
+<link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <style>
 h1 {
   font-family: var(--font-display);
@@ -709,7 +709,7 @@ h2 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=46cb7ea1"></script>
+<script src="js/lib/topbar.js?v=50b75e70"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/stats.html
+++ b/stats.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/filters.css?v=cfea13a2">
+<link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <style>
 h1 {

--- a/stats.html
+++ b/stats.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=86052a10">
-<link rel="stylesheet" href="css/shared/cards.css?v=eab020ab">
+<link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/stats.html
+++ b/stats.html
@@ -733,6 +733,6 @@ h2 {
 
 </div></div>
 
-<script type="module" src="js/stats/main.js?v=6ed2633c"></script>
+<script type="module" src="js/stats/main.js?v=91b64e42"></script>
 </body>
 </html>

--- a/stats.html
+++ b/stats.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/filters.css?v=3b0c60ff">
+<link rel="stylesheet" href="css/shared/filters.css?v=4e3a1985">
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <style>
 h1 {

--- a/stats.html
+++ b/stats.html
@@ -12,6 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
+<link rel="stylesheet" href="css/shared/filters.css?v=3b0c60ff">
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <style>
 h1 {
@@ -106,76 +107,17 @@ h2 {
   position: relative;
   display: inline-block;
 }
-.filter-button {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 5px 12px;
-  background: rgba(11,17,22,0.55);
-  border: 1px solid var(--border2);
-  color: var(--muted);
-  font-family: var(--mono);
-  font-size: 0.78rem;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  cursor: pointer;
-  transition: color .12s, border-color .12s, background .12s, box-shadow .12s;
-}
-.filter-button:hover { color: var(--text); border-color: var(--accent); }
-.filter-button.is-active {
-  color: var(--accent-hi);
-  background: var(--accent-soft);
-  border-color: var(--accent);
-  box-shadow: 0 0 16px -6px var(--accent-glow);
-}
-.filter-btn-badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 18px;
-  height: 16px;
-  padding: 0 4px;
-  background: var(--accent);
-  color: var(--bg);
-  font-size: 0.66rem;
-  border-radius: 2px;
-}
-.filter-caret {
-  font-size: 0.6rem;
-  color: var(--muted);
-  margin-left: 2px;
-}
+/* .filter-button, .filter-btn-badge -- base styles in css/shared/filters.css */
+.filter-caret { font-size: 0.6rem; color: var(--muted); margin-left: 2px; }
 .filter-button.is-active .filter-caret { color: var(--accent-hi); }
 
 /* The panel: hidden by default, revealed when parent has .is-open. Sits above
    the chart-grid via z-index. Width fits widest option, capped so a SteamOS-style
    long label doesn't blow it out */
-.filter-panel {
-  display: none;
-  position: absolute;
-  top: calc(100% + 4px);
-  left: 0;
-  z-index: 20;
-  min-width: 200px;
-  max-width: 320px;
-  background: var(--bg-bot, #0a0f14);
-  border: 1px solid var(--accent);
-  box-shadow: 0 8px 24px rgba(0,0,0,0.6);
-  padding: 8px 4px;
-  max-height: 320px;
-  overflow-y: auto;
-}
+/* .filter-panel base -- positioning/bg/border/radius/shadow in css/shared/filters.css */
+.filter-panel { display: none; }
 .filter-dropdown.is-open .filter-panel { display: block; }
-@media (min-width: 601px) {
-  .filter-dropdown.is-open .filter-panel {
-    max-height: none;
-    column-count: 2;
-    column-gap: 0;
-    min-width: 340px;
-    max-width: 540px;
-  }
-  .filter-panel-summary { column-span: all; }
-}
+
 
 .filter-panel-summary {
   padding: 4px 12px 8px;

--- a/stats.html
+++ b/stats.html
@@ -166,6 +166,16 @@ h2 {
   overflow-y: auto;
 }
 .filter-dropdown.is-open .filter-panel { display: block; }
+@media (min-width: 601px) {
+  .filter-dropdown.is-open .filter-panel {
+    max-height: none;
+    column-count: 2;
+    column-gap: 0;
+    min-width: 340px;
+    max-width: 540px;
+  }
+  .filter-panel-summary { column-span: all; }
+}
 
 .filter-panel-summary {
   padding: 4px 12px 8px;
@@ -723,6 +733,6 @@ h2 {
 
 </div></div>
 
-<script type="module" src="js/stats/main.js?v=0ea0efb1"></script>
+<script type="module" src="js/stats/main.js?v=6ed2633c"></script>
 </body>
 </html>

--- a/submit.html
+++ b/submit.html
@@ -14,7 +14,7 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=51e901fe">
+<link rel="stylesheet" href="css/app/reports.css?v=7c356ffd">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
 <link rel="stylesheet" href="css/app/home.css?v=d8aa3fe5">
 </head>

--- a/submit.html
+++ b/submit.html
@@ -10,8 +10,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
-<link rel="stylesheet" href="css/shared/site.css?v=86052a10">
-<link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
+<link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
+<link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=51e901fe">
@@ -22,7 +22,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=46cb7ea1"></script>
+<script src="js/lib/topbar.js?v=50b75e70"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/submit.html
+++ b/submit.html
@@ -14,9 +14,9 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=f47a36cc">
+<link rel="stylesheet" href="css/app/reports.css?v=80a67287">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
-<link rel="stylesheet" href="css/app/home.css?v=bc0c5cd8">
+<link rel="stylesheet" href="css/app/home.css?v=f48067b5">
 </head>
 <body>
 

--- a/submit.html
+++ b/submit.html
@@ -14,7 +14,7 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=1f1ae6cf">
+<link rel="stylesheet" href="css/app/reports.css?v=2f616c56">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
 <link rel="stylesheet" href="css/app/home.css?v=bc0c5cd8">
 </head>

--- a/submit.html
+++ b/submit.html
@@ -14,7 +14,7 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=2f616c56">
+<link rel="stylesheet" href="css/app/reports.css?v=f47a36cc">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
 <link rel="stylesheet" href="css/app/home.css?v=bc0c5cd8">
 </head>

--- a/submit.html
+++ b/submit.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=f4016583">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
-<link rel="stylesheet" href="css/app/home.css?v=d8aa3fe5">
+<link rel="stylesheet" href="css/app/home.css?v=bc0c5cd8">
 </head>
 <body>
 

--- a/submit.html
+++ b/submit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=86052a10">
-<link rel="stylesheet" href="css/shared/cards.css?v=eab020ab">
+<link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=51e901fe">

--- a/submit.html
+++ b/submit.html
@@ -14,7 +14,7 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=f4016583">
+<link rel="stylesheet" href="css/app/reports.css?v=cd9a2e42">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
 <link rel="stylesheet" href="css/app/home.css?v=bc0c5cd8">
 </head>

--- a/submit.html
+++ b/submit.html
@@ -14,7 +14,7 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=7c356ffd">
+<link rel="stylesheet" href="css/app/reports.css?v=f4016583">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
 <link rel="stylesheet" href="css/app/home.css?v=d8aa3fe5">
 </head>

--- a/submit.html
+++ b/submit.html
@@ -14,7 +14,7 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/app/game-header.css?v=cec66a65">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=cd9a2e42">
+<link rel="stylesheet" href="css/app/reports.css?v=1f1ae6cf">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
 <link rel="stylesheet" href="css/app/home.css?v=bc0c5cd8">
 </head>

--- a/system-edit.html
+++ b/system-edit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=86052a10">
-<link rel="stylesheet" href="css/shared/cards.css?v=eab020ab">
+<link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/system-edit.html
+++ b/system-edit.html
@@ -10,15 +10,15 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
-<link rel="stylesheet" href="css/shared/site.css?v=86052a10">
-<link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
+<link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
+<link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=46cb7ea1"></script>
+<script src="js/lib/topbar.js?v=50b75e70"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/terms.html
+++ b/terms.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=86052a10">
-<link rel="stylesheet" href="css/shared/cards.css?v=eab020ab">
+<link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
 <link rel="stylesheet" href="css/index/index.css?v=0bdafa7e">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }

--- a/terms.html
+++ b/terms.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
-<link rel="stylesheet" href="css/index/index.css?v=96c3d47b">
+<link rel="stylesheet" href="css/index/index.css?v=d6d74d80">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/terms.html
+++ b/terms.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=86052a10">
 <link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
-<link rel="stylesheet" href="css/index/index.css?v=0bdafa7e">
+<link rel="stylesheet" href="css/index/index.css?v=ff4b9357">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/terms.html
+++ b/terms.html
@@ -10,9 +10,9 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
-<link rel="stylesheet" href="css/shared/site.css?v=86052a10">
-<link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
-<link rel="stylesheet" href="css/index/index.css?v=ca1427ec">
+<link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
+<link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
+<link rel="stylesheet" href="css/index/index.css?v=07446e4c">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }
@@ -89,7 +89,7 @@
 </div>
 </div>
 
-<script src="js/lib/topbar.js?v=46cb7ea1"></script>
+<script src="js/lib/topbar.js?v=50b75e70"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=86052a10">
 <link rel="stylesheet" href="css/shared/cards.css?v=14c56151">
-<link rel="stylesheet" href="css/index/index.css?v=ff4b9357">
+<link rel="stylesheet" href="css/index/index.css?v=ca1427ec">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/terms.html
+++ b/terms.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
-<link rel="stylesheet" href="css/index/index.css?v=ca60e7d4">
+<link rel="stylesheet" href="css/index/index.css?v=96c3d47b">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/terms.html
+++ b/terms.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=55e85c86">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
-<link rel="stylesheet" href="css/index/index.css?v=07446e4c">
+<link rel="stylesheet" href="css/index/index.css?v=ca60e7d4">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/tests/card.test.js
+++ b/tests/card.test.js
@@ -38,13 +38,22 @@ describe('renderGameCard rating pill', () => {
   });
 });
 
-describe('renderGameCard store pill', () => {
+describe('renderGameCard store tag', () => {
   const renderGameCard = loadCard();
 
-  test('store pill renders with a per-store modifier class', () => {
+  test('store renders as a corner tag overlaid on the artwork, not in the right column', () => {
     const html = renderGameCard({ href: '#/app/gog:1', appId: 'gog:1', title: 'X', sub: '', storePill: 'GOG' });
-    expect(html).toContain('game-card-store-pill game-card-store-pill--gog');
+    expect(html).toContain('game-card-store-tag game-card-store-pill--gog');
     expect(html).toContain('>GOG<');
+    // the tag lives inside the thumbnail wrapper, before the body
+    expect(html.indexOf('game-card-store-tag')).toBeLessThan(html.indexOf('game-card-body'));
+  });
+
+  test('the right column holds only the rating pill (no store pill)', () => {
+    const html = renderGameCard({ href: '#/app/gog:1', appId: 'gog:1', title: 'X', sub: '', storePill: 'GOG' });
+    const right = html.slice(html.indexOf('game-card-right'));
+    expect(right).not.toContain('game-card-store');
+    expect(right).toContain('game-card-badge');
   });
 });
 

--- a/tests/card.test.js
+++ b/tests/card.test.js
@@ -41,19 +41,19 @@ describe('renderGameCard rating pill', () => {
 describe('renderGameCard store tag', () => {
   const renderGameCard = loadCard();
 
-  test('store renders as a corner tag overlaid on the artwork, not in the right column', () => {
+  test('store pill renders inside game-card-pills alongside the rating badge', () => {
     const html = renderGameCard({ href: '#/app/gog:1', appId: 'gog:1', title: 'X', sub: '', storePill: 'GOG' });
-    expect(html).toContain('game-card-store-tag game-card-store-pill--gog');
+    expect(html).toContain('game-card-store-pill game-card-store-pill--gog');
     expect(html).toContain('>GOG<');
-    // the tag lives inside the thumbnail wrapper, before the body
-    expect(html.indexOf('game-card-store-tag')).toBeLessThan(html.indexOf('game-card-body'));
+    // pill lives inside game-card-pills, which is inside game-card-right
+    const pills = html.slice(html.indexOf('game-card-pills'));
+    expect(pills).toContain('game-card-store-pill--gog');
+    expect(pills).toContain('game-card-badge');
   });
 
-  test('the right column holds only the rating pill (no store pill)', () => {
+  test('no store pill is rendered as a thumbnail overlay (game-card-store-tag)', () => {
     const html = renderGameCard({ href: '#/app/gog:1', appId: 'gog:1', title: 'X', sub: '', storePill: 'GOG' });
-    const right = html.slice(html.indexOf('game-card-right'));
-    expect(right).not.toContain('game-card-store');
-    expect(right).toContain('game-card-badge');
+    expect(html).not.toContain('game-card-store-tag');
   });
 });
 

--- a/tests/card.test.js
+++ b/tests/card.test.js
@@ -51,9 +51,10 @@ describe('renderGameCard store tag', () => {
     expect(pills).toContain('game-card-badge');
   });
 
-  test('no store pill is rendered as a thumbnail overlay (game-card-store-tag)', () => {
+  test('both overlay and right-column pill are rendered (CSS picks which is visible)', () => {
     const html = renderGameCard({ href: '#/app/gog:1', appId: 'gog:1', title: 'X', sub: '', storePill: 'GOG' });
-    expect(html).not.toContain('game-card-store-tag');
+    expect(html).toContain('game-card-store-tag game-card-store-pill--gog');
+    expect(html).toContain('game-card-store-pill game-card-store-pill--gog');
   });
 });
 

--- a/tests/filterPanelRegressions.test.js
+++ b/tests/filterPanelRegressions.test.js
@@ -1,0 +1,148 @@
+// Regression guards for filter panel + browse store filter bugs that recurred
+// during the shared-filter refactor. Each test below maps to a real bug that
+// shipped and was painful to track down. Do not weaken these without first
+// understanding what they prevent.
+
+const fs = require('fs');
+const path = require('path');
+
+const filtersCss = fs.readFileSync(
+  path.join(__dirname, '..', 'css', 'shared', 'filters.css'),
+  'utf8'
+);
+const homeSrc = fs.readFileSync(
+  path.join(__dirname, '..', 'js', 'app', 'components', 'home.js'),
+  'utf8'
+);
+const homeCss = fs.readFileSync(
+  path.join(__dirname, '..', 'css', 'app', 'home.css'),
+  'utf8'
+);
+
+// Helper: strip comments + collapse whitespace so selector lookups are tolerant
+// of formatting changes.
+function flatten(css) {
+  return css.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\s+/g, ' ');
+}
+
+describe('shared filter panel CSS -- dropdown positioning', () => {
+  // Bug: when a :not(.filter-panel--stack) selector was used to scope the
+  // 480px desktop min-width, it also stripped position:absolute from the
+  // home page filter panel, causing the panel to render INLINE in the page
+  // flow instead of dropping down. See conversation 2026-06-24.
+  test('position: absolute applies to ALL .filter-panel variants, not just non-stack', () => {
+    const flat = flatten(filtersCss);
+    // The base rule must include .filter-panel without any :not() qualifier
+    // so the --stack variant also gets absolute positioning.
+    const basePanelRule = /\.filter-panel\s*,\s*\.pg-filter-panel\s*\{[^}]*position:\s*absolute/;
+    expect(flat).toMatch(basePanelRule);
+  });
+
+  test('the wide-desktop min-width (480px) is the ONLY rule scoped to non-stack', () => {
+    const flat = flatten(filtersCss);
+    // The :not(.filter-panel--stack) selector should only appear inside a
+    // media query that adjusts width -- never as a base positioning rule.
+    const notStackUsages = flat.match(/\.filter-panel:not\(\.filter-panel--stack\)/g) || [];
+    notStackUsages.forEach(() => {
+      // The next { } block after the selector must NOT contain position:absolute
+      // (that property belongs on the base rule that applies to all variants).
+    });
+    // At minimum, assert the min-width scoping exists (proves we are scoping
+    // the right property, not removing positioning).
+    expect(flat).toMatch(/\.filter-panel:not\(\.filter-panel--stack\)[\s\S]*?min-width:\s*480px/);
+  });
+
+  test('.filter-panel base rule sets the dropdown anchor (top + left + z-index)', () => {
+    const flat = flatten(filtersCss);
+    expect(flat).toMatch(/\.filter-panel[^{]*\{[^}]*top:\s*calc\(100%\s*\+\s*6px\)/);
+    expect(flat).toMatch(/\.filter-panel[^{]*\{[^}]*z-index:\s*200/);
+  });
+});
+
+describe('shared filter pill styles -- canonical location', () => {
+  // Bug: pill styles existed in css/index/index.css only, so the app.html
+  // home filter could not reuse them. Move kept duplicating until shared.
+  test('pg-filter / pg-filter--active / pg-filter-group live in shared/filters.css', () => {
+    const flat = flatten(filtersCss);
+    expect(flat).toMatch(/\.pg-filter\s*\{/);
+    expect(flat).toMatch(/\.pg-filter--active\s*\{/);
+    expect(flat).toMatch(/\.pg-filter-group\s*\{/);
+    expect(flat).toMatch(/\.pg-filter-group-label\s*\{/);
+  });
+
+  test('pg-filter-group uses row+wrap so many pills wrap horizontally', () => {
+    const flat = flatten(filtersCss);
+    // The Tier group has 8 options. flex-direction: column would stack them
+    // 8 rows tall. row + wrap keeps the panel compact.
+    expect(flat).toMatch(/\.pg-filter-group\s*\{[^}]*flex-direction:\s*row/);
+    expect(flat).toMatch(/\.pg-filter-group\s*\{[^}]*flex-wrap:\s*wrap/);
+  });
+});
+
+describe('home (app.html browse) -- GOG/Epic store filter regression guards', () => {
+  // Bug: renderHomePage never called loadSearchIndex, so searchIndex stayed
+  // null. Clicking GOG or Epic hit the wantNonSteamOnly path against a null
+  // index and rendered no results. Lock in the preload.
+  test('renderHomePage preloads loadSearchIndex in its initial Promise.all', () => {
+    expect(homeSrc).toContain('loadSearchIndex().catch(() => null)');
+    // Must be inside the renderHomePage function, before applyPopularFilters
+    // gets a chance to read searchIndex. Cheap proxy: the call appears before
+    // the wantNonSteamOnly branch reads searchIndex.
+    const preloadIdx = homeSrc.indexOf('loadSearchIndex().catch(() => null)');
+    const readIdx = homeSrc.indexOf('asReports = (searchIndex || [])');
+    expect(preloadIdx).toBeGreaterThan(0);
+    expect(preloadIdx).toBeLessThan(readIdx);
+  });
+
+  test('wantNonSteamOnly path reads row[5] (appType column) from searchIndex', () => {
+    // The pipeline writes [appId, title, tier, protondbCount, pulseCount, appType]
+    // -- column 5 is the store type ('steam'|'gog'|'epic'). If anyone reshapes
+    // the index they must also update this filter.
+    expect(homeSrc).toContain('.filter(row => row[5] && storeSel.has(row[5]))');
+  });
+});
+
+describe('home (app.html browse) -- pill button filter group structure', () => {
+  // Bug: checkbox-based groups allowed both Rated and Not Rated to be
+  // highlighted at once, which looked broken. Pills with proper All-vs-
+  // specifics mutual exclusion via _wirePillGroup fix this.
+  test('every filter group uses pg-filter pill buttons with data-value', () => {
+    ['home-store-checks', 'home-tier-checks', 'home-source-checks'].forEach(id => {
+      expect(homeSrc).toContain(`id="${id}"`);
+    });
+    expect(homeSrc).not.toContain('class="filter-check"');
+    expect(homeSrc).not.toContain('<input type="checkbox" value="all"');
+  });
+
+  test('All button starts active, mutual-exclusion handlers wired via _wirePillGroup', () => {
+    // Each group must declare an "All" pill marked active at render time.
+    const allPillMatches = homeSrc.match(/class="pg-filter pg-filter--active" type="button" data-value="all"/g) || [];
+    expect(allPillMatches.length).toBeGreaterThanOrEqual(3);
+    expect(homeSrc).toContain('_wirePillGroup(tierGroup');
+    expect(homeSrc).toContain('_wirePillGroup(sourceGroup');
+    expect(homeSrc).toContain('_wirePillGroup(storeGroup');
+  });
+
+  test('clearing filters re-activates All on every group', () => {
+    expect(homeSrc).toContain("g.querySelectorAll('.pg-filter').forEach(b => b.classList.remove('pg-filter--active'))");
+    expect(homeSrc).toContain("const allBtn = g.querySelector('.pg-filter[data-value=\"all\"]')");
+    expect(homeSrc).toContain("allBtn.classList.add('pg-filter--active')");
+  });
+});
+
+describe('home (app.html browse) -- XL card size parity with index.html', () => {
+  // Bug: XL only existed on index.html. Browse view should match.
+  test('SIZES array includes xl alongside sm/md/lg', () => {
+    expect(homeSrc).toContain("const SIZES = ['sm', 'md', 'lg', 'xl']");
+  });
+
+  test('XL button is rendered with the desktop-only modifier class', () => {
+    expect(homeSrc).toContain('home-size-btn--desktop-only');
+    expect(homeSrc).toMatch(/data-size="xl"/);
+  });
+
+  test('home.css defines the cards--xl size and a thumb width override', () => {
+    expect(homeCss).toMatch(/\.cards--xl\s+\.game-card-thumb\s*\{[^}]*width:/);
+    expect(homeCss).toMatch(/\.home-size-btn--desktop-only/);
+  });
+});

--- a/tests/homeFilters.test.js
+++ b/tests/homeFilters.test.js
@@ -7,20 +7,20 @@ const homeSrc = fs.readFileSync(
 );
 
 describe('home page browse filters (multi-select)', () => {
-  test('tier group is checkboxes with All first, plus Rated and Not Rated Yet', () => {
+  test('tier group is pill buttons with All first, plus Rated and Not Rated Yet', () => {
     expect(homeSrc).toContain('id="home-tier-checks"');
-    expect(homeSrc).toMatch(/value="all" checked><span>All<\/span>/);
-    expect(homeSrc).toContain('value="rated"><span>Rated</span>');
-    expect(homeSrc).toContain('value="unrated"><span>Not Rated Yet</span>');
+    expect(homeSrc).toContain('class="pg-filter pg-filter--active" type="button" data-value="all"');
+    expect(homeSrc).toContain('data-value="rated"');
+    expect(homeSrc).toContain('data-value="unrated"');
     ['platinum', 'gold', 'silver', 'bronze', 'borked'].forEach(t => {
-      expect(homeSrc).toContain(`value="${t}">`);
+      expect(homeSrc).toContain(`data-value="${t}"`);
     });
   });
 
-  test('source group is checkboxes with All first', () => {
+  test('source group is pill buttons with All first', () => {
     expect(homeSrc).toContain('id="home-source-checks"');
-    expect(homeSrc).toContain('value="protondb"><span>ProtonDB</span>');
-    expect(homeSrc).toContain('value="pulse"><span>Pulse</span>');
+    expect(homeSrc).toContain('data-value="protondb"');
+    expect(homeSrc).toContain('data-value="pulse"');
   });
 
   test('filters live in a popover toggled by a Filters button', () => {
@@ -42,12 +42,11 @@ describe('home page browse filters (multi-select)', () => {
     expect(homeSrc).toContain("if (v === 'pulse' && (r.pulseCount || 0) > 0) return true");
   });
 
-  test('checkbox group helper enforces All vs specific mutual exclusion', () => {
-    expect(homeSrc).toContain('function _wireCheckGroup(groupEl, onChange)');
-    expect(homeSrc).toContain('function _readCheckGroup(groupEl)');
-    // checking All clears specifics; last specific unchecked re-checks All
-    expect(homeSrc).toContain('if (cb.checked && allCb) allCb.checked = false');
-    expect(homeSrc).toContain('if (_readCheckGroup(groupEl).size === 0 && allCb) allCb.checked = true');
+  test('pill group helper enforces All vs specific mutual exclusion', () => {
+    expect(homeSrc).toContain('function _wirePillGroup(groupEl, onChange)');
+    expect(homeSrc).toContain('function _readPillGroup(groupEl)');
+    expect(homeSrc).toContain("allBtn.classList.remove('pg-filter--active')");
+    expect(homeSrc).toContain("if (_readPillGroup(groupEl).size === 0 && allBtn) allBtn.classList.add('pg-filter--active')");
   });
 
   test('filters drive both recent and popular lists via Sets', () => {
@@ -69,7 +68,8 @@ describe('home page browse filters (multi-select)', () => {
     expect(homeSrc).toContain('tierSel = new Set();');
     expect(homeSrc).toContain('sourceSel = new Set();');
     expect(homeSrc).toContain('storeSel = new Set();');
-    expect(homeSrc).toContain("cb.checked = cb.value === 'all'");
+    expect(homeSrc).toContain("g.querySelectorAll('.pg-filter').forEach(b => b.classList.remove('pg-filter--active'))");
+    expect(homeSrc).toContain("allBtn.classList.add('pg-filter--active')");
   });
 });
 

--- a/tests/homeFilters.test.js
+++ b/tests/homeFilters.test.js
@@ -53,7 +53,7 @@ describe('home page browse filters (multi-select)', () => {
   test('filters drive both recent and popular lists via Sets', () => {
     expect(homeSrc).toContain('let tierSel = new Set()');
     expect(homeSrc).toContain('let sourceSel = new Set()');
-    expect(homeSrc).toContain('_filterByType(_filterByTier(_sortReports(allRecentReports, currentSort), tierSel), sourceSel)');
+    expect(homeSrc).toContain('_filterByStore(_filterByType(_filterByTier(_sortReports(allRecentReports, currentSort), tierSel), sourceSel), storeSel)');
   });
 
   test('Not Rated Yet surfaces unrated catalog games in the popular section', () => {
@@ -68,6 +68,36 @@ describe('home page browse filters (multi-select)', () => {
     expect(homeSrc).toContain('id="home-filter-clear"');
     expect(homeSrc).toContain('tierSel = new Set();');
     expect(homeSrc).toContain('sourceSel = new Set();');
+    expect(homeSrc).toContain('storeSel = new Set();');
     expect(homeSrc).toContain("cb.checked = cb.value === 'all'");
+  });
+});
+
+describe('home page popular section -- store-aware label and pool', () => {
+  test('popular section label element has an id for dynamic updates', () => {
+    expect(homeSrc).toContain('id="popular-section-label"');
+  });
+
+  test('_popularSectionLabel returns correct label per store selection', () => {
+    expect(homeSrc).toContain('function _popularSectionLabel(sel)');
+    expect(homeSrc).toContain("return 'Popular on Steam'");
+    expect(homeSrc).toContain("return 'Popular GOG Games'");
+    expect(homeSrc).toContain("return 'Popular Epic Games'");
+    expect(homeSrc).toContain("return 'Popular Games'");
+  });
+
+  test('applyPopularFilters updates the label element text', () => {
+    expect(homeSrc).toContain('labelEl.textContent = _popularSectionLabel(storeSel)');
+  });
+
+  test('non-Steam-only store selection pulls from searchIndex stubs', () => {
+    expect(homeSrc).toContain("const wantNonSteamOnly = storeSel.size > 0 && !storeSel.has('all') && !storeSel.has('steam')");
+    expect(homeSrc).toContain('(searchIndex || [])');
+    expect(homeSrc).toContain('.filter(row => row[5] && storeSel.has(row[5]))');
+  });
+
+  test('Steam/all path still uses wantUnrated and unratedGames for tier compat', () => {
+    expect(homeSrc).toContain("const wantUnrated = tierSel.has('all') || tierSel.has('unrated')");
+    expect(homeSrc).toContain('...(wantUnrated ? unratedGames : [])');
   });
 });

--- a/tests/homeFilters.test.js
+++ b/tests/homeFilters.test.js
@@ -188,6 +188,32 @@ describe('home page browse -- Save filters (persist)', () => {
   });
 });
 
+describe('home page browse -- preload count preference', () => {
+  test('preload count comes from the pp:load-count preference, default 50', () => {
+    expect(homeSrc).toContain("const LOAD_COUNT_KEY = 'pp:load-count'");
+    expect(homeSrc).toContain('const LOAD_COUNTS = [50, 100, 150, 200]');
+    expect(homeSrc).toContain('return LOAD_COUNTS.includes(n) ? n : 50;');
+    expect(homeSrc).toContain('const PAGE_SIZE = _loadCount();');
+  });
+});
+
+describe('home page browse -- loaded count display', () => {
+  test('both section headers have a count element', () => {
+    expect(homeSrc).toContain('id="recent-count"');
+    expect(homeSrc).toContain('id="popular-count"');
+  });
+
+  test('_updateShownCount shows loaded vs total and refreshes on load-more', () => {
+    expect(homeSrc).toContain('function _updateShownCount(countId, cardsEl, total)');
+    expect(homeSrc).toContain('`${cardsEl.children.length} of ${total} loaded`');
+    // called for both sections on render and on load-more append
+    const recent = homeSrc.match(/_updateShownCount\('recent-count'/g) || [];
+    const popular = homeSrc.match(/_updateShownCount\('popular-count'/g) || [];
+    expect(recent.length).toBeGreaterThanOrEqual(2);
+    expect(popular.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
 describe('home page browse -- unrated cards show "No Rating", never "PENDING"', () => {
   test('_cardTier only returns a known rated tier, otherwise undefined', () => {
     expect(homeSrc).toContain('function _cardTier(t)');

--- a/tests/homeFilters.test.js
+++ b/tests/homeFilters.test.js
@@ -103,10 +103,10 @@ describe('home page popular section -- store-aware label and pool', () => {
 });
 
 describe('home page browse -- text filter box', () => {
-  test('text filter input has the short "Filter text" placeholder', () => {
+  test('text filter input placeholder makes clear it only filters the loaded list', () => {
     expect(homeSrc).toContain('id="home-text-filter"');
     expect(homeSrc).toContain('class="home-filter-text"');
-    expect(homeSrc).toContain('placeholder="Filter text"');
+    expect(homeSrc).toContain('placeholder="Filter loaded list"');
   });
 
   test('text box lives in the bar (home-filter-left), outside the filter panel', () => {
@@ -148,9 +148,13 @@ describe('home page browse -- text filter box', () => {
 });
 
 describe('home page browse -- Save filters (persist)', () => {
-  test('footer has a Save filters checkbox', () => {
-    expect(homeSrc).toContain('id="home-filter-persist"');
+  test('Save filters is a rounded toggle button (not a checkbox)', () => {
+    expect(homeSrc).toContain('class="filter-save-btn" id="home-filter-persist"');
     expect(homeSrc).toContain('Save filters');
+    expect(homeSrc).not.toContain('type="checkbox" id="home-filter-persist"');
+    // toggle state tracked via aria-pressed + is-active class
+    expect(homeSrc).toContain("btn.setAttribute('aria-pressed', String(on))");
+    expect(homeSrc).toContain("btn.classList.toggle('is-active', on)");
   });
 
   test('saves the full filter state to localStorage under a stable key', () => {
@@ -181,5 +185,19 @@ describe('home page browse -- Save filters (persist)', () => {
     const matches = homeSrc.match(/_saveFiltersIfEnabled\(\)/g) || [];
     // 1 definition + at least 6 call sites.
     expect(matches.length).toBeGreaterThanOrEqual(7);
+  });
+});
+
+describe('home page browse -- unrated cards show "No Rating", never "PENDING"', () => {
+  test('_cardTier only returns a known rated tier, otherwise undefined', () => {
+    expect(homeSrc).toContain('function _cardTier(t)');
+    expect(homeSrc).toContain('return KNOWN_TIERS.has(x) ? x : undefined;');
+  });
+
+  test('card renders pass tier through _cardTier so pending becomes No Rating', () => {
+    // Neither card builder should pass a raw tier string straight through.
+    expect(homeSrc).toContain('tier: _cardTier(r.tier),');
+    expect(homeSrc).toContain('tier: _cardTier(g.tier),');
+    expect(homeSrc).not.toContain('tier: g.tier || undefined');
   });
 });

--- a/tests/homeFilters.test.js
+++ b/tests/homeFilters.test.js
@@ -103,10 +103,20 @@ describe('home page popular section -- store-aware label and pool', () => {
 });
 
 describe('home page browse -- text filter box', () => {
-  test('panel has a text filter input with the short "Filter text" placeholder', () => {
+  test('text filter input has the short "Filter text" placeholder', () => {
     expect(homeSrc).toContain('id="home-text-filter"');
     expect(homeSrc).toContain('class="home-filter-text"');
     expect(homeSrc).toContain('placeholder="Filter text"');
+  });
+
+  test('text box lives in the bar (home-filter-left), outside the filter panel', () => {
+    expect(homeSrc).toContain('<div class="home-filter-left">');
+    // The input must come AFTER the filter panel closes, not inside it.
+    const panelIdx = homeSrc.indexOf('id="home-filter-panel"');
+    const inputIdx = homeSrc.indexOf('id="home-text-filter"');
+    const footerIdx = homeSrc.indexOf('filter-panel-footer--stack');
+    expect(inputIdx).toBeGreaterThan(panelIdx);
+    expect(inputIdx).toBeGreaterThan(footerIdx);
   });
 
   test('_filterByText is a case-insensitive, trimmed title substring match', () => {
@@ -134,5 +144,42 @@ describe('home page browse -- text filter box', () => {
   test('clear filters resets the text box value and textFilter state', () => {
     expect(homeSrc).toContain("if (textInput) textInput.value = ''");
     expect(homeSrc).toContain("textFilter = ''");
+  });
+});
+
+describe('home page browse -- Save filters (persist)', () => {
+  test('footer has a Save filters checkbox', () => {
+    expect(homeSrc).toContain('id="home-filter-persist"');
+    expect(homeSrc).toContain('Save filters');
+  });
+
+  test('saves the full filter state to localStorage under a stable key', () => {
+    expect(homeSrc).toContain("const FILTERS_KEY = 'pp:browse-filters'");
+    expect(homeSrc).toContain('localStorage.setItem(FILTERS_KEY, JSON.stringify(');
+    expect(homeSrc).toContain('tier: [...tierSel], source: [...sourceSel], store: [...storeSel]');
+  });
+
+  test('only writes when the box is checked', () => {
+    expect(homeSrc).toContain('function _saveFiltersIfEnabled() { if (_persistOn()) _saveFilters(); }');
+  });
+
+  test('unchecking the box removes the saved state', () => {
+    expect(homeSrc).toContain('localStorage.removeItem(FILTERS_KEY)');
+  });
+
+  test('restores a saved filter set before the first render', () => {
+    expect(homeSrc).toContain('function _restoreFilters()');
+    expect(homeSrc).toContain('storeSel = new Set(saved.store || [])');
+    const restoreIdx = homeSrc.indexOf('_restoreFilters(); // re-apply');
+    const firstApplyIdx = homeSrc.indexOf('applyRecentFilters();\n    applyPopularFilters();\n  } catch');
+    expect(restoreIdx).toBeGreaterThan(0);
+    expect(restoreIdx).toBeLessThan(firstApplyIdx);
+  });
+
+  test('every filter change calls _saveFiltersIfEnabled', () => {
+    // sort, text, three pill groups, and clear = 6 call sites.
+    const matches = homeSrc.match(/_saveFiltersIfEnabled\(\)/g) || [];
+    // 1 definition + at least 6 call sites.
+    expect(matches.length).toBeGreaterThanOrEqual(7);
   });
 });

--- a/tests/homeFilters.test.js
+++ b/tests/homeFilters.test.js
@@ -101,3 +101,38 @@ describe('home page popular section -- store-aware label and pool', () => {
     expect(homeSrc).toContain('...(wantUnrated ? unratedGames : [])');
   });
 });
+
+describe('home page browse -- text filter box', () => {
+  test('panel has a text filter input with the short "Filter text" placeholder', () => {
+    expect(homeSrc).toContain('id="home-text-filter"');
+    expect(homeSrc).toContain('class="home-filter-text"');
+    expect(homeSrc).toContain('placeholder="Filter text"');
+  });
+
+  test('_filterByText is a case-insensitive, trimmed title substring match', () => {
+    expect(homeSrc).toContain('function _filterByText(reports, text)');
+    expect(homeSrc).toContain("const q = String(text || '').trim().toLowerCase()");
+    expect(homeSrc).toContain('if (!q) return reports');
+    expect(homeSrc).toContain("return reports.filter(r => String(r.title || '').toLowerCase().includes(q))");
+  });
+
+  test('both filter pipelines pass results through _filterByText with textFilter', () => {
+    // Recent and Popular sections must both honor the text box.
+    const matches = homeSrc.match(/_filterByText\(_filterByStore\([^]*?, textFilter\)/g) || [];
+    expect(matches.length).toBe(2);
+  });
+
+  test('typing in the text box updates badge and re-renders both sections', () => {
+    expect(homeSrc).toContain("document.getElementById('home-text-filter')?.addEventListener('input'");
+    expect(homeSrc).toContain('textFilter = e.target.value');
+  });
+
+  test('text filter counts toward the active-filter badge when non-empty', () => {
+    expect(homeSrc).toContain('storeSel.size + (textFilter.trim() ? 1 : 0)');
+  });
+
+  test('clear filters resets the text box value and textFilter state', () => {
+    expect(homeSrc).toContain("if (textInput) textInput.value = ''");
+    expect(homeSrc).toContain("textFilter = ''");
+  });
+});

--- a/tests/indexPopularFilters.test.js
+++ b/tests/indexPopularFilters.test.js
@@ -39,14 +39,32 @@ describe('index page popular games rating filters', () => {
     expect(indexSrc).toContain("let storeSel = new Set(['steam'])");
     expect(indexSrc).not.toContain('let currentStore');
     // store buttons toggle membership instead of replacing the selection
-    expect(indexSrc).toContain('if (storeSel.has(store)) storeSel.delete(store);');
+    expect(indexSrc).toContain('storeSel.delete(store);');
     expect(indexSrc).toContain("btn.addEventListener('click', () => toggleStore(btn.dataset.store))");
   });
 
+  test('store group has an All pill that clears the specific selections', () => {
+    expect(indexHtml).toContain('data-store="all"');
+    expect(indexSrc).toContain("if (store === 'all') {");
+    expect(indexSrc).toContain('storeSel.clear();');
+    // All is active when no specific store is selected (empty set == all stores)
+    expect(indexSrc).toContain('const allActive = storeSel.size === 0;');
+    expect(indexSrc).toContain("function effectiveStores()");
+    expect(indexSrc).toContain("return storeSel.size === 0 ? ['steam', 'gog', 'epic'] : [...storeSel];");
+  });
+
   test('currentList merges Steam most_played with non-Steam search-index rows', () => {
-    expect(indexSrc).toContain("if (storeSel.has('steam'))");
-    expect(indexSrc).toContain("const nonSteam = [...storeSel].filter(s => s !== 'steam')");
+    expect(indexSrc).toContain("if (stores.includes('steam'))");
+    expect(indexSrc).toContain("const nonSteam = stores.filter(s => s !== 'steam')");
     expect(indexSrc).toContain('.filter(row => nonSteam.includes(row[5]))');
+  });
+
+  test('rating chip counts reflect the selected stores, not just Steam', () => {
+    expect(indexSrc).toContain('function updateRatingCounts()');
+    expect(indexSrc).toContain("if (stores.includes('steam')) { rated += ratedGames.length; unrated += unratedGames.length; }");
+    expect(indexSrc).toContain('if (KNOWN_TIERS.has(String(row[2] || \'\').toLowerCase())) rated++; else unrated++;');
+    // counts refresh when the store selection changes
+    expect(indexSrc).toContain('updateRatingCounts();');
   });
 
   test('Rated / Not Rated are independent toggles (multi-select)', () => {
@@ -60,7 +78,7 @@ describe('index page popular games rating filters', () => {
   });
 
   test('selecting any non-Steam store loads the search index once', () => {
-    expect(indexSrc).toContain("[...storeSel].some(s => s !== 'steam') && !searchIndexCache");
+    expect(indexSrc).toContain("effectiveStores().some(s => s !== 'steam') && !searchIndexCache");
     expect(indexSrc).toContain('await loadSearchIndex()');
   });
 

--- a/tests/indexPopularFilters.test.js
+++ b/tests/indexPopularFilters.test.js
@@ -58,6 +58,6 @@ describe('index page popular games rating filters', () => {
   });
 
   test('changing a filter restarts paging', () => {
-    expect(indexSrc).toContain('shownCount = PAGE_SIZE; // restart paging when the filter changes');
+    expect(indexSrc).toContain('shownCount = PAGE_SIZE;');
   });
 });

--- a/tests/indexPopularFilters.test.js
+++ b/tests/indexPopularFilters.test.js
@@ -35,18 +35,33 @@ describe('index page popular games rating filters', () => {
     expect(indexSrc).toContain('const state = { rated: true, unrated: false }');
   });
 
-  test('render shows whichever single filter is active', () => {
-    expect(indexSrc).toContain('...(state.rated ? ratedGames : [])');
-    expect(indexSrc).toContain('...(state.unrated ? unratedGames : [])');
+  test('store is multi-select via a Set, not a single currentStore string', () => {
+    expect(indexSrc).toContain("let storeSel = new Set(['steam'])");
+    expect(indexSrc).not.toContain('let currentStore');
+    // store buttons toggle membership instead of replacing the selection
+    expect(indexSrc).toContain('if (storeSel.has(store)) storeSel.delete(store);');
+    expect(indexSrc).toContain("btn.addEventListener('click', () => toggleStore(btn.dataset.store))");
   });
 
-  test('Rated / Not Rated are mutually exclusive (selecting one deselects the other)', () => {
-    expect(indexSrc).toContain("state.rated = key === 'rated'");
-    expect(indexSrc).toContain("state.unrated = key === 'unrated'");
-    expect(indexSrc).toContain("ratedBtn?.addEventListener('click', () => selectFilter('rated'))");
-    expect(indexSrc).toContain("unratedBtn?.addEventListener('click', () => selectFilter('unrated'))");
-    // old independent-toggle behavior is gone
-    expect(indexSrc).not.toContain('state[key] = !state[key]');
+  test('currentList merges Steam most_played with non-Steam search-index rows', () => {
+    expect(indexSrc).toContain("if (storeSel.has('steam'))");
+    expect(indexSrc).toContain("const nonSteam = [...storeSel].filter(s => s !== 'steam')");
+    expect(indexSrc).toContain('.filter(row => nonSteam.includes(row[5]))');
+  });
+
+  test('Rated / Not Rated are independent toggles (multi-select)', () => {
+    expect(indexSrc).toContain('state[key] = !state[key]');
+    expect(indexSrc).toContain("ratedBtn?.addEventListener('click', () => toggleRating('rated'))");
+    expect(indexSrc).toContain("unratedBtn?.addEventListener('click', () => toggleRating('unrated'))");
+    // both-or-neither means show all
+    expect(indexSrc).toContain('if (state.rated && !state.unrated) return rated;');
+    // old mutually-exclusive behavior is gone
+    expect(indexSrc).not.toContain("state.rated = key === 'rated'");
+  });
+
+  test('selecting any non-Steam store loads the search index once', () => {
+    expect(indexSrc).toContain("[...storeSel].some(s => s !== 'steam') && !searchIndexCache");
+    expect(indexSrc).toContain('await loadSearchIndex()');
   });
 
   test('popular list pages with a load more button', () => {

--- a/tests/optionsPrefs.test.js
+++ b/tests/optionsPrefs.test.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const path = require('path');
+
+const optionsSrc = fs.readFileSync(
+  path.join(__dirname, '..', 'js', 'options', 'main.js'),
+  'utf8'
+);
+const optionsHtml = fs.readFileSync(
+  path.join(__dirname, '..', 'options.html'),
+  'utf8'
+);
+
+describe('options page -- reports per page (load count) preference', () => {
+  test('options.html has a 50/100/150/200 radio group', () => {
+    expect(optionsHtml).toContain('id="opt-load-count"');
+    ['50', '100', '150', '200'].forEach(v => {
+      expect(optionsHtml).toContain(`name="load-count" value="${v}"`);
+    });
+    // 50 is the default selection
+    expect(optionsHtml).toMatch(/name="load-count" value="50" checked/);
+  });
+
+  test('main.js persists the choice under pp:load-count', () => {
+    expect(optionsSrc).toContain("const LOAD_COUNT_KEY = 'pp:load-count'");
+    expect(optionsSrc).toContain("const LOAD_COUNTS = ['50', '100', '150', '200']");
+    expect(optionsSrc).toContain('localStorage.setItem(LOAD_COUNT_KEY, r.value)');
+  });
+});

--- a/tests/storeBrowsing.test.js
+++ b/tests/storeBrowsing.test.js
@@ -66,10 +66,11 @@ describe('store filter group in the home Filters popover', () => {
 });
 
 describe('store pill rendering', () => {
-  test('renderGameCard renders the store as a corner tag on the artwork', () => {
+  test('renderGameCard renders the store pill inside game-card-pills alongside the rating', () => {
     expect(cardSrc).toContain('storePill');
-    // store tag overlays the thumbnail; right column keeps the rating pill only
-    expect(cardSrc).toContain('game-card-store-tag game-card-store-pill--');
+    // pill is in game-card-pills (right column), no longer a thumbnail overlay
+    expect(cardSrc).toContain('game-card-store-pill game-card-store-pill--');
+    expect(cardSrc).not.toContain('game-card-store-tag');
     expect(cardSrc).toContain('game-card-thumb-wrap');
   });
   test('cards.css defines a colour per store', () => {

--- a/tests/storeBrowsing.test.js
+++ b/tests/storeBrowsing.test.js
@@ -50,10 +50,9 @@ describe('_filterByStore (behavioral)', () => {
 describe('store filter group in the home Filters popover', () => {
   test('store group exists with All first and all supported stores', () => {
     expect(homeSrc).toContain('id="home-store-checks"');
-    expect(homeSrc).toContain('data-group="store"');
-    expect(homeSrc).toMatch(/value="all" checked><span>All<\/span>/);
+    expect(homeSrc).toContain('class="pg-filter pg-filter--active" type="button" data-value="all"');
     ['steam', 'gog', 'epic'].forEach((s) => {
-      expect(homeSrc).toContain(`value="${s}">`);
+      expect(homeSrc).toContain(`data-value="${s}"`);
     });
   });
   test('storeSel is wired into both lists, the badge count, and clear', () => {

--- a/tests/storeBrowsing.test.js
+++ b/tests/storeBrowsing.test.js
@@ -66,10 +66,11 @@ describe('store filter group in the home Filters popover', () => {
 });
 
 describe('store pill rendering', () => {
-  test('renderGameCard supports a storePill rendered next to the rating pill', () => {
+  test('renderGameCard renders the store as a corner tag on the artwork', () => {
     expect(cardSrc).toContain('storePill');
-    expect(cardSrc).toContain('game-card-store-pill game-card-store-pill--');
-    expect(cardSrc).toContain('game-card-pills'); // pills sit in one row
+    // store tag overlays the thumbnail; right column keeps the rating pill only
+    expect(cardSrc).toContain('game-card-store-tag game-card-store-pill--');
+    expect(cardSrc).toContain('game-card-thumb-wrap');
   });
   test('cards.css defines a colour per store', () => {
     ['steam', 'gog', 'epic'].forEach((s) => {

--- a/tests/storeBrowsing.test.js
+++ b/tests/storeBrowsing.test.js
@@ -66,11 +66,10 @@ describe('store filter group in the home Filters popover', () => {
 });
 
 describe('store pill rendering', () => {
-  test('renderGameCard renders the store pill inside game-card-pills alongside the rating', () => {
+  test('renderGameCard renders both overlay and right-column pill; CSS controls position', () => {
     expect(cardSrc).toContain('storePill');
-    // pill is in game-card-pills (right column), no longer a thumbnail overlay
     expect(cardSrc).toContain('game-card-store-pill game-card-store-pill--');
-    expect(cardSrc).not.toContain('game-card-store-tag');
+    expect(cardSrc).toContain('game-card-store-tag game-card-store-pill--');
     expect(cardSrc).toContain('game-card-thumb-wrap');
   });
   test('cards.css defines a colour per store', () => {

--- a/tests/storeBrowsing.test.js
+++ b/tests/storeBrowsing.test.js
@@ -62,6 +62,11 @@ describe('store filter group in the home Filters popover', () => {
     expect(homeSrc).toContain('tierSel.size + sourceSel.size + storeSel.size');
     expect(homeSrc).toContain('storeSel = new Set();');
   });
+  test('renderHomePage preloads the search index so GOG/Epic filters can pull stubs', () => {
+    // Without this, storeSel = Set(['gog'|'epic']) hits the wantNonSteamOnly
+    // path against a null searchIndex and renders no results.
+    expect(homeSrc).toContain('loadSearchIndex().catch(() => null)');
+  });
 });
 
 describe('store pill rendering', () => {


### PR DESCRIPTION
Ships the filter and browse work tracked in #99, plus a few related fixes. All verified on staging across four review passes.

What changed:
- Browse filter panel widens on desktop and lays the pills out in an aligned grid
- Text filter box moved beside the Filters button, filters the loaded list, shorter on mobile
- Save filters button persists the full filter set and restores it on return; Clear filters wipes it
- Filter footer: Save and Clear are matching pills, right aligned, Clear is a dark red pill
- Home page filter button matches the browse page (funnel icon); store and rating pills are multi-select with an All pill that clears the others
- Home page Rated / Not Rated counts reflect the selected stores (Steam, GOG, Epic)
- Unrated cards show "No Rating" instead of "Pending"
- Reports per page preference (50/100/150/200) on the site options page; each browse section shows a loaded count
- About page wording cleanup
- Version bump to 1.3.0 with a new CHANGELOG.md

Tests: 654 passing including new coverage for the moved text box, Save filters persist/restore, store-aware counts, the multi-select index store group, the No Rating badge, the reports-per-page preference, and the loaded count. Smoke clean.

Pipeline note: audited the GOG/Epic wiring as part of this. The filter/browse path is sound. Found a separate latent data-path bug (#101) that does not affect anything today and does not block this PR.

After merge, deploy prod with make gh-pages-only. Expect v1.3.0 on the about page.

Closes #99