### PR TITLE
ci(workflow): copy data-versions.json to gh-pages on deploy

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -336,6 +336,7 @@ jobs:
           cp /tmp/protondb-output/most_played.json . 2>/dev/null || true
           cp /tmp/protondb-output/nonsteam-images.json . 2>/dev/null || true
           cp /tmp/protondb-output/proton-versions.json . 2>/dev/null || true
+          cp /tmp/protondb-output/data-versions.json . 2>/dev/null || true
           cp /tmp/protondb-output/steam-catalog.json . 2>/dev/null || true
           cp /tmp/protondb-output/hardware-suggestions.json . 2>/dev/null || true
           git show main:gh-pages-manifest.txt > gh-pages-manifest.txt
@@ -357,7 +358,7 @@ jobs:
           git add data/ data-index.html coverage.html search-index.json scoring-info.json form-schema.json badges/
           # add optional pipeline outputs (skip silently if a fresh checkout
           # didn't have them yet, e.g. first run after introducing the file)
-          for f in coverage-summary.json stats.json recent-reports.json game-images.json game-images-skip.json game-images-cache.json gog-catalog-cache.json epic-catalog-cache.json most_played.json proton-versions.json steam-catalog.json hardware-suggestions.json nonsteam-images.json; do
+          for f in coverage-summary.json stats.json recent-reports.json game-images.json game-images-skip.json game-images-cache.json gog-catalog-cache.json epic-catalog-cache.json most_played.json proton-versions.json steam-catalog.json hardware-suggestions.json nonsteam-images.json data-versions.json; do
             [ -f "$f" ] && git add "$f"
           done
           while IFS= read -r path; do
@@ -596,6 +597,7 @@ jobs:
           cp /tmp/protondb-output/most_played.json . 2>/dev/null || true
           cp /tmp/protondb-output/nonsteam-images.json . 2>/dev/null || true
           cp /tmp/protondb-output/proton-versions.json . 2>/dev/null || true
+          cp /tmp/protondb-output/data-versions.json . 2>/dev/null || true
           cp /tmp/protondb-output/steam-catalog.json . 2>/dev/null || true
           cp /tmp/protondb-output/hardware-suggestions.json . 2>/dev/null || true
           git show main:gh-pages-manifest.txt > gh-pages-manifest.txt
@@ -617,7 +619,7 @@ jobs:
           git add data/ data-index.html coverage.html search-index.json scoring-info.json form-schema.json badges/
           # add optional pipeline outputs (skip silently if a fresh checkout
           # didn't have them yet, e.g. first run after introducing the file)
-          for f in coverage-summary.json stats.json recent-reports.json game-images.json game-images-skip.json game-images-cache.json gog-catalog-cache.json epic-catalog-cache.json most_played.json proton-versions.json steam-catalog.json hardware-suggestions.json nonsteam-images.json; do
+          for f in coverage-summary.json stats.json recent-reports.json game-images.json game-images-skip.json game-images-cache.json gog-catalog-cache.json epic-catalog-cache.json most_played.json proton-versions.json steam-catalog.json hardware-suggestions.json nonsteam-images.json data-versions.json; do
             [ -f "$f" ] && git add "$f"
           done
           while IFS= read -r path; do
@@ -813,6 +815,7 @@ jobs:
           cp /tmp/protondb-output/most_played.json . 2>/dev/null || true
           cp /tmp/protondb-output/nonsteam-images.json . 2>/dev/null || true
           cp /tmp/protondb-output/proton-versions.json . 2>/dev/null || true
+          cp /tmp/protondb-output/data-versions.json . 2>/dev/null || true
           cp /tmp/protondb-output/steam-catalog.json . 2>/dev/null || true
           cp /tmp/protondb-output/hardware-suggestions.json . 2>/dev/null || true
           git show main:gh-pages-manifest.txt > gh-pages-manifest.txt
@@ -834,7 +837,7 @@ jobs:
           git add data/ data-index.html coverage.html search-index.json scoring-info.json form-schema.json badges/
           # add optional pipeline outputs (skip silently if a fresh checkout
           # didn't have them yet, e.g. first run after introducing the file)
-          for f in coverage-summary.json stats.json recent-reports.json game-images.json game-images-skip.json game-images-cache.json gog-catalog-cache.json epic-catalog-cache.json most_played.json proton-versions.json steam-catalog.json hardware-suggestions.json nonsteam-images.json; do
+          for f in coverage-summary.json stats.json recent-reports.json game-images.json game-images-skip.json game-images-cache.json gog-catalog-cache.json epic-catalog-cache.json most_played.json proton-versions.json steam-catalog.json hardware-suggestions.json nonsteam-images.json data-versions.json; do
             [ -f "$f" ] && git add "$f"
           done
           while IFS= read -r path; do


### PR DESCRIPTION
Pipeline wrote it but deploy step skipped it -- manifest was 404 in prod after the first run. Added to the cp chain and the optional-files git add loop in all 3 deploy paths.