### PR TITLE
ProtonDB-signal stub fallback + discord-ci coverage gaps

### DIFF
--- a/.github/workflows/discord-ci.yml
+++ b/.github/workflows/discord-ci.yml
@@ -2,12 +2,20 @@ name: Discord CI Status
 
 on:
   workflow_run:
+    # When adding a new workflow .yml to this repo, add its `name:` value here
+    # so a failure surfaces in #builds. Discord-* notifier workflows are
+    # intentionally excluded -- if Discord is down they would not be able to
+    # report their own failure anyway.
     workflows:
       - Update ProtonDB Data
       - CI
       - Deploy Supabase Edge Functions
       - Backup
       - Content Moderation
+      - Deploy on merge to main
+      - Sync staging repo
+      - Update Epic Catalog
+      - Update GOG Catalog
     types: [completed]
 
 permissions:

--- a/scripts/pipeline/finalize.py
+++ b/scripts/pipeline/finalize.py
@@ -741,6 +741,7 @@ def generate_search_index(
     epic_catalog: dict[str, str] | None = None,
     steam_catalog: dict[str, str] | None = None,
     protondb_known_app_ids: set[str] | None = None,
+    protondb_signal_titles: dict[str, str] | None = None,
 ) -> None:
     """Generate search-index.json with overall tier + report counts per game.
 
@@ -813,6 +814,29 @@ def generate_search_index(
             log(
                 f"[search-index] Added {stubs:,} Steam catalog stubs "
                 f"(ProtonDB-known apps with no local data; {skipped_no_signal:,} skipped without signal)"
+            )
+
+    # ProtonDB-only fallback: apps that ProtonDB knows about but Steam has
+    # fully removed from GetAppList. Steam catalog won't yield a title, but
+    # the signal export does. These are nearly always delisted -- the chip
+    # at column 7 lands in the same enrich pass that the cache-confirmed
+    # delistings use. See #122.
+    if protondb_signal_titles:
+        stubs = 0
+        skipped_no_title = 0
+        for app_id, title in sorted(protondb_signal_titles.items(), key=lambda kv: (kv[1] or "").lower()):
+            if app_id in seen_ids:
+                continue
+            if not title:
+                skipped_no_title += 1
+                continue
+            entries.append([str(app_id), title, "", 0, 0, "steam"])
+            seen_ids.add(str(app_id))
+            stubs += 1
+        if stubs:
+            log(
+                f"[search-index] Added {stubs:,} ProtonDB-only stubs "
+                f"(known to ProtonDB but absent from Steam catalog; {skipped_no_title:,} skipped without title)"
             )
 
     index_file = output_path / "search-index.json"
@@ -1471,6 +1495,7 @@ def finalize_output(output_dir, skip_probe: bool = False):
         epic_catalog=epic_catalog,
         steam_catalog=steam_catalog,
         protondb_known_app_ids=protondb_known_app_ids,
+        protondb_signal_titles=protondb_signal_catalog,
     )
     # Fill in releaseYear column on same-name collisions (e.g. Prey 2006 vs
     # Prey 2017). Runs against the freshly written search-index.json so it can

--- a/tests/test_search_index_stubs.py
+++ b/tests/test_search_index_stubs.py
@@ -137,3 +137,68 @@ def test_steam_and_gog_stubs_coexist(tmp_path):
     entries = json.loads((tmp_path / "search-index.json").read_text())
     ids = sorted(e[0] for e in entries)
     assert ids == ["480490", "gog:1158493447"]
+
+
+def test_protondb_signal_stub_for_app_absent_from_steam_catalog(tmp_path):
+    """An app that ProtonDB knows about but Steam dropped from GetAppList
+    falls through the steam_catalog stub pass. The signal-catalog fallback
+    picks it up using ProtonDB's stored title -- the #122 case.
+    """
+    _data_dir(tmp_path)
+    generate_search_index(
+        index_keys=set(),
+        data_output_path=tmp_path / "data",
+        output_path=tmp_path,
+        steam_catalog={},  # Steam dropped this app
+        protondb_known_app_ids={"236830"},
+        protondb_signal_titles={"236830": "Some Delisted Game"},
+    )
+    entries = json.loads((tmp_path / "search-index.json").read_text())
+    assert entries == [["236830", "Some Delisted Game", "", 0, 0, "steam"]]
+
+
+def test_protondb_signal_stub_does_not_duplicate_steam_catalog_entry(tmp_path):
+    """When an app is in BOTH steam_catalog and signal_titles, only one row
+    -- the steam_catalog pass owns it because that is the canonical title.
+    """
+    _data_dir(tmp_path)
+    generate_search_index(
+        index_keys=set(),
+        data_output_path=tmp_path / "data",
+        output_path=tmp_path,
+        steam_catalog={"480490": "Prey"},
+        protondb_known_app_ids={"480490"},
+        protondb_signal_titles={"480490": "Prey (ProtonDB title)"},
+    )
+    entries = json.loads((tmp_path / "search-index.json").read_text())
+    assert entries == [["480490", "Prey", "", 0, 0, "steam"]]
+
+
+def test_protondb_signal_stub_skips_empty_title(tmp_path):
+    """Some signal-catalog entries lack a title -- still cannot stub them."""
+    _data_dir(tmp_path)
+    generate_search_index(
+        index_keys=set(),
+        data_output_path=tmp_path / "data",
+        output_path=tmp_path,
+        steam_catalog={},
+        protondb_known_app_ids={"236830"},
+        protondb_signal_titles={"236830": ""},
+    )
+    entries = json.loads((tmp_path / "search-index.json").read_text())
+    assert entries == []
+
+
+def test_protondb_signal_stub_pass_is_noop_without_signal_titles(tmp_path):
+    """No signal_titles param -> no signal-catalog stub pass."""
+    _data_dir(tmp_path)
+    generate_search_index(
+        index_keys=set(),
+        data_output_path=tmp_path / "data",
+        output_path=tmp_path,
+        steam_catalog={"480490": "Prey"},
+        protondb_known_app_ids={"480490"},
+        protondb_signal_titles=None,
+    )
+    entries = json.loads((tmp_path / "search-index.json").read_text())
+    assert entries == [["480490", "Prey", "", 0, 0, "steam"]]


### PR DESCRIPTION
Two staging commits.

c5f890c ci: wire all functional workflows to discord-ci notifier
  Adds Deploy on merge to main, Sync staging repo, Update Epic Catalog, and
  Update GOG Catalog to discord-ci.yml's workflow_run list. workflow_run only
  fires from the default branch so this needs to land on main to activate.
  Discord-* notifier workflows are intentionally excluded -- they post to
  Discord, so a Discord outage cannot announce its own failure.

9e1255d feat(pipeline): protondb-signal stub fallback (closes #122)
  generate_search_index now takes protondb_signal_titles. After the
  steam_catalog stub pass, the new ProtonDB-only fallback emits a row for any
  signal-known app id absent from steam_catalog using the ProtonDB-stored
  title. This is the discovery half of #108: apps that Steam fully removed
  from GetAppList stay in the ProtonDB signal export, so we can still make
  them searchable.

After merge, the next full prod pipeline run (make gh-run) will surface
ProtonDB-only stubs and enrich_search_index_with_delisted will flag any
that the game-images cache confirms as delisted.

Tests: 4 new in tests/test_search_index_stubs.py.
Wiki: ProtonDB-only stub fallback section in Delisted-Detection.