### PR TITLE
Rating layout preference + delisted multi-signal refinements

### DIFF
--- a/about.html
+++ b/about.html
@@ -15,7 +15,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
+<link rel="stylesheet" href="css/shared/cards.css?v=eb6b6d9b">
 <link rel="stylesheet" href="css/index/index.css?v=d6d74d80">
 </head>
 <body>
@@ -194,7 +194,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=856ad13f"></script>
+<script src="js/lib/topbar.js?v=02244420"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/about/version.js?v=dd0d91d0"></script>
 </body>

--- a/about.html
+++ b/about.html
@@ -15,8 +15,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5a77b933">
-<link rel="stylesheet" href="css/index/index.css?v=d47ad49c">
+<link rel="stylesheet" href="css/shared/cards.css?v=3e6f26ea">
+<link rel="stylesheet" href="css/index/index.css?v=ae3ec6ba">
 </head>
 <body>
 

--- a/about.html
+++ b/about.html
@@ -15,8 +15,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=226fc2e4">
-<link rel="stylesheet" href="css/index/index.css?v=49ad1440">
+<link rel="stylesheet" href="css/shared/cards.css?v=f37cb570">
+<link rel="stylesheet" href="css/index/index.css?v=5d1b0b2f">
 </head>
 <body>
 

--- a/about.html
+++ b/about.html
@@ -15,8 +15,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=feb62384">
-<link rel="stylesheet" href="css/index/index.css?v=737d9ea1">
+<link rel="stylesheet" href="css/shared/cards.css?v=5ff17bf3">
+<link rel="stylesheet" href="css/index/index.css?v=4937adb2">
 </head>
 <body>
 

--- a/about.html
+++ b/about.html
@@ -15,8 +15,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=f95cc608">
-<link rel="stylesheet" href="css/index/index.css?v=d6d74d80">
+<link rel="stylesheet" href="css/shared/cards.css?v=5a77b933">
+<link rel="stylesheet" href="css/index/index.css?v=d47ad49c">
 </head>
 <body>
 

--- a/about.html
+++ b/about.html
@@ -15,8 +15,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5aa50963">
-<link rel="stylesheet" href="css/index/index.css?v=10ba7ed4">
+<link rel="stylesheet" href="css/shared/cards.css?v=06c0ca5e">
+<link rel="stylesheet" href="css/index/index.css?v=0634ef06">
 </head>
 <body>
 

--- a/about.html
+++ b/about.html
@@ -15,7 +15,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=eb6b6d9b">
+<link rel="stylesheet" href="css/shared/cards.css?v=f95cc608">
 <link rel="stylesheet" href="css/index/index.css?v=d6d74d80">
 </head>
 <body>

--- a/about.html
+++ b/about.html
@@ -15,8 +15,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=a6c64175">
-<link rel="stylesheet" href="css/index/index.css?v=dfc58003">
+<link rel="stylesheet" href="css/shared/cards.css?v=00fd0966">
+<link rel="stylesheet" href="css/index/index.css?v=80d71662">
 </head>
 <body>
 

--- a/about.html
+++ b/about.html
@@ -15,8 +15,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=93cb549c">
-<link rel="stylesheet" href="css/index/index.css?v=5348a551">
+<link rel="stylesheet" href="css/shared/cards.css?v=feb62384">
+<link rel="stylesheet" href="css/index/index.css?v=737d9ea1">
 </head>
 <body>
 

--- a/about.html
+++ b/about.html
@@ -15,8 +15,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=47cab2de">
-<link rel="stylesheet" href="css/index/index.css?v=47cc1a85">
+<link rel="stylesheet" href="css/shared/cards.css?v=c7090912">
+<link rel="stylesheet" href="css/index/index.css?v=5e2fb213">
 </head>
 <body>
 

--- a/about.html
+++ b/about.html
@@ -15,8 +15,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=00fd0966">
-<link rel="stylesheet" href="css/index/index.css?v=80d71662">
+<link rel="stylesheet" href="css/shared/cards.css?v=226fc2e4">
+<link rel="stylesheet" href="css/index/index.css?v=49ad1440">
 </head>
 <body>
 

--- a/about.html
+++ b/about.html
@@ -15,8 +15,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5ff17bf3">
-<link rel="stylesheet" href="css/index/index.css?v=4937adb2">
+<link rel="stylesheet" href="css/shared/cards.css?v=a6c64175">
+<link rel="stylesheet" href="css/index/index.css?v=dfc58003">
 </head>
 <body>
 

--- a/about.html
+++ b/about.html
@@ -15,8 +15,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=06c0ca5e">
-<link rel="stylesheet" href="css/index/index.css?v=0634ef06">
+<link rel="stylesheet" href="css/shared/cards.css?v=93cb549c">
+<link rel="stylesheet" href="css/index/index.css?v=5348a551">
 </head>
 <body>
 

--- a/about.html
+++ b/about.html
@@ -15,8 +15,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=f37cb570">
-<link rel="stylesheet" href="css/index/index.css?v=5d1b0b2f">
+<link rel="stylesheet" href="css/shared/cards.css?v=47cab2de">
+<link rel="stylesheet" href="css/index/index.css?v=47cc1a85">
 </head>
 <body>
 

--- a/about.html
+++ b/about.html
@@ -194,7 +194,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=02244420"></script>
+<script src="js/lib/topbar.js?v=7e8205f8"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/about/version.js?v=dd0d91d0"></script>
 </body>

--- a/about.html
+++ b/about.html
@@ -15,8 +15,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=3e6f26ea">
-<link rel="stylesheet" href="css/index/index.css?v=ae3ec6ba">
+<link rel="stylesheet" href="css/shared/cards.css?v=5aa50963">
+<link rel="stylesheet" href="css/index/index.css?v=10ba7ed4">
 </head>
 <body>
 

--- a/admin.html
+++ b/admin.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=93cb549c">
+<link rel="stylesheet" href="css/shared/cards.css?v=feb62384">
 <link rel="stylesheet" href="css/admin/admin.css?v=4609c726">
 </head>
 <body>

--- a/admin.html
+++ b/admin.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5a77b933">
+<link rel="stylesheet" href="css/shared/cards.css?v=3e6f26ea">
 <link rel="stylesheet" href="css/admin/admin.css?v=4609c726">
 </head>
 <body>

--- a/admin.html
+++ b/admin.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=00fd0966">
+<link rel="stylesheet" href="css/shared/cards.css?v=226fc2e4">
 <link rel="stylesheet" href="css/admin/admin.css?v=4609c726">
 </head>
 <body>

--- a/admin.html
+++ b/admin.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=feb62384">
+<link rel="stylesheet" href="css/shared/cards.css?v=5ff17bf3">
 <link rel="stylesheet" href="css/admin/admin.css?v=4609c726">
 </head>
 <body>

--- a/admin.html
+++ b/admin.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=eb6b6d9b">
+<link rel="stylesheet" href="css/shared/cards.css?v=f95cc608">
 <link rel="stylesheet" href="css/admin/admin.css?v=4609c726">
 </head>
 <body>

--- a/admin.html
+++ b/admin.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
+<link rel="stylesheet" href="css/shared/cards.css?v=eb6b6d9b">
 <link rel="stylesheet" href="css/admin/admin.css?v=4609c726">
 </head>
 <body>
@@ -320,7 +320,7 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/analytics.js?v=89bd7747"></script>
-<script src="js/lib/topbar.js?v=856ad13f"></script>
+<script src="js/lib/topbar.js?v=02244420"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/admin/main.js?v=9ffcb709"></script>
 </body>

--- a/admin.html
+++ b/admin.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=f95cc608">
+<link rel="stylesheet" href="css/shared/cards.css?v=5a77b933">
 <link rel="stylesheet" href="css/admin/admin.css?v=4609c726">
 </head>
 <body>

--- a/admin.html
+++ b/admin.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=a6c64175">
+<link rel="stylesheet" href="css/shared/cards.css?v=00fd0966">
 <link rel="stylesheet" href="css/admin/admin.css?v=4609c726">
 </head>
 <body>

--- a/admin.html
+++ b/admin.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=47cab2de">
+<link rel="stylesheet" href="css/shared/cards.css?v=c7090912">
 <link rel="stylesheet" href="css/admin/admin.css?v=4609c726">
 </head>
 <body>

--- a/admin.html
+++ b/admin.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=226fc2e4">
+<link rel="stylesheet" href="css/shared/cards.css?v=f37cb570">
 <link rel="stylesheet" href="css/admin/admin.css?v=4609c726">
 </head>
 <body>

--- a/admin.html
+++ b/admin.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5aa50963">
+<link rel="stylesheet" href="css/shared/cards.css?v=06c0ca5e">
 <link rel="stylesheet" href="css/admin/admin.css?v=4609c726">
 </head>
 <body>

--- a/admin.html
+++ b/admin.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=06c0ca5e">
+<link rel="stylesheet" href="css/shared/cards.css?v=93cb549c">
 <link rel="stylesheet" href="css/admin/admin.css?v=4609c726">
 </head>
 <body>

--- a/admin.html
+++ b/admin.html
@@ -320,7 +320,7 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/analytics.js?v=89bd7747"></script>
-<script src="js/lib/topbar.js?v=02244420"></script>
+<script src="js/lib/topbar.js?v=7e8205f8"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/admin/main.js?v=9ffcb709"></script>
 </body>

--- a/admin.html
+++ b/admin.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5ff17bf3">
+<link rel="stylesheet" href="css/shared/cards.css?v=a6c64175">
 <link rel="stylesheet" href="css/admin/admin.css?v=4609c726">
 </head>
 <body>

--- a/admin.html
+++ b/admin.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=f37cb570">
+<link rel="stylesheet" href="css/shared/cards.css?v=47cab2de">
 <link rel="stylesheet" href="css/admin/admin.css?v=4609c726">
 </head>
 <body>

--- a/admin.html
+++ b/admin.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=3e6f26ea">
+<link rel="stylesheet" href="css/shared/cards.css?v=5aa50963">
 <link rel="stylesheet" href="css/admin/admin.css?v=4609c726">
 </head>
 <body>

--- a/app.html
+++ b/app.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=5aa50963">
+<link rel="stylesheet" href="css/shared/cards.css?v=06c0ca5e">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/app.html
+++ b/app.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=5a77b933">
+<link rel="stylesheet" href="css/shared/cards.css?v=3e6f26ea">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/app.html
+++ b/app.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=feb62384">
+<link rel="stylesheet" href="css/shared/cards.css?v=5ff17bf3">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/app.html
+++ b/app.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=f95cc608">
+<link rel="stylesheet" href="css/shared/cards.css?v=5a77b933">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/app.html
+++ b/app.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=00fd0966">
+<link rel="stylesheet" href="css/shared/cards.css?v=226fc2e4">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/app.html
+++ b/app.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=93cb549c">
+<link rel="stylesheet" href="css/shared/cards.css?v=feb62384">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/app.html
+++ b/app.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=eb6b6d9b">
+<link rel="stylesheet" href="css/shared/cards.css?v=f95cc608">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/app.html
+++ b/app.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=226fc2e4">
+<link rel="stylesheet" href="css/shared/cards.css?v=f37cb570">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/app.html
+++ b/app.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=47cab2de">
+<link rel="stylesheet" href="css/shared/cards.css?v=c7090912">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/app.html
+++ b/app.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=a6c64175">
+<link rel="stylesheet" href="css/shared/cards.css?v=00fd0966">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/app.html
+++ b/app.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
+<link rel="stylesheet" href="css/shared/cards.css?v=eb6b6d9b">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
@@ -55,7 +55,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=856ad13f"></script>
+<script src="js/lib/topbar.js?v=02244420"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
 <script type="module" src="js/app/main.js?v=7417f4a4"></script>

--- a/app.html
+++ b/app.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=3e6f26ea">
+<link rel="stylesheet" href="css/shared/cards.css?v=5aa50963">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/app.html
+++ b/app.html
@@ -16,12 +16,12 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=f37cb570">
+<link rel="stylesheet" href="css/shared/cards.css?v=47cab2de">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
-<link rel="stylesheet" href="css/app/home.css?v=f48067b5">
+<link rel="stylesheet" href="css/app/home.css?v=4bf8008f">
 </head>
 <body>
 

--- a/app.html
+++ b/app.html
@@ -55,7 +55,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=02244420"></script>
+<script src="js/lib/topbar.js?v=7e8205f8"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
 <script type="module" src="js/app/main.js?v=7417f4a4"></script>

--- a/app.html
+++ b/app.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=5ff17bf3">
+<link rel="stylesheet" href="css/shared/cards.css?v=a6c64175">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/app.html
+++ b/app.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=06c0ca5e">
+<link rel="stylesheet" href="css/shared/cards.css?v=93cb549c">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/auth.html
+++ b/auth.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=f95cc608">
+<link rel="stylesheet" href="css/shared/cards.css?v=5a77b933">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/auth.html
+++ b/auth.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5aa50963">
+<link rel="stylesheet" href="css/shared/cards.css?v=06c0ca5e">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/auth.html
+++ b/auth.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=93cb549c">
+<link rel="stylesheet" href="css/shared/cards.css?v=feb62384">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/auth.html
+++ b/auth.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5a77b933">
+<link rel="stylesheet" href="css/shared/cards.css?v=3e6f26ea">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/auth.html
+++ b/auth.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=226fc2e4">
+<link rel="stylesheet" href="css/shared/cards.css?v=f37cb570">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/auth.html
+++ b/auth.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=47cab2de">
+<link rel="stylesheet" href="css/shared/cards.css?v=c7090912">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/auth.html
+++ b/auth.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
+<link rel="stylesheet" href="css/shared/cards.css?v=eb6b6d9b">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/auth.html
+++ b/auth.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=feb62384">
+<link rel="stylesheet" href="css/shared/cards.css?v=5ff17bf3">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/auth.html
+++ b/auth.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=00fd0966">
+<link rel="stylesheet" href="css/shared/cards.css?v=226fc2e4">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/auth.html
+++ b/auth.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=eb6b6d9b">
+<link rel="stylesheet" href="css/shared/cards.css?v=f95cc608">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/auth.html
+++ b/auth.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=a6c64175">
+<link rel="stylesheet" href="css/shared/cards.css?v=00fd0966">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/auth.html
+++ b/auth.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5ff17bf3">
+<link rel="stylesheet" href="css/shared/cards.css?v=a6c64175">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/auth.html
+++ b/auth.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=06c0ca5e">
+<link rel="stylesheet" href="css/shared/cards.css?v=93cb549c">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/auth.html
+++ b/auth.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=f37cb570">
+<link rel="stylesheet" href="css/shared/cards.css?v=47cab2de">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/auth.html
+++ b/auth.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=3e6f26ea">
+<link rel="stylesheet" href="css/shared/cards.css?v=5aa50963">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/confidence.html
+++ b/confidence.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=47cab2de">
+<link rel="stylesheet" href="css/shared/cards.css?v=c7090912">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/confidence.html
+++ b/confidence.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
+<link rel="stylesheet" href="css/shared/cards.css?v=eb6b6d9b">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
@@ -203,7 +203,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=856ad13f"></script>
+<script src="js/lib/topbar.js?v=02244420"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/confidence.html
+++ b/confidence.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=f95cc608">
+<link rel="stylesheet" href="css/shared/cards.css?v=5a77b933">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/confidence.html
+++ b/confidence.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=eb6b6d9b">
+<link rel="stylesheet" href="css/shared/cards.css?v=f95cc608">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/confidence.html
+++ b/confidence.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=93cb549c">
+<link rel="stylesheet" href="css/shared/cards.css?v=feb62384">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/confidence.html
+++ b/confidence.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=a6c64175">
+<link rel="stylesheet" href="css/shared/cards.css?v=00fd0966">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/confidence.html
+++ b/confidence.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5aa50963">
+<link rel="stylesheet" href="css/shared/cards.css?v=06c0ca5e">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/confidence.html
+++ b/confidence.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=feb62384">
+<link rel="stylesheet" href="css/shared/cards.css?v=5ff17bf3">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/confidence.html
+++ b/confidence.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5a77b933">
+<link rel="stylesheet" href="css/shared/cards.css?v=3e6f26ea">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/confidence.html
+++ b/confidence.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=00fd0966">
+<link rel="stylesheet" href="css/shared/cards.css?v=226fc2e4">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/confidence.html
+++ b/confidence.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=226fc2e4">
+<link rel="stylesheet" href="css/shared/cards.css?v=f37cb570">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/confidence.html
+++ b/confidence.html
@@ -12,12 +12,12 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=f37cb570">
+<link rel="stylesheet" href="css/shared/cards.css?v=47cab2de">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
-<link rel="stylesheet" href="css/app/home.css?v=f48067b5">
+<link rel="stylesheet" href="css/app/home.css?v=4bf8008f">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/confidence.html
+++ b/confidence.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5ff17bf3">
+<link rel="stylesheet" href="css/shared/cards.css?v=a6c64175">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/confidence.html
+++ b/confidence.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=06c0ca5e">
+<link rel="stylesheet" href="css/shared/cards.css?v=93cb549c">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/confidence.html
+++ b/confidence.html
@@ -203,7 +203,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=02244420"></script>
+<script src="js/lib/topbar.js?v=7e8205f8"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/confidence.html
+++ b/confidence.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=3e6f26ea">
+<link rel="stylesheet" href="css/shared/cards.css?v=5aa50963">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/css/app/home.css
+++ b/css/app/home.css
@@ -151,9 +151,13 @@
 .cards--md .game-card-thumb { width: 138px; height: 64px; }
 .cards--lg .game-card-thumb { width: 200px; height: 93px; }
 .cards--xl .game-card-thumb { width: 280px; height: 130px; }
-.cards--sm .game-card { gap: 12px; padding: 8px 12px 8px 8px; }
-.cards--lg .game-card { gap: 20px; padding: 14px 20px 14px 12px; }
-.cards--xl .game-card { gap: 24px; padding: 16px 22px 16px 14px; }
+/* Size-variant padding lives on .game-card-row so the bottom-bar strip
+   (a sibling of the row) can still reach the card's bottom and side
+   edges. Same change pattern as the matching .pg-list--XX rules in
+   css/index/index.css for the homescreen card. */
+.cards--sm .game-card-row { gap: 12px; padding: 8px 12px 8px 8px; }
+.cards--lg .game-card-row { gap: 20px; padding: 14px 20px 14px 12px; }
+.cards--xl .game-card-row { gap: 24px; padding: 16px 22px 16px 14px; }
 .cards--sm .game-card-title { font-size: 0.92rem; }
 .cards--lg .game-card-title { font-size: 1.12rem; }
 .cards--lg .game-card-sub { font-size: 0.85rem; }

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -245,7 +245,7 @@
   text-decoration: none;
   transition: box-shadow 0.15s, background 0.15s, transform 0.05s;
 }
-[data-card-layout="strip"] .pg-card { padding-bottom: 26px; }
+[data-card-layout="strip"] .pg-card { padding-bottom: 32px; }
 .pg-card-row {
   display: flex;
   align-items: center;
@@ -255,8 +255,6 @@
 /* Hide the bottom strip by default; "Rating layout: Bottom bar" flips it on. */
 .pg-card-strip { display: none; }
 [data-card-layout="strip"] .pg-card-strip {
-  /* Absolute positioning forces edge-to-edge spanning. See matching
-     .game-card-strip rule for the rationale. */
   position: absolute;
   left: 0;
   right: 0;
@@ -265,7 +263,8 @@
   align-items: center;
   justify-content: center;
   gap: 8px;
-  padding: 4px 14px;
+  height: 26px;
+  padding: 0 14px;
   background: var(--s2);
   color: var(--muted);
 }

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -258,9 +258,8 @@
   justify-content: center;
   gap: 8px;
   flex: 0 0 26px;
-  margin: 0 -16px;
-  width: calc(100% + 32px);
-  padding: 0 30px;
+  width: 100%;
+  padding: 0 14px;
   background: var(--s2);
   color: var(--muted);
   box-sizing: border-box;
@@ -406,16 +405,20 @@
 .pg-layout-btn.active { color: var(--accent); border-color: var(--accent); background: rgba(74,159,208,0.08); }
 
 /* S/M/L/XL card sizes */
+/* Size modifiers redirect spacing to .pg-card-row instead of .pg-card so
+   the bottom-bar strip (a sibling of the row) can still reach the card's
+   bottom and side edges. Putting padding on .pg-card itself would inset
+   every child including the strip. */
 .pg-list--sm .pg-thumb { width: 68px; height: 32px; }
-.pg-list--sm .pg-card { gap: 10px; padding: 6px 10px 6px 6px; }
+.pg-list--sm .pg-card-row { gap: 10px; padding: 6px 10px 6px 6px; }
 .pg-list--sm .pg-title { font-size: 0.85rem; }
 .pg-list--md .pg-thumb { width: 92px; height: 43px; }
 .pg-list--lg .pg-thumb { width: 130px; height: 61px; }
-.pg-list--lg .pg-card { gap: 18px; padding: 10px 16px 10px 10px; }
+.pg-list--lg .pg-card-row { gap: 18px; padding: 10px 16px 10px 10px; }
 .pg-list--lg .pg-title { font-size: 1.05rem; }
 .pg-list--lg .pg-sub { font-size: 0.82rem; }
 .pg-list--xl .pg-thumb { width: 184px; height: 86px; }
-.pg-list--xl .pg-card { gap: 20px; padding: 12px 18px 12px 12px; }
+.pg-list--xl .pg-card-row { gap: 20px; padding: 12px 18px 12px 12px; }
 .pg-list--xl .pg-title { font-size: 1.15rem; }
 .pg-list--xl .pg-sub { font-size: 0.88rem; }
 /* XL only makes sense on wider screens */

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -252,13 +252,20 @@
 /* Hide the bottom strip by default; "Rating layout: Bottom bar" flips it on. */
 .pg-card-strip { display: none; }
 [data-card-layout="strip"] .pg-card-strip {
+  position: relative;
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
   gap: 8px;
-  padding: 7px 14px;
+  padding: 3px 14px;
   background: var(--s2);
   color: var(--muted);
+}
+[data-card-layout="strip"] .pg-card-strip .game-card-store-pill {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
 }
 [data-card-layout="strip"] .pg-card-strip[data-tier="platinum"] { background: linear-gradient(90deg, #b4c7dc, #cad8e7); color: #0a0c10; }
 [data-card-layout="strip"] .pg-card-strip[data-tier="gold"]     { background: linear-gradient(90deg, #cfb274, #e4cb8f); color: #0a0c10; }
@@ -266,10 +273,11 @@
 [data-card-layout="strip"] .pg-card-strip[data-tier="bronze"]   { background: linear-gradient(90deg, #b07d4f, #cf9e6f); color: #0a0c10; }
 [data-card-layout="strip"] .pg-card-strip[data-tier="borked"]   { background: linear-gradient(90deg, #884444, #b25555); color: #fff; }
 [data-card-layout="strip"] .pg-card-strip-tier {
-  font-size: 0.78rem;
+  font-size: 0.7rem;
   font-weight: 800;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+  line-height: 1.2;
 }
 [data-card-layout="strip"] .pg-card-strip .game-card-store-pill {
   background: rgba(0, 0, 0, 0.22) !important;

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -235,15 +235,49 @@
 }
 .pg-card {
   display: flex;
-  align-items: center;
-  gap: 14px;
-  padding: 8px 14px 8px 8px;
+  flex-direction: column;
   border: 1px solid var(--border);
   border-radius: 10px;
   background: var(--card);
+  overflow: hidden;
   text-decoration: none;
   transition: border-color 0.15s, background 0.15s, transform 0.05s;
 }
+.pg-card-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 8px 14px 8px 8px;
+}
+/* Hide the bottom strip by default; "Rating layout: Bottom bar" flips it on. */
+.pg-card-strip { display: none; }
+[data-card-layout="strip"] .pg-card-strip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 7px 14px;
+  background: var(--s2);
+  color: var(--muted);
+}
+[data-card-layout="strip"] .pg-card-strip[data-tier="platinum"] { background: linear-gradient(90deg, #b4c7dc, #cad8e7); color: #0a0c10; }
+[data-card-layout="strip"] .pg-card-strip[data-tier="gold"]     { background: linear-gradient(90deg, #cfb274, #e4cb8f); color: #0a0c10; }
+[data-card-layout="strip"] .pg-card-strip[data-tier="silver"]   { background: linear-gradient(90deg, #a8b1bd, #c5cdd7); color: #0a0c10; }
+[data-card-layout="strip"] .pg-card-strip[data-tier="bronze"]   { background: linear-gradient(90deg, #b07d4f, #cf9e6f); color: #0a0c10; }
+[data-card-layout="strip"] .pg-card-strip[data-tier="borked"]   { background: linear-gradient(90deg, #884444, #b25555); color: #fff; }
+[data-card-layout="strip"] .pg-card-strip-tier {
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+[data-card-layout="strip"] .pg-card-strip .game-card-store-pill {
+  background: rgba(0, 0, 0, 0.22) !important;
+  color: inherit;
+  font-size: 0.62rem;
+  padding: 2px 8px;
+}
+[data-card-layout="strip"] .pg-right { display: none; }
 .pg-card:hover { border-color: var(--accent); }
 .pg-card:active { transform: translateY(1px); }
 .pg-thumb-wrap {

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -258,8 +258,9 @@
   justify-content: center;
   gap: 8px;
   flex: 0 0 26px;
-  width: 100%;
-  padding: 0 14px;
+  margin: 0 -16px;
+  width: calc(100% + 32px);
+  padding: 0 30px;
   background: var(--s2);
   color: var(--muted);
   box-sizing: border-box;

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -263,6 +263,8 @@
   background: var(--s2);
   color: var(--muted);
   box-sizing: border-box;
+  border-bottom-left-radius: 10px;
+  border-bottom-right-radius: 10px;
 }
 [data-card-layout="strip"] .pg-card-strip .game-card-store-pill {
   position: absolute;

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -234,11 +234,10 @@
   gap: 10px;
 }
 .pg-card {
+  position: relative;
   display: flex;
   flex-direction: column;
   border: 0;
-  /* box-shadow outline so the inside strip can fill edge-to-edge; see
-     the matching .game-card rule for the rationale. */
   box-shadow: 0 0 0 1px var(--border);
   border-radius: 10px;
   background: var(--card);
@@ -246,6 +245,7 @@
   text-decoration: none;
   transition: box-shadow 0.15s, background 0.15s, transform 0.05s;
 }
+[data-card-layout="strip"] .pg-card { padding-bottom: 26px; }
 .pg-card-row {
   display: flex;
   align-items: center;
@@ -255,15 +255,17 @@
 /* Hide the bottom strip by default; "Rating layout: Bottom bar" flips it on. */
 .pg-card-strip { display: none; }
 [data-card-layout="strip"] .pg-card-strip {
-  position: relative;
+  /* Absolute positioning forces edge-to-edge spanning. See matching
+     .game-card-strip rule for the rationale. */
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 8px;
-  align-self: stretch;
-  margin-left: -1px;
-  margin-right: -1px;
-  padding: 4px 15px;
+  padding: 4px 14px;
   background: var(--s2);
   color: var(--muted);
 }

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -259,7 +259,7 @@
   gap: 8px;
   flex: 0 0 26px;
   width: 100%;
-  margin-top: 6px;
+  margin-top: 12px;
   padding: 0 14px;
   background: var(--s2);
   color: var(--muted);

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -260,9 +260,14 @@
   align-items: center;
   justify-content: center;
   gap: 8px;
+  width: 100%;
   padding: 3px 14px;
   background: var(--s2);
   color: var(--muted);
+  /* Rounded bottom corners that follow the parent .pg-card border-radius
+     so the bar reads as part of the card, not a separate inset block. */
+  border-bottom-left-radius: 10px;
+  border-bottom-right-radius: 10px;
 }
 [data-card-layout="strip"] .pg-card-strip .game-card-store-pill {
   position: absolute;

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -260,14 +260,12 @@
   align-items: center;
   justify-content: center;
   gap: 8px;
-  width: 100%;
-  padding: 3px 14px;
+  align-self: stretch;
+  margin-left: -1px;
+  margin-right: -1px;
+  padding: 4px 15px;
   background: var(--s2);
   color: var(--muted);
-  /* Rounded bottom corners that follow the parent .pg-card border-radius
-     so the bar reads as part of the card, not a separate inset block. */
-  border-bottom-left-radius: 10px;
-  border-bottom-right-radius: 10px;
 }
 [data-card-layout="strip"] .pg-card-strip .game-card-store-pill {
   position: absolute;

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -234,7 +234,6 @@
   gap: 10px;
 }
 .pg-card {
-  position: relative;
   display: flex;
   flex-direction: column;
   border: 0;
@@ -245,7 +244,6 @@
   text-decoration: none;
   transition: box-shadow 0.15s, background 0.15s, transform 0.05s;
 }
-[data-card-layout="strip"] .pg-card { padding-bottom: 32px; }
 .pg-card-row {
   display: flex;
   align-items: center;
@@ -255,18 +253,16 @@
 /* Hide the bottom strip by default; "Rating layout: Bottom bar" flips it on. */
 .pg-card-strip { display: none; }
 [data-card-layout="strip"] .pg-card-strip {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 8px;
-  height: 26px;
+  flex: 0 0 26px;
+  width: 100%;
   padding: 0 14px;
   background: var(--s2);
   color: var(--muted);
+  box-sizing: border-box;
 }
 [data-card-layout="strip"] .pg-card-strip .game-card-store-pill {
   position: absolute;

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -259,6 +259,7 @@
   gap: 8px;
   flex: 0 0 26px;
   width: 100%;
+  margin-top: 6px;
   padding: 0 14px;
   background: var(--s2);
   color: var(--muted);

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -236,12 +236,15 @@
 .pg-card {
   display: flex;
   flex-direction: column;
-  border: 1px solid var(--border);
+  border: 0;
+  /* box-shadow outline so the inside strip can fill edge-to-edge; see
+     the matching .game-card rule for the rationale. */
+  box-shadow: 0 0 0 1px var(--border);
   border-radius: 10px;
   background: var(--card);
   overflow: hidden;
   text-decoration: none;
-  transition: border-color 0.15s, background 0.15s, transform 0.05s;
+  transition: box-shadow 0.15s, background 0.15s, transform 0.05s;
 }
 .pg-card-row {
   display: flex;
@@ -286,7 +289,7 @@
   padding: 2px 8px;
 }
 [data-card-layout="strip"] .pg-right { display: none; }
-.pg-card:hover { border-color: var(--accent); }
+.pg-card:hover { box-shadow: 0 0 0 1px var(--accent); }
 .pg-card:active { transform: translateY(1px); }
 .pg-thumb-wrap {
   position: relative;

--- a/css/shared/cards.css
+++ b/css/shared/cards.css
@@ -17,8 +17,9 @@
   transition: box-shadow 0.15s, background 0.15s, transform 0.05s;
 }
 /* Reserve room for the absolutely-positioned strip in strip mode so the
-   card grows by the strip height instead of overlapping the row content. */
-[data-card-layout="strip"] .game-card { padding-bottom: 26px; }
+   card grows by the strip height instead of overlapping the row content.
+   The padding-bottom must match the strip's fixed height below. */
+[data-card-layout="strip"] .game-card { padding-bottom: 32px; }
 .game-card-row {
   display: flex;
   align-items: center;
@@ -161,10 +162,6 @@
    Toggle lives in options.html as "Rating layout". See #111. */
 .game-card-strip { display: none; }
 [data-card-layout="strip"] .game-card-strip {
-  /* Absolute positioning forces the strip to span left:0 to right:0 of the
-     card -- the flex/stretch approach left a visible inset in some
-     browsers. overflow: hidden on .game-card clips the bottom corners
-     so the bar follows the card's rounded outline. */
   position: absolute;
   left: 0;
   right: 0;
@@ -173,7 +170,8 @@
   align-items: center;
   justify-content: center;
   gap: 8px;
-  padding: 4px 14px;
+  height: 26px;
+  padding: 0 14px;
   background: var(--s2);
   color: var(--muted);
 }

--- a/css/shared/cards.css
+++ b/css/shared/cards.css
@@ -144,6 +144,29 @@
   opacity: 0.7;
   padding-right: 10px;
 }
+
+/* Strip card layout (data-card-layout="strip"): hide the right column,
+   show the rating row beneath the title so long names get the full body
+   width. Especially useful on mobile where the right column squeezes the
+   title to ~half the card width.
+   See #111 -- toggle lives in options.html as "Card layout". */
+.game-card-strip { display: none; }
+[data-card-layout="strip"] .game-card-strip {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+}
+[data-card-layout="strip"] .game-card-strip .game-card-pills {
+  /* Strip mode keeps pills horizontal even on narrow mobile widths --
+     the override in @media (max-width: 600px) above would otherwise
+     stack them vertically against the right edge. */
+  flex-direction: row;
+  align-items: center;
+  gap: 6px;
+}
+[data-card-layout="strip"] .game-card-right { display: none; }
 .load-more-btn {
   display: block;
   margin: 12px auto 0;

--- a/css/shared/cards.css
+++ b/css/shared/cards.css
@@ -4,16 +4,21 @@
    Mobile: thumbnail shrinks to 60x28, title stays bold, sub truncates.        */
 .game-card {
   display: flex;
-  align-items: center;
-  gap: 14px;
-  padding: 8px 14px 8px 8px;
+  flex-direction: column;
   background: var(--s1);
   border: 1px solid var(--border);
   border-radius: 10px;
+  overflow: hidden;
   text-decoration: none;
   color: inherit;
   cursor: pointer;
   transition: border-color 0.15s, background 0.15s, transform 0.05s;
+}
+.game-card-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 8px 14px 8px 8px;
 }
 .game-card:hover { border-color: var(--accent); text-decoration: none; }
 .game-card:active { transform: translateY(1px); }
@@ -145,20 +150,17 @@
   padding-right: 10px;
 }
 
-/* Strip card layout (data-card-layout="strip"): hide the right column,
-   show a tier-colored bar beneath the title spanning the full card body
-   width. Mirrors ProtonDB's card design so long names get the title row
-   to themselves. Toggle lives in options.html as "Card layout".
-   See #111. */
+/* Bottom-bar layout (data-card-layout="strip"): hide the right column,
+   show a tier-colored bar spanning the full card width across the bottom,
+   mirroring ProtonDB's card design. Title row gets the full body width.
+   Toggle lives in options.html as "Rating layout". See #111. */
 .game-card-strip { display: none; }
 [data-card-layout="strip"] .game-card-strip {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  margin-top: 8px;
-  padding: 6px 12px;
-  border-radius: 5px;
+  padding: 7px 14px;
   background: var(--s2);
   color: var(--muted);
 }

--- a/css/shared/cards.css
+++ b/css/shared/cards.css
@@ -162,13 +162,15 @@
   justify-content: center;
   gap: 8px;
   flex: 0 0 26px;
-  width: 100%;
-  padding: 0 14px;
+  /* Aggressive negative-margin bleed pushes the strip past any phantom
+     padding on the card. overflow: hidden on the card clips the bleed
+     so it never visually overshoots the card outline. */
+  margin: 0 -16px;
+  width: calc(100% + 32px);
+  padding: 0 30px;
   background: var(--s2);
   color: var(--muted);
   box-sizing: border-box;
-  /* Explicit bottom-corner radius matches the card's outer 10px so the bar
-     curves into the card outline instead of squaring off inside it. */
   border-bottom-left-radius: 10px;
   border-bottom-right-radius: 10px;
 }

--- a/css/shared/cards.css
+++ b/css/shared/cards.css
@@ -3,14 +3,11 @@
    Use renderGameCard() in js/app/lib/card.js to generate the HTML.
    Mobile: thumbnail shrinks to 60x28, title stays bold, sub truncates.        */
 .game-card {
+  position: relative;
   display: flex;
   flex-direction: column;
   background: var(--s1);
   border: 0;
-  /* box-shadow draws the outline OUTSIDE the box so the inside content
-     (including a tier strip at the bottom) can fill edge-to-edge without
-     a 1px border peeking between the strip background and the card's
-     rounded corner. */
   box-shadow: 0 0 0 1px var(--border);
   border-radius: 10px;
   overflow: hidden;
@@ -19,6 +16,9 @@
   cursor: pointer;
   transition: box-shadow 0.15s, background 0.15s, transform 0.05s;
 }
+/* Reserve room for the absolutely-positioned strip in strip mode so the
+   card grows by the strip height instead of overlapping the row content. */
+[data-card-layout="strip"] .game-card { padding-bottom: 26px; }
 .game-card-row {
   display: flex;
   align-items: center;
@@ -161,20 +161,19 @@
    Toggle lives in options.html as "Rating layout". See #111. */
 .game-card-strip { display: none; }
 [data-card-layout="strip"] .game-card-strip {
-  position: relative;
+  /* Absolute positioning forces the strip to span left:0 to right:0 of the
+     card -- the flex/stretch approach left a visible inset in some
+     browsers. overflow: hidden on .game-card clips the bottom corners
+     so the bar follows the card's rounded outline. */
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 8px;
-  align-self: stretch;
-  /* Negative horizontal margin lets the strip bleed past any phantom
-     inset (some flex implementations leave a ~1px gap at the trailing
-     edge when align-self: stretch meets overflow: hidden). Card has
-     overflow: hidden + border-radius: 10px, which clips both the
-     bottom corners and the horizontal bleed. */
-  margin-left: -1px;
-  margin-right: -1px;
-  padding: 4px 15px;
+  padding: 4px 14px;
   background: var(--s2);
   color: var(--muted);
 }

--- a/css/shared/cards.css
+++ b/css/shared/cards.css
@@ -166,9 +166,17 @@
   align-items: center;
   justify-content: center;
   gap: 8px;
+  width: 100%;
   padding: 3px 14px;
   background: var(--s2);
   color: var(--muted);
+  /* Match the parent card's border-radius so the bar's bottom corners
+     curve into the card outline instead of squaring off. Belt-and-
+     suspenders -- the card has overflow: hidden too, but some browsers
+     still paint the corners square inside an overflow-hidden flex parent
+     when the child is the last in flow. */
+  border-bottom-left-radius: 10px;
+  border-bottom-right-radius: 10px;
 }
 [data-card-layout="strip"] .game-card-strip .game-card-store-pill {
   position: absolute;

--- a/css/shared/cards.css
+++ b/css/shared/cards.css
@@ -156,13 +156,20 @@
    Toggle lives in options.html as "Rating layout". See #111. */
 .game-card-strip { display: none; }
 [data-card-layout="strip"] .game-card-strip {
+  position: relative;
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
   gap: 8px;
-  padding: 7px 14px;
+  padding: 3px 14px;
   background: var(--s2);
   color: var(--muted);
+}
+[data-card-layout="strip"] .game-card-strip .game-card-store-pill {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
 }
 [data-card-layout="strip"] .game-card-strip[data-tier="platinum"] { background: linear-gradient(90deg, #b4c7dc, #cad8e7); color: #0a0c10; }
 [data-card-layout="strip"] .game-card-strip[data-tier="gold"]     { background: linear-gradient(90deg, #cfb274, #e4cb8f); color: #0a0c10; }
@@ -170,10 +177,11 @@
 [data-card-layout="strip"] .game-card-strip[data-tier="bronze"]   { background: linear-gradient(90deg, #b07d4f, #cf9e6f); color: #0a0c10; }
 [data-card-layout="strip"] .game-card-strip[data-tier="borked"]   { background: linear-gradient(90deg, #884444, #b25555); color: #fff; }
 [data-card-layout="strip"] .game-card-strip-tier {
-  font-size: 0.78rem;
+  font-size: 0.7rem;
   font-weight: 800;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+  line-height: 1.2;
 }
 [data-card-layout="strip"] .game-card-strip .game-card-store-pill {
   /* Knock the store pill darker so it reads as a chip on top of the

--- a/css/shared/cards.css
+++ b/css/shared/cards.css
@@ -162,12 +162,8 @@
   justify-content: center;
   gap: 8px;
   flex: 0 0 26px;
-  /* Aggressive negative-margin bleed pushes the strip past any phantom
-     padding on the card. overflow: hidden on the card clips the bleed
-     so it never visually overshoots the card outline. */
-  margin: 0 -16px;
-  width: calc(100% + 32px);
-  padding: 0 30px;
+  width: 100%;
+  padding: 0 14px;
   background: var(--s2);
   color: var(--muted);
   box-sizing: border-box;

--- a/css/shared/cards.css
+++ b/css/shared/cards.css
@@ -146,25 +146,40 @@
 }
 
 /* Strip card layout (data-card-layout="strip"): hide the right column,
-   show the rating row beneath the title so long names get the full body
-   width. Especially useful on mobile where the right column squeezes the
-   title to ~half the card width.
-   See #111 -- toggle lives in options.html as "Card layout". */
+   show a tier-colored bar beneath the title spanning the full card body
+   width. Mirrors ProtonDB's card design so long names get the title row
+   to themselves. Toggle lives in options.html as "Card layout".
+   See #111. */
 .game-card-strip { display: none; }
 [data-card-layout="strip"] .game-card-strip {
   display: flex;
   align-items: center;
-  flex-wrap: wrap;
+  justify-content: space-between;
   gap: 8px;
   margin-top: 8px;
+  padding: 6px 12px;
+  border-radius: 5px;
+  background: var(--s2);
+  color: var(--muted);
 }
-[data-card-layout="strip"] .game-card-strip .game-card-pills {
-  /* Strip mode keeps pills horizontal even on narrow mobile widths --
-     the override in @media (max-width: 600px) above would otherwise
-     stack them vertically against the right edge. */
-  flex-direction: row;
-  align-items: center;
-  gap: 6px;
+[data-card-layout="strip"] .game-card-strip[data-tier="platinum"] { background: linear-gradient(90deg, #b4c7dc, #cad8e7); color: #0a0c10; }
+[data-card-layout="strip"] .game-card-strip[data-tier="gold"]     { background: linear-gradient(90deg, #cfb274, #e4cb8f); color: #0a0c10; }
+[data-card-layout="strip"] .game-card-strip[data-tier="silver"]   { background: linear-gradient(90deg, #a8b1bd, #c5cdd7); color: #0a0c10; }
+[data-card-layout="strip"] .game-card-strip[data-tier="bronze"]   { background: linear-gradient(90deg, #b07d4f, #cf9e6f); color: #0a0c10; }
+[data-card-layout="strip"] .game-card-strip[data-tier="borked"]   { background: linear-gradient(90deg, #884444, #b25555); color: #fff; }
+[data-card-layout="strip"] .game-card-strip-tier {
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+[data-card-layout="strip"] .game-card-strip .game-card-store-pill {
+  /* Knock the store pill darker so it reads as a chip on top of the
+     tier-colored bar instead of competing with it. */
+  background: rgba(0, 0, 0, 0.22) !important;
+  color: inherit;
+  font-size: 0.62rem;
+  padding: 2px 8px;
 }
 [data-card-layout="strip"] .game-card-right { display: none; }
 .load-more-btn {

--- a/css/shared/cards.css
+++ b/css/shared/cards.css
@@ -168,7 +168,7 @@
   width: 100%;
   /* margin-top adds breathing space between the row text and the rating
      strip so the title/sub aren't sandwiched against the bar. */
-  margin-top: 6px;
+  margin-top: 12px;
   padding: 0 14px;
   background: var(--s2);
   color: var(--muted);

--- a/css/shared/cards.css
+++ b/css/shared/cards.css
@@ -167,6 +167,10 @@
   background: var(--s2);
   color: var(--muted);
   box-sizing: border-box;
+  /* Explicit bottom-corner radius matches the card's outer 10px so the bar
+     curves into the card outline instead of squaring off inside it. */
+  border-bottom-left-radius: 10px;
+  border-bottom-right-radius: 10px;
 }
 [data-card-layout="strip"] .game-card-strip .game-card-store-pill {
   position: absolute;

--- a/css/shared/cards.css
+++ b/css/shared/cards.css
@@ -54,7 +54,10 @@
 /* Desktop: give the report rows more presence with a bigger boxart and
    roomier padding. Steam header ratio (~2.14:1) is preserved. */
 @media (min-width: 760px) {
-  .game-card { gap: 18px; padding: 11px 18px 11px 11px; }
+  /* Padding goes on .game-card-row so the bottom-bar strip (a sibling) can
+     still reach the card's bottom and side edges. See the matching note
+     on the size-modifier rules below. */
+  .game-card-row { gap: 18px; padding: 11px 18px 11px 11px; }
   .game-card-thumb { width: 138px; height: 64px; border-radius: 8px; }
   .game-card-title { font-size: 1.04rem; }
   .game-card-sub { font-size: 0.82rem; }
@@ -163,6 +166,9 @@
   gap: 8px;
   flex: 0 0 26px;
   width: 100%;
+  /* margin-top adds breathing space between the row text and the rating
+     strip so the title/sub aren't sandwiched against the bar. */
+  margin-top: 6px;
   padding: 0 14px;
   background: var(--s2);
   color: var(--muted);

--- a/css/shared/cards.css
+++ b/css/shared/cards.css
@@ -3,7 +3,6 @@
    Use renderGameCard() in js/app/lib/card.js to generate the HTML.
    Mobile: thumbnail shrinks to 60x28, title stays bold, sub truncates.        */
 .game-card {
-  position: relative;
   display: flex;
   flex-direction: column;
   background: var(--s1);
@@ -16,10 +15,6 @@
   cursor: pointer;
   transition: box-shadow 0.15s, background 0.15s, transform 0.05s;
 }
-/* Reserve room for the absolutely-positioned strip in strip mode so the
-   card grows by the strip height instead of overlapping the row content.
-   The padding-bottom must match the strip's fixed height below. */
-[data-card-layout="strip"] .game-card { padding-bottom: 32px; }
 .game-card-row {
   display: flex;
   align-items: center;
@@ -162,18 +157,16 @@
    Toggle lives in options.html as "Rating layout". See #111. */
 .game-card-strip { display: none; }
 [data-card-layout="strip"] .game-card-strip {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 8px;
-  height: 26px;
+  flex: 0 0 26px;
+  width: 100%;
   padding: 0 14px;
   background: var(--s2);
   color: var(--muted);
+  box-sizing: border-box;
 }
 [data-card-layout="strip"] .game-card-strip .game-card-store-pill {
   position: absolute;

--- a/css/shared/cards.css
+++ b/css/shared/cards.css
@@ -6,13 +6,18 @@
   display: flex;
   flex-direction: column;
   background: var(--s1);
-  border: 1px solid var(--border);
+  border: 0;
+  /* box-shadow draws the outline OUTSIDE the box so the inside content
+     (including a tier strip at the bottom) can fill edge-to-edge without
+     a 1px border peeking between the strip background and the card's
+     rounded corner. */
+  box-shadow: 0 0 0 1px var(--border);
   border-radius: 10px;
   overflow: hidden;
   text-decoration: none;
   color: inherit;
   cursor: pointer;
-  transition: border-color 0.15s, background 0.15s, transform 0.05s;
+  transition: box-shadow 0.15s, background 0.15s, transform 0.05s;
 }
 .game-card-row {
   display: flex;
@@ -20,7 +25,7 @@
   gap: 14px;
   padding: 8px 14px 8px 8px;
 }
-.game-card:hover { border-color: var(--accent); text-decoration: none; }
+.game-card:hover { box-shadow: 0 0 0 1px var(--accent); text-decoration: none; }
 .game-card:active { transform: translateY(1px); }
 .game-card-thumb-wrap {
   position: relative;

--- a/css/shared/cards.css
+++ b/css/shared/cards.css
@@ -166,17 +166,17 @@
   align-items: center;
   justify-content: center;
   gap: 8px;
-  width: 100%;
-  padding: 3px 14px;
+  align-self: stretch;
+  /* Negative horizontal margin lets the strip bleed past any phantom
+     inset (some flex implementations leave a ~1px gap at the trailing
+     edge when align-self: stretch meets overflow: hidden). Card has
+     overflow: hidden + border-radius: 10px, which clips both the
+     bottom corners and the horizontal bleed. */
+  margin-left: -1px;
+  margin-right: -1px;
+  padding: 4px 15px;
   background: var(--s2);
   color: var(--muted);
-  /* Match the parent card's border-radius so the bar's bottom corners
-     curve into the card outline instead of squaring off. Belt-and-
-     suspenders -- the card has overflow: hidden too, but some browsers
-     still paint the corners square inside an overflow-hidden flex parent
-     when the child is the last in flow. */
-  border-bottom-left-radius: 10px;
-  border-bottom-right-radius: 10px;
 }
 [data-card-layout="strip"] .game-card-strip .game-card-store-pill {
   position: absolute;

--- a/game-stats.html
+++ b/game-stats.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=47cab2de">
+<link rel="stylesheet" href="css/shared/cards.css?v=c7090912">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/game-stats.html
+++ b/game-stats.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=f95cc608">
+<link rel="stylesheet" href="css/shared/cards.css?v=5a77b933">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/game-stats.html
+++ b/game-stats.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=eb6b6d9b">
+<link rel="stylesheet" href="css/shared/cards.css?v=f95cc608">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/game-stats.html
+++ b/game-stats.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=93cb549c">
+<link rel="stylesheet" href="css/shared/cards.css?v=feb62384">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/game-stats.html
+++ b/game-stats.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=a6c64175">
+<link rel="stylesheet" href="css/shared/cards.css?v=00fd0966">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/game-stats.html
+++ b/game-stats.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5aa50963">
+<link rel="stylesheet" href="css/shared/cards.css?v=06c0ca5e">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/game-stats.html
+++ b/game-stats.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=feb62384">
+<link rel="stylesheet" href="css/shared/cards.css?v=5ff17bf3">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/game-stats.html
+++ b/game-stats.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
+<link rel="stylesheet" href="css/shared/cards.css?v=eb6b6d9b">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
@@ -309,7 +309,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=856ad13f"></script>
+<script src="js/lib/topbar.js?v=02244420"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/game-stats.html
+++ b/game-stats.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5a77b933">
+<link rel="stylesheet" href="css/shared/cards.css?v=3e6f26ea">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/game-stats.html
+++ b/game-stats.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=00fd0966">
+<link rel="stylesheet" href="css/shared/cards.css?v=226fc2e4">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/game-stats.html
+++ b/game-stats.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=226fc2e4">
+<link rel="stylesheet" href="css/shared/cards.css?v=f37cb570">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/game-stats.html
+++ b/game-stats.html
@@ -12,12 +12,12 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=f37cb570">
+<link rel="stylesheet" href="css/shared/cards.css?v=47cab2de">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
-<link rel="stylesheet" href="css/app/home.css?v=f48067b5">
+<link rel="stylesheet" href="css/app/home.css?v=4bf8008f">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/game-stats.html
+++ b/game-stats.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5ff17bf3">
+<link rel="stylesheet" href="css/shared/cards.css?v=a6c64175">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/game-stats.html
+++ b/game-stats.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=06c0ca5e">
+<link rel="stylesheet" href="css/shared/cards.css?v=93cb549c">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/game-stats.html
+++ b/game-stats.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=3e6f26ea">
+<link rel="stylesheet" href="css/shared/cards.css?v=5aa50963">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/game-stats.html
+++ b/game-stats.html
@@ -309,7 +309,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=02244420"></script>
+<script src="js/lib/topbar.js?v=7e8205f8"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=feb62384">
-<link rel="stylesheet" href="css/index/index.css?v=737d9ea1">
+<link rel="stylesheet" href="css/shared/cards.css?v=5ff17bf3">
+<link rel="stylesheet" href="css/index/index.css?v=4937adb2">
 </head>
 <body>
 

--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=a6c64175">
-<link rel="stylesheet" href="css/index/index.css?v=dfc58003">
+<link rel="stylesheet" href="css/shared/cards.css?v=00fd0966">
+<link rel="stylesheet" href="css/index/index.css?v=80d71662">
 </head>
 <body>
 

--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=47cab2de">
-<link rel="stylesheet" href="css/index/index.css?v=47cc1a85">
+<link rel="stylesheet" href="css/shared/cards.css?v=c7090912">
+<link rel="stylesheet" href="css/index/index.css?v=5e2fb213">
 </head>
 <body>
 

--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=5aa50963">
-<link rel="stylesheet" href="css/index/index.css?v=10ba7ed4">
+<link rel="stylesheet" href="css/shared/cards.css?v=06c0ca5e">
+<link rel="stylesheet" href="css/index/index.css?v=0634ef06">
 </head>
 <body>
 

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
+<link rel="stylesheet" href="css/shared/cards.css?v=eb6b6d9b">
 <link rel="stylesheet" href="css/index/index.css?v=d6d74d80">
 </head>
 <body>
@@ -219,7 +219,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=856ad13f"></script>
+<script src="js/lib/topbar.js?v=02244420"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/index/main.js?v=d53cf296"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=226fc2e4">
-<link rel="stylesheet" href="css/index/index.css?v=49ad1440">
+<link rel="stylesheet" href="css/shared/cards.css?v=f37cb570">
+<link rel="stylesheet" href="css/index/index.css?v=5d1b0b2f">
 </head>
 <body>
 

--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=5a77b933">
-<link rel="stylesheet" href="css/index/index.css?v=d47ad49c">
+<link rel="stylesheet" href="css/shared/cards.css?v=3e6f26ea">
+<link rel="stylesheet" href="css/index/index.css?v=ae3ec6ba">
 </head>
 <body>
 

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=eb6b6d9b">
+<link rel="stylesheet" href="css/shared/cards.css?v=f95cc608">
 <link rel="stylesheet" href="css/index/index.css?v=d6d74d80">
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=93cb549c">
-<link rel="stylesheet" href="css/index/index.css?v=5348a551">
+<link rel="stylesheet" href="css/shared/cards.css?v=feb62384">
+<link rel="stylesheet" href="css/index/index.css?v=737d9ea1">
 </head>
 <body>
 

--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=00fd0966">
-<link rel="stylesheet" href="css/index/index.css?v=80d71662">
+<link rel="stylesheet" href="css/shared/cards.css?v=226fc2e4">
+<link rel="stylesheet" href="css/index/index.css?v=49ad1440">
 </head>
 <body>
 

--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=f95cc608">
-<link rel="stylesheet" href="css/index/index.css?v=d6d74d80">
+<link rel="stylesheet" href="css/shared/cards.css?v=5a77b933">
+<link rel="stylesheet" href="css/index/index.css?v=d47ad49c">
 </head>
 <body>
 
@@ -221,6 +221,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=02244420"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/index/main.js?v=d53cf296"></script>
+<script type="module" src="js/index/main.js?v=7adace90"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=06c0ca5e">
-<link rel="stylesheet" href="css/index/index.css?v=0634ef06">
+<link rel="stylesheet" href="css/shared/cards.css?v=93cb549c">
+<link rel="stylesheet" href="css/index/index.css?v=5348a551">
 </head>
 <body>
 

--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=f37cb570">
-<link rel="stylesheet" href="css/index/index.css?v=5d1b0b2f">
+<link rel="stylesheet" href="css/shared/cards.css?v=47cab2de">
+<link rel="stylesheet" href="css/index/index.css?v=47cc1a85">
 </head>
 <body>
 

--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=3e6f26ea">
-<link rel="stylesheet" href="css/index/index.css?v=ae3ec6ba">
+<link rel="stylesheet" href="css/shared/cards.css?v=5aa50963">
+<link rel="stylesheet" href="css/index/index.css?v=10ba7ed4">
 </head>
 <body>
 

--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=5ff17bf3">
-<link rel="stylesheet" href="css/index/index.css?v=4937adb2">
+<link rel="stylesheet" href="css/shared/cards.css?v=a6c64175">
+<link rel="stylesheet" href="css/index/index.css?v=dfc58003">
 </head>
 <body>
 

--- a/index.html
+++ b/index.html
@@ -219,7 +219,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=02244420"></script>
+<script src="js/lib/topbar.js?v=7e8205f8"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/index/main.js?v=7adace90"></script>
 </body>

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -4,7 +4,7 @@ import { fetchRecentPulseReports } from '../api/reports.js?v=003f23c0';
 import { loadSearchIndex, searchIndex } from './search.js?v=7ef4c01d';
 import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '../config.js?v=df5b5024';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
-import { renderGameCard } from '../lib/card.js?v=e29af0e5';
+import { renderGameCard } from '../lib/card.js?v=8e9687ef';
 
 const LOAD_COUNT_KEY = 'pp:load-count';
 const LOAD_COUNTS = [50, 100, 150, 200];

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -4,7 +4,7 @@ import { fetchRecentPulseReports } from '../api/reports.js?v=003f23c0';
 import { loadSearchIndex, searchIndex } from './search.js?v=7ef4c01d';
 import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '../config.js?v=df5b5024';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
-import { renderGameCard } from '../lib/card.js?v=35cea16c';
+import { renderGameCard } from '../lib/card.js?v=20b34baa';
 
 const LOAD_COUNT_KEY = 'pp:load-count';
 const LOAD_COUNTS = [50, 100, 150, 200];

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -4,7 +4,7 @@ import { fetchRecentPulseReports } from '../api/reports.js?v=003f23c0';
 import { loadSearchIndex, searchIndex } from './search.js?v=7ef4c01d';
 import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '../config.js?v=df5b5024';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
-import { renderGameCard } from '../lib/card.js?v=8e9687ef';
+import { renderGameCard } from '../lib/card.js?v=35cea16c';
 
 const LOAD_COUNT_KEY = 'pp:load-count';
 const LOAD_COUNTS = [50, 100, 150, 200];

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -5,7 +5,7 @@ import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../ap
 import { renderGamePage } from './game-page.js?v=565f22df';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
-import { renderGameCard } from '../lib/card.js?v=8e9687ef';
+import { renderGameCard } from '../lib/card.js?v=35cea16c';
 
 // Search index + results UX -- factored out of app.js.
 // Loaded as a classic script BEFORE app.js so its globals

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -5,7 +5,7 @@ import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../ap
 import { renderGamePage } from './game-page.js?v=565f22df';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
-import { renderGameCard } from '../lib/card.js?v=e29af0e5';
+import { renderGameCard } from '../lib/card.js?v=8e9687ef';
 
 // Search index + results UX -- factored out of app.js.
 // Loaded as a classic script BEFORE app.js so its globals

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -5,7 +5,7 @@ import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../ap
 import { renderGamePage } from './game-page.js?v=565f22df';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
-import { renderGameCard } from '../lib/card.js?v=35cea16c';
+import { renderGameCard } from '../lib/card.js?v=20b34baa';
 
 // Search index + results UX -- factored out of app.js.
 // Loaded as a classic script BEFORE app.js so its globals

--- a/js/app/lib/card.js
+++ b/js/app/lib/card.js
@@ -60,5 +60,7 @@ export function renderGameCard({ href, appId, title, sub, tier, badge, badgeBg, 
   const stripLabel = tier ? tier.toUpperCase() : 'NO RATING';
   const stripHtml = `<div class="game-card-strip" data-tier="${esc(stripTier)}"><span class="game-card-strip-tier">${esc(stripLabel)}</span>${storePillHtml}</div>`;
 
-  return `<a class="game-card" href="${href}">${thumbHtml}<div class="game-card-body"><div class="game-card-title">${esc(title)}</div><div class="game-card-sub">${sub}</div>${stripHtml}</div>${rightHtml}</a>`;
+  // Strip is a sibling of the row (not inside the body) so it can extend
+  // the full card width including under the thumbnail when strip mode is on.
+  return `<a class="game-card" href="${href}"><div class="game-card-row">${thumbHtml}<div class="game-card-body"><div class="game-card-title">${esc(title)}</div><div class="game-card-sub">${sub}</div></div>${rightHtml}</div>${stripHtml}</a>`;
 }

--- a/js/app/lib/card.js
+++ b/js/app/lib/card.js
@@ -52,6 +52,10 @@ export function renderGameCard({ href, appId, title, sub, tier, badge, badgeBg, 
     ? `<span class="game-card-source">${esc(sourceLabel)}</span>`
     : '';
   const rightHtml = `<div class="game-card-right">${pillsRowHtml}${sourceLabelHtml}</div>`;
+  // Strip layout duplicates the same pills row beneath the title. CSS picks
+  // which is visible based on <html data-card-layout="strip">; on the default
+  // setting the strip is hidden and the right column shows.
+  const stripHtml = `<div class="game-card-strip">${pillsRowHtml}${sourceLabelHtml}</div>`;
 
-  return `<a class="game-card" href="${href}">${thumbHtml}<div class="game-card-body"><div class="game-card-title">${esc(title)}</div><div class="game-card-sub">${sub}</div></div>${rightHtml}</a>`;
+  return `<a class="game-card" href="${href}">${thumbHtml}<div class="game-card-body"><div class="game-card-title">${esc(title)}</div><div class="game-card-sub">${sub}</div>${stripHtml}</div>${rightHtml}</a>`;
 }

--- a/js/app/lib/card.js
+++ b/js/app/lib/card.js
@@ -52,10 +52,13 @@ export function renderGameCard({ href, appId, title, sub, tier, badge, badgeBg, 
     ? `<span class="game-card-source">${esc(sourceLabel)}</span>`
     : '';
   const rightHtml = `<div class="game-card-right">${pillsRowHtml}${sourceLabelHtml}</div>`;
-  // Strip layout duplicates the same pills row beneath the title. CSS picks
-  // which is visible based on <html data-card-layout="strip">; on the default
-  // setting the strip is hidden and the right column shows.
-  const stripHtml = `<div class="game-card-strip">${pillsRowHtml}${sourceLabelHtml}</div>`;
+  // Strip layout: a full-width tier-colored bar beneath the title (ProtonDB
+  // style). data-tier drives the background via CSS so we do not have to
+  // inline color per-card. Hidden by default; data-card-layout="strip" on
+  // <html> flips it in for both visibility and the right-column hide.
+  const stripTier = tier ? String(tier).toLowerCase() : '';
+  const stripLabel = tier ? tier.toUpperCase() : 'NO RATING';
+  const stripHtml = `<div class="game-card-strip" data-tier="${esc(stripTier)}"><span class="game-card-strip-tier">${esc(stripLabel)}</span>${storePillHtml}</div>`;
 
   return `<a class="game-card" href="${href}">${thumbHtml}<div class="game-card-body"><div class="game-card-title">${esc(title)}</div><div class="game-card-sub">${sub}</div>${stripHtml}</div>${rightHtml}</a>`;
 }

--- a/js/index/main.js
+++ b/js/index/main.js
@@ -142,18 +142,29 @@ import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=e7fe3ce
     const rated = KNOWN_TIERS.has(rating);
     const badgeClass = rated ? `pg-${rating}` : 'pg-unrated';
     const rLabel = rated ? RATING_LABEL[rating] : 'Unrated';
+    // Rating layout = strip: tier-colored bar across the full card bottom.
+    // The pg-card-row wraps thumb/info/right so the strip can sit as a
+    // sibling and span the full card width (including under the thumbnail).
+    const stripTier = rated ? rating : '';
+    const stripLabel = rated ? RATING_LABEL[rating].toUpperCase() : 'NO RATING';
     return `
       <a class="pg-card" href="app.html#/app/${encodeURIComponent(g.appId)}">
-        <div class="pg-thumb-wrap">
-          <img class="pg-thumb" src="${img}" data-appid="${g.appId}" alt="" loading="lazy" onerror="window.__steamImgLoad(this)">
-          ${storeTag(g.appType)}
+        <div class="pg-card-row">
+          <div class="pg-thumb-wrap">
+            <img class="pg-thumb" src="${img}" data-appid="${g.appId}" alt="" loading="lazy" onerror="window.__steamImgLoad(this)">
+            ${storeTag(g.appType)}
+          </div>
+          <div class="pg-info">
+            <div class="pg-title">${esc(g.title)}</div>
+            ${peak ? `<div class="pg-sub">${peak} peak players</div>` : ''}
+          </div>
+          <div class="pg-right">
+            <span class="pg-badge ${badgeClass}">${rLabel}</span>
+            ${storePill(g.appType)}
+          </div>
         </div>
-        <div class="pg-info">
-          <div class="pg-title">${esc(g.title)}</div>
-          ${peak ? `<div class="pg-sub">${peak} peak players</div>` : ''}
-        </div>
-        <div class="pg-right">
-          <span class="pg-badge ${badgeClass}">${rLabel}</span>
+        <div class="pg-card-strip" data-tier="${stripTier}">
+          <span class="pg-card-strip-tier">${stripLabel}</span>
           ${storePill(g.appType)}
         </div>
       </a>`;

--- a/js/lib/topbar.js
+++ b/js/lib/topbar.js
@@ -365,6 +365,11 @@
   if (localStorage.getItem('pp:store-pill-pos') === 'art') {
     document.documentElement.setAttribute('data-store-pill-pos', 'art');
   }
+  // Card layout preference: 'strip' = rating row under title (more title width
+  // on mobile), default = rating pill in right column.
+  if (localStorage.getItem('pp:card-layout') === 'strip') {
+    document.documentElement.setAttribute('data-card-layout', 'strip');
+  }
 
   // inject favicon if the page doesn't already have one
   if (!document.querySelector('link[rel="icon"]')) {

--- a/js/lib/topbar.js
+++ b/js/lib/topbar.js
@@ -235,14 +235,15 @@
           </a>
         </div>
       </div>
-      <!-- About: top-level, placed after the dropdowns (dropdowns come first) -->
-      <a href="about.html" data-page="about" title="What Proton Pulse is and how it compares to ProtonDB">
-        <svg class="nav-icon" aria-hidden="true"><use href="#icon-info"/></svg>
-        <span>About</span>
-      </a>
       <!-- Admin link: hidden until checkIsAdmin confirms the signed-in user is an admin -->
       <a href="admin.html" id="topbar-admin-link" class="auth-admin-navlink" hidden>
         <span>Admin</span>
+      </a>
+      <!-- About: kept last in nav order so it sits at the trailing edge
+           regardless of whether the admin link is visible. -->
+      <a href="about.html" data-page="about" title="What Proton Pulse is and how it compares to ProtonDB">
+        <svg class="nav-icon" aria-hidden="true"><use href="#icon-info"/></svg>
+        <span>About</span>
       </a>
       <!-- Overflow "More" button. Hidden by default; topbar resize observer
            reveals it and migrates trailing items into the panel when the nav
@@ -270,13 +271,15 @@
   <a href="data-index.html" data-page="data-index"><svg class="nav-icon" aria-hidden="true"><use href="#icon-database"/></svg> Data</a>
   <a href="coverage.html" data-page="coverage"><svg class="nav-icon" aria-hidden="true"><use href="#icon-chart"/></svg> Coverage</a>
   <a href="stats.html" data-page="stats"><svg class="nav-icon" aria-hidden="true"><use href="#icon-stats"/></svg> Stats</a>
-  <a href="about.html" data-page="about"><svg class="nav-icon" aria-hidden="true"><use href="#icon-info"/></svg> About</a>
   <a href="scoring.html" data-page="scoring"><svg class="nav-icon" aria-hidden="true"><use href="#icon-scoring"/></svg> Scoring</a>
   <a href="https://github.com/mdeguzis/proton-pulse-web/issues/new/choose" target="_blank" rel="noopener"><svg class="nav-icon" aria-hidden="true"><use href="#icon-contact"/></svg> Contact</a>
   <a href="https://github.com/mdeguzis/decky-proton-pulse" target="_blank" rel="noopener"><svg class="nav-icon" aria-hidden="true"><use href="#icon-gamepad"/></svg> Decky Plugin</a>
   <a href="https://github.com/mdeguzis/proton-pulse-web" target="_blank" rel="noopener"><svg class="nav-icon" aria-hidden="true"><use href="#icon-github"/></svg> GitHub</a>
   <a href="https://discord.gg/4p6e4X7xW" target="_blank" rel="noopener"><svg class="nav-icon" aria-hidden="true"><use href="#icon-discord"/></svg> Discord</a>
   <a href="admin.html" id="mobile-admin-link" data-page="admin" hidden><svg class="nav-icon" aria-hidden="true"><use href="#icon-stats"/></svg> Admin</a>
+  <!-- About kept last so it remains the trailing item whether the
+       admin link is visible or not. -->
+  <a href="about.html" data-page="about"><svg class="nav-icon" aria-hidden="true"><use href="#icon-info"/></svg> About</a>
 </div>`;
 
   // ---- 2. Insert markup at body start (skip if already present) --------

--- a/js/options/main.js
+++ b/js/options/main.js
@@ -67,6 +67,33 @@ if (storePillGroup) {
   applyStorePillPos(stored);
 }
 
+// Card layout: 'right' (rating pill in right column) or 'strip' (rating row
+// beneath the title so long names get the full card width). Mirrors the
+// store-pill-pos pattern: a single attribute on <html> drives the CSS swap.
+const CARD_LAYOUT_KEY = 'pp:card-layout';
+function applyCardLayout(pos) {
+  if (pos === 'strip') {
+    document.documentElement.setAttribute('data-card-layout', 'strip');
+  } else {
+    document.documentElement.removeAttribute('data-card-layout');
+  }
+}
+const cardLayoutGroup = document.getElementById('opt-card-layout');
+if (cardLayoutGroup) {
+  const stored = localStorage.getItem(CARD_LAYOUT_KEY) || 'right';
+  cardLayoutGroup.querySelectorAll('input[type="radio"]').forEach(r => {
+    r.checked = r.value === stored;
+    r.addEventListener('change', () => {
+      if (r.checked) {
+        localStorage.setItem(CARD_LAYOUT_KEY, r.value);
+        applyCardLayout(r.value);
+        console.log('[options] card-layout:', r.value);
+      }
+    });
+  });
+  applyCardLayout(stored);
+}
+
 // Reports per page: how many cards app.html preloads per section before "Load
 // more". Stored as a string number; app.html reads it on load. Default 50.
 const LOAD_COUNT_KEY = 'pp:load-count';

--- a/options.html
+++ b/options.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=f95cc608">
+<link rel="stylesheet" href="css/shared/cards.css?v=5a77b933">
 <link rel="stylesheet" href="css/options/options.css?v=11d3971b">
 </head>
 <body>
@@ -69,12 +69,13 @@
 
       <div class="option-row option-row--block">
         <div class="option-text">
-          <div class="option-title">Card layout</div>
+          <div class="option-title">Rating layout</div>
           <div class="option-desc">
             Where to show the rating on game cards. "On right" keeps the
-            rating pill in a column next to the title. "Under title" moves
-            the rating beneath the title so long names get the full card
-            width -- easier to read on mobile.
+            rating pill in a column next to the title. "Bottom bar" puts
+            the rating into a tier-colored bar across the full bottom of
+            the card -- easier to read on mobile because the title gets
+            the full card width.
           </div>
         </div>
         <div class="option-radio-group" id="opt-card-layout">
@@ -84,7 +85,7 @@
           </label>
           <label class="option-radio">
             <input type="radio" name="card-layout" value="strip">
-            <span>Under title</span>
+            <span>Bottom bar</span>
           </label>
         </div>
       </div>

--- a/options.html
+++ b/options.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5aa50963">
+<link rel="stylesheet" href="css/shared/cards.css?v=06c0ca5e">
 <link rel="stylesheet" href="css/options/options.css?v=11d3971b">
 </head>
 <body>

--- a/options.html
+++ b/options.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=eb6b6d9b">
+<link rel="stylesheet" href="css/shared/cards.css?v=f95cc608">
 <link rel="stylesheet" href="css/options/options.css?v=11d3971b">
 </head>
 <body>

--- a/options.html
+++ b/options.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=00fd0966">
+<link rel="stylesheet" href="css/shared/cards.css?v=226fc2e4">
 <link rel="stylesheet" href="css/options/options.css?v=11d3971b">
 </head>
 <body>

--- a/options.html
+++ b/options.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=93cb549c">
+<link rel="stylesheet" href="css/shared/cards.css?v=feb62384">
 <link rel="stylesheet" href="css/options/options.css?v=11d3971b">
 </head>
 <body>

--- a/options.html
+++ b/options.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=a6c64175">
+<link rel="stylesheet" href="css/shared/cards.css?v=00fd0966">
 <link rel="stylesheet" href="css/options/options.css?v=11d3971b">
 </head>
 <body>

--- a/options.html
+++ b/options.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=feb62384">
+<link rel="stylesheet" href="css/shared/cards.css?v=5ff17bf3">
 <link rel="stylesheet" href="css/options/options.css?v=11d3971b">
 </head>
 <body>

--- a/options.html
+++ b/options.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=47cab2de">
+<link rel="stylesheet" href="css/shared/cards.css?v=c7090912">
 <link rel="stylesheet" href="css/options/options.css?v=11d3971b">
 </head>
 <body>

--- a/options.html
+++ b/options.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=226fc2e4">
+<link rel="stylesheet" href="css/shared/cards.css?v=f37cb570">
 <link rel="stylesheet" href="css/options/options.css?v=11d3971b">
 </head>
 <body>

--- a/options.html
+++ b/options.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5a77b933">
+<link rel="stylesheet" href="css/shared/cards.css?v=3e6f26ea">
 <link rel="stylesheet" href="css/options/options.css?v=11d3971b">
 </head>
 <body>

--- a/options.html
+++ b/options.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
+<link rel="stylesheet" href="css/shared/cards.css?v=eb6b6d9b">
 <link rel="stylesheet" href="css/options/options.css?v=11d3971b">
 </head>
 <body>
@@ -69,6 +69,28 @@
 
       <div class="option-row option-row--block">
         <div class="option-text">
+          <div class="option-title">Card layout</div>
+          <div class="option-desc">
+            Where to show the rating on game cards. "On right" keeps the
+            rating pill in a column next to the title. "Under title" moves
+            the rating beneath the title so long names get the full card
+            width -- easier to read on mobile.
+          </div>
+        </div>
+        <div class="option-radio-group" id="opt-card-layout">
+          <label class="option-radio">
+            <input type="radio" name="card-layout" value="right" checked>
+            <span>On right</span>
+          </label>
+          <label class="option-radio">
+            <input type="radio" name="card-layout" value="strip">
+            <span>Under title</span>
+          </label>
+        </div>
+      </div>
+
+      <div class="option-row option-row--block">
+        <div class="option-text">
           <div class="option-title">Reports per page</div>
           <div class="option-desc">
             How many game cards to preload in each section when browsing reports
@@ -108,8 +130,8 @@
   <a href="terms.html">Terms</a>
 </footer>
 
-<script src="js/lib/topbar.js?v=856ad13f"></script>
+<script src="js/lib/topbar.js?v=02244420"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/options/main.js?v=fbbb541e"></script>
+<script type="module" src="js/options/main.js?v=59780486"></script>
 </body>
 </html>

--- a/options.html
+++ b/options.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5ff17bf3">
+<link rel="stylesheet" href="css/shared/cards.css?v=a6c64175">
 <link rel="stylesheet" href="css/options/options.css?v=11d3971b">
 </head>
 <body>

--- a/options.html
+++ b/options.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=06c0ca5e">
+<link rel="stylesheet" href="css/shared/cards.css?v=93cb549c">
 <link rel="stylesheet" href="css/options/options.css?v=11d3971b">
 </head>
 <body>

--- a/options.html
+++ b/options.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=f37cb570">
+<link rel="stylesheet" href="css/shared/cards.css?v=47cab2de">
 <link rel="stylesheet" href="css/options/options.css?v=11d3971b">
 </head>
 <body>

--- a/options.html
+++ b/options.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=3e6f26ea">
+<link rel="stylesheet" href="css/shared/cards.css?v=5aa50963">
 <link rel="stylesheet" href="css/options/options.css?v=11d3971b">
 </head>
 <body>

--- a/options.html
+++ b/options.html
@@ -131,7 +131,7 @@
   <a href="terms.html">Terms</a>
 </footer>
 
-<script src="js/lib/topbar.js?v=02244420"></script>
+<script src="js/lib/topbar.js?v=7e8205f8"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/options/main.js?v=59780486"></script>
 </body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=f95cc608">
+<link rel="stylesheet" href="css/shared/cards.css?v=5a77b933">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
+<link rel="stylesheet" href="css/shared/cards.css?v=eb6b6d9b">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=eb6b6d9b">
+<link rel="stylesheet" href="css/shared/cards.css?v=f95cc608">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5aa50963">
+<link rel="stylesheet" href="css/shared/cards.css?v=06c0ca5e">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=47cab2de">
+<link rel="stylesheet" href="css/shared/cards.css?v=c7090912">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=226fc2e4">
+<link rel="stylesheet" href="css/shared/cards.css?v=f37cb570">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=feb62384">
+<link rel="stylesheet" href="css/shared/cards.css?v=5ff17bf3">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=a6c64175">
+<link rel="stylesheet" href="css/shared/cards.css?v=00fd0966">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5a77b933">
+<link rel="stylesheet" href="css/shared/cards.css?v=3e6f26ea">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=93cb549c">
+<link rel="stylesheet" href="css/shared/cards.css?v=feb62384">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=00fd0966">
+<link rel="stylesheet" href="css/shared/cards.css?v=226fc2e4">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=f37cb570">
+<link rel="stylesheet" href="css/shared/cards.css?v=47cab2de">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=06c0ca5e">
+<link rel="stylesheet" href="css/shared/cards.css?v=93cb549c">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=3e6f26ea">
+<link rel="stylesheet" href="css/shared/cards.css?v=5aa50963">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5ff17bf3">
+<link rel="stylesheet" href="css/shared/cards.css?v=a6c64175">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/privacy.html
+++ b/privacy.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=a6c64175">
-<link rel="stylesheet" href="css/index/index.css?v=dfc58003">
+<link rel="stylesheet" href="css/shared/cards.css?v=00fd0966">
+<link rel="stylesheet" href="css/index/index.css?v=80d71662">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/privacy.html
+++ b/privacy.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5aa50963">
-<link rel="stylesheet" href="css/index/index.css?v=10ba7ed4">
+<link rel="stylesheet" href="css/shared/cards.css?v=06c0ca5e">
+<link rel="stylesheet" href="css/index/index.css?v=0634ef06">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/privacy.html
+++ b/privacy.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=00fd0966">
-<link rel="stylesheet" href="css/index/index.css?v=80d71662">
+<link rel="stylesheet" href="css/shared/cards.css?v=226fc2e4">
+<link rel="stylesheet" href="css/index/index.css?v=49ad1440">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/privacy.html
+++ b/privacy.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=f95cc608">
-<link rel="stylesheet" href="css/index/index.css?v=d6d74d80">
+<link rel="stylesheet" href="css/shared/cards.css?v=5a77b933">
+<link rel="stylesheet" href="css/index/index.css?v=d47ad49c">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/privacy.html
+++ b/privacy.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=eb6b6d9b">
+<link rel="stylesheet" href="css/shared/cards.css?v=f95cc608">
 <link rel="stylesheet" href="css/index/index.css?v=d6d74d80">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }

--- a/privacy.html
+++ b/privacy.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
+<link rel="stylesheet" href="css/shared/cards.css?v=eb6b6d9b">
 <link rel="stylesheet" href="css/index/index.css?v=d6d74d80">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
@@ -87,7 +87,7 @@
 </div>
 </div>
 
-<script src="js/lib/topbar.js?v=856ad13f"></script>
+<script src="js/lib/topbar.js?v=02244420"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5a77b933">
-<link rel="stylesheet" href="css/index/index.css?v=d47ad49c">
+<link rel="stylesheet" href="css/shared/cards.css?v=3e6f26ea">
+<link rel="stylesheet" href="css/index/index.css?v=ae3ec6ba">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/privacy.html
+++ b/privacy.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=47cab2de">
-<link rel="stylesheet" href="css/index/index.css?v=47cc1a85">
+<link rel="stylesheet" href="css/shared/cards.css?v=c7090912">
+<link rel="stylesheet" href="css/index/index.css?v=5e2fb213">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/privacy.html
+++ b/privacy.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=93cb549c">
-<link rel="stylesheet" href="css/index/index.css?v=5348a551">
+<link rel="stylesheet" href="css/shared/cards.css?v=feb62384">
+<link rel="stylesheet" href="css/index/index.css?v=737d9ea1">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/privacy.html
+++ b/privacy.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=226fc2e4">
-<link rel="stylesheet" href="css/index/index.css?v=49ad1440">
+<link rel="stylesheet" href="css/shared/cards.css?v=f37cb570">
+<link rel="stylesheet" href="css/index/index.css?v=5d1b0b2f">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/privacy.html
+++ b/privacy.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=feb62384">
-<link rel="stylesheet" href="css/index/index.css?v=737d9ea1">
+<link rel="stylesheet" href="css/shared/cards.css?v=5ff17bf3">
+<link rel="stylesheet" href="css/index/index.css?v=4937adb2">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/privacy.html
+++ b/privacy.html
@@ -87,7 +87,7 @@
 </div>
 </div>
 
-<script src="js/lib/topbar.js?v=02244420"></script>
+<script src="js/lib/topbar.js?v=7e8205f8"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=3e6f26ea">
-<link rel="stylesheet" href="css/index/index.css?v=ae3ec6ba">
+<link rel="stylesheet" href="css/shared/cards.css?v=5aa50963">
+<link rel="stylesheet" href="css/index/index.css?v=10ba7ed4">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/privacy.html
+++ b/privacy.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=f37cb570">
-<link rel="stylesheet" href="css/index/index.css?v=5d1b0b2f">
+<link rel="stylesheet" href="css/shared/cards.css?v=47cab2de">
+<link rel="stylesheet" href="css/index/index.css?v=47cc1a85">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/privacy.html
+++ b/privacy.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5ff17bf3">
-<link rel="stylesheet" href="css/index/index.css?v=4937adb2">
+<link rel="stylesheet" href="css/shared/cards.css?v=a6c64175">
+<link rel="stylesheet" href="css/index/index.css?v=dfc58003">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/privacy.html
+++ b/privacy.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=06c0ca5e">
-<link rel="stylesheet" href="css/index/index.css?v=0634ef06">
+<link rel="stylesheet" href="css/shared/cards.css?v=93cb549c">
+<link rel="stylesheet" href="css/index/index.css?v=5348a551">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/profile.html
+++ b/profile.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
+<link rel="stylesheet" href="css/shared/cards.css?v=eb6b6d9b">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>
@@ -289,7 +289,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=856ad13f"></script>
+<script src="js/lib/topbar.js?v=02244420"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/profile/main.js?v=7207779a"></script>
 </body>

--- a/profile.html
+++ b/profile.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=a6c64175">
+<link rel="stylesheet" href="css/shared/cards.css?v=00fd0966">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/profile.html
+++ b/profile.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5aa50963">
+<link rel="stylesheet" href="css/shared/cards.css?v=06c0ca5e">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/profile.html
+++ b/profile.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5a77b933">
+<link rel="stylesheet" href="css/shared/cards.css?v=3e6f26ea">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/profile.html
+++ b/profile.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=47cab2de">
+<link rel="stylesheet" href="css/shared/cards.css?v=c7090912">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/profile.html
+++ b/profile.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=feb62384">
+<link rel="stylesheet" href="css/shared/cards.css?v=5ff17bf3">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/profile.html
+++ b/profile.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=00fd0966">
+<link rel="stylesheet" href="css/shared/cards.css?v=226fc2e4">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/profile.html
+++ b/profile.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=f95cc608">
+<link rel="stylesheet" href="css/shared/cards.css?v=5a77b933">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/profile.html
+++ b/profile.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=eb6b6d9b">
+<link rel="stylesheet" href="css/shared/cards.css?v=f95cc608">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/profile.html
+++ b/profile.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=226fc2e4">
+<link rel="stylesheet" href="css/shared/cards.css?v=f37cb570">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/profile.html
+++ b/profile.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=93cb549c">
+<link rel="stylesheet" href="css/shared/cards.css?v=feb62384">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/profile.html
+++ b/profile.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=f37cb570">
+<link rel="stylesheet" href="css/shared/cards.css?v=47cab2de">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/profile.html
+++ b/profile.html
@@ -289,7 +289,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=02244420"></script>
+<script src="js/lib/topbar.js?v=7e8205f8"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/profile/main.js?v=7207779a"></script>
 </body>

--- a/profile.html
+++ b/profile.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=06c0ca5e">
+<link rel="stylesheet" href="css/shared/cards.css?v=93cb549c">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/profile.html
+++ b/profile.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5ff17bf3">
+<link rel="stylesheet" href="css/shared/cards.css?v=a6c64175">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/profile.html
+++ b/profile.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=3e6f26ea">
+<link rel="stylesheet" href="css/shared/cards.css?v=5aa50963">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/scoring.html
+++ b/scoring.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=feb62384">
+<link rel="stylesheet" href="css/shared/cards.css?v=5ff17bf3">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/scoring.html
+++ b/scoring.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5aa50963">
+<link rel="stylesheet" href="css/shared/cards.css?v=06c0ca5e">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/scoring.html
+++ b/scoring.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=f95cc608">
+<link rel="stylesheet" href="css/shared/cards.css?v=5a77b933">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/scoring.html
+++ b/scoring.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
+<link rel="stylesheet" href="css/shared/cards.css?v=eb6b6d9b">
 <style>
 h1 {
   font-family: var(--font-display);
@@ -490,7 +490,7 @@ h2 small {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=856ad13f"></script>
+<script src="js/lib/topbar.js?v=02244420"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/scoring.html
+++ b/scoring.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5a77b933">
+<link rel="stylesheet" href="css/shared/cards.css?v=3e6f26ea">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/scoring.html
+++ b/scoring.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=eb6b6d9b">
+<link rel="stylesheet" href="css/shared/cards.css?v=f95cc608">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/scoring.html
+++ b/scoring.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=226fc2e4">
+<link rel="stylesheet" href="css/shared/cards.css?v=f37cb570">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/scoring.html
+++ b/scoring.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=47cab2de">
+<link rel="stylesheet" href="css/shared/cards.css?v=c7090912">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/scoring.html
+++ b/scoring.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=00fd0966">
+<link rel="stylesheet" href="css/shared/cards.css?v=226fc2e4">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/scoring.html
+++ b/scoring.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=a6c64175">
+<link rel="stylesheet" href="css/shared/cards.css?v=00fd0966">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/scoring.html
+++ b/scoring.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=93cb549c">
+<link rel="stylesheet" href="css/shared/cards.css?v=feb62384">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/scoring.html
+++ b/scoring.html
@@ -490,7 +490,7 @@ h2 small {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=02244420"></script>
+<script src="js/lib/topbar.js?v=7e8205f8"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/scoring.html
+++ b/scoring.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5ff17bf3">
+<link rel="stylesheet" href="css/shared/cards.css?v=a6c64175">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/scoring.html
+++ b/scoring.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=3e6f26ea">
+<link rel="stylesheet" href="css/shared/cards.css?v=5aa50963">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/scoring.html
+++ b/scoring.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=f37cb570">
+<link rel="stylesheet" href="css/shared/cards.css?v=47cab2de">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/scoring.html
+++ b/scoring.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=06c0ca5e">
+<link rel="stylesheet" href="css/shared/cards.css?v=93cb549c">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/stats.html
+++ b/stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=eb6b6d9b">
+<link rel="stylesheet" href="css/shared/cards.css?v=f95cc608">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/stats.html
+++ b/stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=a6c64175">
+<link rel="stylesheet" href="css/shared/cards.css?v=00fd0966">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/stats.html
+++ b/stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=5aa50963">
+<link rel="stylesheet" href="css/shared/cards.css?v=06c0ca5e">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/stats.html
+++ b/stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=00fd0966">
+<link rel="stylesheet" href="css/shared/cards.css?v=226fc2e4">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/stats.html
+++ b/stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=226fc2e4">
+<link rel="stylesheet" href="css/shared/cards.css?v=f37cb570">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/stats.html
+++ b/stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=47cab2de">
+<link rel="stylesheet" href="css/shared/cards.css?v=c7090912">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/stats.html
+++ b/stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
+<link rel="stylesheet" href="css/shared/cards.css?v=eb6b6d9b">
 <style>
 h1 {
   font-family: var(--font-display);
@@ -661,7 +661,7 @@ h2 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=856ad13f"></script>
+<script src="js/lib/topbar.js?v=02244420"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/stats.html
+++ b/stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=5a77b933">
+<link rel="stylesheet" href="css/shared/cards.css?v=3e6f26ea">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/stats.html
+++ b/stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=feb62384">
+<link rel="stylesheet" href="css/shared/cards.css?v=5ff17bf3">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/stats.html
+++ b/stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=f95cc608">
+<link rel="stylesheet" href="css/shared/cards.css?v=5a77b933">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/stats.html
+++ b/stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=93cb549c">
+<link rel="stylesheet" href="css/shared/cards.css?v=feb62384">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/stats.html
+++ b/stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=3e6f26ea">
+<link rel="stylesheet" href="css/shared/cards.css?v=5aa50963">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/stats.html
+++ b/stats.html
@@ -661,7 +661,7 @@ h2 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=02244420"></script>
+<script src="js/lib/topbar.js?v=7e8205f8"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/stats.html
+++ b/stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=f37cb570">
+<link rel="stylesheet" href="css/shared/cards.css?v=47cab2de">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/stats.html
+++ b/stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=06c0ca5e">
+<link rel="stylesheet" href="css/shared/cards.css?v=93cb549c">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/stats.html
+++ b/stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=5ff17bf3">
+<link rel="stylesheet" href="css/shared/cards.css?v=a6c64175">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/submit.html
+++ b/submit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
+<link rel="stylesheet" href="css/shared/cards.css?v=eb6b6d9b">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
@@ -22,7 +22,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=856ad13f"></script>
+<script src="js/lib/topbar.js?v=02244420"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/submit.html
+++ b/submit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5a77b933">
+<link rel="stylesheet" href="css/shared/cards.css?v=3e6f26ea">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/submit.html
+++ b/submit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=a6c64175">
+<link rel="stylesheet" href="css/shared/cards.css?v=00fd0966">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/submit.html
+++ b/submit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=93cb549c">
+<link rel="stylesheet" href="css/shared/cards.css?v=feb62384">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/submit.html
+++ b/submit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=226fc2e4">
+<link rel="stylesheet" href="css/shared/cards.css?v=f37cb570">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/submit.html
+++ b/submit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5aa50963">
+<link rel="stylesheet" href="css/shared/cards.css?v=06c0ca5e">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/submit.html
+++ b/submit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=eb6b6d9b">
+<link rel="stylesheet" href="css/shared/cards.css?v=f95cc608">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/submit.html
+++ b/submit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=47cab2de">
+<link rel="stylesheet" href="css/shared/cards.css?v=c7090912">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/submit.html
+++ b/submit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=00fd0966">
+<link rel="stylesheet" href="css/shared/cards.css?v=226fc2e4">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/submit.html
+++ b/submit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=feb62384">
+<link rel="stylesheet" href="css/shared/cards.css?v=5ff17bf3">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/submit.html
+++ b/submit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=f95cc608">
+<link rel="stylesheet" href="css/shared/cards.css?v=5a77b933">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/submit.html
+++ b/submit.html
@@ -11,12 +11,12 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=f37cb570">
+<link rel="stylesheet" href="css/shared/cards.css?v=47cab2de">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
-<link rel="stylesheet" href="css/app/home.css?v=f48067b5">
+<link rel="stylesheet" href="css/app/home.css?v=4bf8008f">
 </head>
 <body>
 

--- a/submit.html
+++ b/submit.html
@@ -22,7 +22,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=02244420"></script>
+<script src="js/lib/topbar.js?v=7e8205f8"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/submit.html
+++ b/submit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=06c0ca5e">
+<link rel="stylesheet" href="css/shared/cards.css?v=93cb549c">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/submit.html
+++ b/submit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=3e6f26ea">
+<link rel="stylesheet" href="css/shared/cards.css?v=5aa50963">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/submit.html
+++ b/submit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5ff17bf3">
+<link rel="stylesheet" href="css/shared/cards.css?v=a6c64175">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/system-edit.html
+++ b/system-edit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=a6c64175">
+<link rel="stylesheet" href="css/shared/cards.css?v=00fd0966">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/system-edit.html
+++ b/system-edit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5aa50963">
+<link rel="stylesheet" href="css/shared/cards.css?v=06c0ca5e">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/system-edit.html
+++ b/system-edit.html
@@ -11,14 +11,14 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
+<link rel="stylesheet" href="css/shared/cards.css?v=eb6b6d9b">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=856ad13f"></script>
+<script src="js/lib/topbar.js?v=02244420"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/system-edit.html
+++ b/system-edit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5a77b933">
+<link rel="stylesheet" href="css/shared/cards.css?v=3e6f26ea">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/system-edit.html
+++ b/system-edit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=47cab2de">
+<link rel="stylesheet" href="css/shared/cards.css?v=c7090912">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/system-edit.html
+++ b/system-edit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=feb62384">
+<link rel="stylesheet" href="css/shared/cards.css?v=5ff17bf3">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/system-edit.html
+++ b/system-edit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=00fd0966">
+<link rel="stylesheet" href="css/shared/cards.css?v=226fc2e4">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/system-edit.html
+++ b/system-edit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=f95cc608">
+<link rel="stylesheet" href="css/shared/cards.css?v=5a77b933">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/system-edit.html
+++ b/system-edit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=eb6b6d9b">
+<link rel="stylesheet" href="css/shared/cards.css?v=f95cc608">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/system-edit.html
+++ b/system-edit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=226fc2e4">
+<link rel="stylesheet" href="css/shared/cards.css?v=f37cb570">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/system-edit.html
+++ b/system-edit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=93cb549c">
+<link rel="stylesheet" href="css/shared/cards.css?v=feb62384">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/system-edit.html
+++ b/system-edit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=f37cb570">
+<link rel="stylesheet" href="css/shared/cards.css?v=47cab2de">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/system-edit.html
+++ b/system-edit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=06c0ca5e">
+<link rel="stylesheet" href="css/shared/cards.css?v=93cb549c">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/system-edit.html
+++ b/system-edit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5ff17bf3">
+<link rel="stylesheet" href="css/shared/cards.css?v=a6c64175">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/system-edit.html
+++ b/system-edit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=3e6f26ea">
+<link rel="stylesheet" href="css/shared/cards.css?v=5aa50963">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/system-edit.html
+++ b/system-edit.html
@@ -18,7 +18,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=02244420"></script>
+<script src="js/lib/topbar.js?v=7e8205f8"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/terms.html
+++ b/terms.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=a6c64175">
-<link rel="stylesheet" href="css/index/index.css?v=dfc58003">
+<link rel="stylesheet" href="css/shared/cards.css?v=00fd0966">
+<link rel="stylesheet" href="css/index/index.css?v=80d71662">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/terms.html
+++ b/terms.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5aa50963">
-<link rel="stylesheet" href="css/index/index.css?v=10ba7ed4">
+<link rel="stylesheet" href="css/shared/cards.css?v=06c0ca5e">
+<link rel="stylesheet" href="css/index/index.css?v=0634ef06">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/terms.html
+++ b/terms.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=00fd0966">
-<link rel="stylesheet" href="css/index/index.css?v=80d71662">
+<link rel="stylesheet" href="css/shared/cards.css?v=226fc2e4">
+<link rel="stylesheet" href="css/index/index.css?v=49ad1440">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/terms.html
+++ b/terms.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=f95cc608">
-<link rel="stylesheet" href="css/index/index.css?v=d6d74d80">
+<link rel="stylesheet" href="css/shared/cards.css?v=5a77b933">
+<link rel="stylesheet" href="css/index/index.css?v=d47ad49c">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/terms.html
+++ b/terms.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=eb6b6d9b">
+<link rel="stylesheet" href="css/shared/cards.css?v=f95cc608">
 <link rel="stylesheet" href="css/index/index.css?v=d6d74d80">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }

--- a/terms.html
+++ b/terms.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5a77b933">
-<link rel="stylesheet" href="css/index/index.css?v=d47ad49c">
+<link rel="stylesheet" href="css/shared/cards.css?v=3e6f26ea">
+<link rel="stylesheet" href="css/index/index.css?v=ae3ec6ba">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/terms.html
+++ b/terms.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=68f59a72">
+<link rel="stylesheet" href="css/shared/cards.css?v=eb6b6d9b">
 <link rel="stylesheet" href="css/index/index.css?v=d6d74d80">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
@@ -89,7 +89,7 @@
 </div>
 </div>
 
-<script src="js/lib/topbar.js?v=856ad13f"></script>
+<script src="js/lib/topbar.js?v=02244420"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=47cab2de">
-<link rel="stylesheet" href="css/index/index.css?v=47cc1a85">
+<link rel="stylesheet" href="css/shared/cards.css?v=c7090912">
+<link rel="stylesheet" href="css/index/index.css?v=5e2fb213">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/terms.html
+++ b/terms.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=93cb549c">
-<link rel="stylesheet" href="css/index/index.css?v=5348a551">
+<link rel="stylesheet" href="css/shared/cards.css?v=feb62384">
+<link rel="stylesheet" href="css/index/index.css?v=737d9ea1">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/terms.html
+++ b/terms.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=226fc2e4">
-<link rel="stylesheet" href="css/index/index.css?v=49ad1440">
+<link rel="stylesheet" href="css/shared/cards.css?v=f37cb570">
+<link rel="stylesheet" href="css/index/index.css?v=5d1b0b2f">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/terms.html
+++ b/terms.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=feb62384">
-<link rel="stylesheet" href="css/index/index.css?v=737d9ea1">
+<link rel="stylesheet" href="css/shared/cards.css?v=5ff17bf3">
+<link rel="stylesheet" href="css/index/index.css?v=4937adb2">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/terms.html
+++ b/terms.html
@@ -89,7 +89,7 @@
 </div>
 </div>
 
-<script src="js/lib/topbar.js?v=02244420"></script>
+<script src="js/lib/topbar.js?v=7e8205f8"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=3e6f26ea">
-<link rel="stylesheet" href="css/index/index.css?v=ae3ec6ba">
+<link rel="stylesheet" href="css/shared/cards.css?v=5aa50963">
+<link rel="stylesheet" href="css/index/index.css?v=10ba7ed4">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/terms.html
+++ b/terms.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=f37cb570">
-<link rel="stylesheet" href="css/index/index.css?v=5d1b0b2f">
+<link rel="stylesheet" href="css/shared/cards.css?v=47cab2de">
+<link rel="stylesheet" href="css/index/index.css?v=47cc1a85">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/terms.html
+++ b/terms.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=5ff17bf3">
-<link rel="stylesheet" href="css/index/index.css?v=4937adb2">
+<link rel="stylesheet" href="css/shared/cards.css?v=a6c64175">
+<link rel="stylesheet" href="css/index/index.css?v=dfc58003">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/terms.html
+++ b/terms.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=06c0ca5e">
-<link rel="stylesheet" href="css/index/index.css?v=0634ef06">
+<link rel="stylesheet" href="css/shared/cards.css?v=93cb549c">
+<link rel="stylesheet" href="css/index/index.css?v=5348a551">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/tests/card.test.js
+++ b/tests/card.test.js
@@ -75,8 +75,18 @@ describe('renderGameCard strip layout', () => {
     const html = renderGameCard({ href: '#/app/1', appId: '1', title: 'X', sub: '', tier: 'gold', storePill: 'Steam' });
     expect(html).toContain('game-card-right');
     expect(html).toContain('game-card-strip');
-    // Pills row markup appears twice (once per layout container)
-    const matches = html.match(/game-card-pills/g) || [];
-    expect(matches.length).toBe(2);
+  });
+
+  test('strip carries data-tier so CSS can color the bar by tier', () => {
+    const html = renderGameCard({ href: '#/app/1', appId: '1', title: 'X', sub: '', tier: 'gold' });
+    expect(html).toContain('data-tier="gold"');
+    expect(html).toContain('game-card-strip-tier');
+    expect(html).toContain('>GOLD<');
+  });
+
+  test('strip falls back to NO RATING when tier is missing', () => {
+    const html = renderGameCard({ href: '#/app/1', appId: '1', title: 'X', sub: '' });
+    expect(html).toContain('data-tier=""');
+    expect(html).toContain('>NO RATING<');
   });
 });

--- a/tests/card.test.js
+++ b/tests/card.test.js
@@ -77,6 +77,20 @@ describe('renderGameCard strip layout', () => {
     expect(html).toContain('game-card-strip');
   });
 
+  test('strip is a sibling of the row -- can span full card width', () => {
+    // The bottom-bar layout needs the strip outside of game-card-body so it
+    // can extend under the thumbnail. Verify the markup order: row, then strip.
+    const html = renderGameCard({ href: '#/app/1', appId: '1', title: 'X', sub: '', tier: 'gold' });
+    const rowIdx = html.indexOf('game-card-row');
+    const stripIdx = html.indexOf('game-card-strip');
+    expect(rowIdx).toBeGreaterThan(-1);
+    expect(stripIdx).toBeGreaterThan(rowIdx);
+    // Strip should NOT be inside game-card-body
+    const bodyOpen = html.indexOf('game-card-body');
+    const bodyClose = html.indexOf('</div>', bodyOpen);
+    expect(stripIdx).toBeGreaterThan(bodyClose);
+  });
+
   test('strip carries data-tier so CSS can color the bar by tier', () => {
     const html = renderGameCard({ href: '#/app/1', appId: '1', title: 'X', sub: '', tier: 'gold' });
     expect(html).toContain('data-tier="gold"');

--- a/tests/card.test.js
+++ b/tests/card.test.js
@@ -67,3 +67,16 @@ describe('renderGameCard thumbnail', () => {
     expect(html).toContain('onerror="window.__steamImgLoad(this)"');
   });
 });
+
+describe('renderGameCard strip layout', () => {
+  const renderGameCard = loadCard();
+
+  test('renders both the right column and the strip element so CSS can pick one', () => {
+    const html = renderGameCard({ href: '#/app/1', appId: '1', title: 'X', sub: '', tier: 'gold', storePill: 'Steam' });
+    expect(html).toContain('game-card-right');
+    expect(html).toContain('game-card-strip');
+    // Pills row markup appears twice (once per layout container)
+    const matches = html.match(/game-card-pills/g) || [];
+    expect(matches.length).toBe(2);
+  });
+});


### PR DESCRIPTION
Promotes 16 staging commits to main. Two themes.

#111 rating layout preference. New "Rating layout" toggle in options.html:
- On right (default) keeps the existing pill column.
- Bottom bar moves the rating into a tier-colored bar at the bottom of the
  card, spanning edge-to-edge. Title row gets the full card width, helpful
  for long names on mobile.

This shipped with a lot of CSS iteration -- visible in the commit history --
because the homepage uses its own .pg-card markup and the size-variant rules
were attached to the wrong element. Final landed state:
- renderGameCard + pgCardHtml wrap row content in a row child, strip is a
  sibling so it can reach the card's outer edges.
- Card has overflow: hidden + box-shadow outline so the strip's rounded
  bottom corners follow the card outline cleanly.
- Size variants on .game-card-row / .pg-card-row instead of .game-card /
  .pg-card so the strip is never inset.
- 12px breathing space above the strip so the row text doesn't sandwich.
- Tier-colored gradients per data-tier on the strip.

Filed #125 as a tech-debt follow-up to consolidate homepage cards into
renderGameCard so the same CSS bug never has to be fixed twice again.

About nav: small UX change. About now sits last in both the topbar and
the mobile drawer so it stays the trailing item regardless of whether the
admin link is visible.

Tests: card.test.js extended to assert the row/strip split and tier
data-attribute pass-through. Pre-push green throughout (701 JS tests,
smoke OK, coverage 94.73%).

After merge, no full pipeline run needed -- all changes are frontend.
make gh-pages-only is enough to promote.