### PR TITLE
Data-versions deploy fix, live-fallback title, home stats refresh, favicon polish

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -336,6 +336,7 @@ jobs:
           cp /tmp/protondb-output/most_played.json . 2>/dev/null || true
           cp /tmp/protondb-output/nonsteam-images.json . 2>/dev/null || true
           cp /tmp/protondb-output/proton-versions.json . 2>/dev/null || true
+          cp /tmp/protondb-output/data-versions.json . 2>/dev/null || true
           cp /tmp/protondb-output/steam-catalog.json . 2>/dev/null || true
           cp /tmp/protondb-output/hardware-suggestions.json . 2>/dev/null || true
           git show main:gh-pages-manifest.txt > gh-pages-manifest.txt
@@ -357,7 +358,7 @@ jobs:
           git add data/ data-index.html coverage.html search-index.json scoring-info.json form-schema.json badges/
           # add optional pipeline outputs (skip silently if a fresh checkout
           # didn't have them yet, e.g. first run after introducing the file)
-          for f in coverage-summary.json stats.json recent-reports.json game-images.json game-images-skip.json game-images-cache.json gog-catalog-cache.json epic-catalog-cache.json most_played.json proton-versions.json steam-catalog.json hardware-suggestions.json nonsteam-images.json; do
+          for f in coverage-summary.json stats.json recent-reports.json game-images.json game-images-skip.json game-images-cache.json gog-catalog-cache.json epic-catalog-cache.json most_played.json proton-versions.json steam-catalog.json hardware-suggestions.json nonsteam-images.json data-versions.json; do
             [ -f "$f" ] && git add "$f"
           done
           while IFS= read -r path; do
@@ -596,6 +597,7 @@ jobs:
           cp /tmp/protondb-output/most_played.json . 2>/dev/null || true
           cp /tmp/protondb-output/nonsteam-images.json . 2>/dev/null || true
           cp /tmp/protondb-output/proton-versions.json . 2>/dev/null || true
+          cp /tmp/protondb-output/data-versions.json . 2>/dev/null || true
           cp /tmp/protondb-output/steam-catalog.json . 2>/dev/null || true
           cp /tmp/protondb-output/hardware-suggestions.json . 2>/dev/null || true
           git show main:gh-pages-manifest.txt > gh-pages-manifest.txt
@@ -617,7 +619,7 @@ jobs:
           git add data/ data-index.html coverage.html search-index.json scoring-info.json form-schema.json badges/
           # add optional pipeline outputs (skip silently if a fresh checkout
           # didn't have them yet, e.g. first run after introducing the file)
-          for f in coverage-summary.json stats.json recent-reports.json game-images.json game-images-skip.json game-images-cache.json gog-catalog-cache.json epic-catalog-cache.json most_played.json proton-versions.json steam-catalog.json hardware-suggestions.json nonsteam-images.json; do
+          for f in coverage-summary.json stats.json recent-reports.json game-images.json game-images-skip.json game-images-cache.json gog-catalog-cache.json epic-catalog-cache.json most_played.json proton-versions.json steam-catalog.json hardware-suggestions.json nonsteam-images.json data-versions.json; do
             [ -f "$f" ] && git add "$f"
           done
           while IFS= read -r path; do
@@ -813,6 +815,7 @@ jobs:
           cp /tmp/protondb-output/most_played.json . 2>/dev/null || true
           cp /tmp/protondb-output/nonsteam-images.json . 2>/dev/null || true
           cp /tmp/protondb-output/proton-versions.json . 2>/dev/null || true
+          cp /tmp/protondb-output/data-versions.json . 2>/dev/null || true
           cp /tmp/protondb-output/steam-catalog.json . 2>/dev/null || true
           cp /tmp/protondb-output/hardware-suggestions.json . 2>/dev/null || true
           git show main:gh-pages-manifest.txt > gh-pages-manifest.txt
@@ -834,7 +837,7 @@ jobs:
           git add data/ data-index.html coverage.html search-index.json scoring-info.json form-schema.json badges/
           # add optional pipeline outputs (skip silently if a fresh checkout
           # didn't have them yet, e.g. first run after introducing the file)
-          for f in coverage-summary.json stats.json recent-reports.json game-images.json game-images-skip.json game-images-cache.json gog-catalog-cache.json epic-catalog-cache.json most_played.json proton-versions.json steam-catalog.json hardware-suggestions.json nonsteam-images.json; do
+          for f in coverage-summary.json stats.json recent-reports.json game-images.json game-images-skip.json game-images-cache.json gog-catalog-cache.json epic-catalog-cache.json most_played.json proton-versions.json steam-catalog.json hardware-suggestions.json nonsteam-images.json data-versions.json; do
             [ -f "$f" ] && git add "$f"
           done
           while IFS= read -r path; do

--- a/about.html
+++ b/about.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/cards.css?v=b75e75b2">
-<link rel="stylesheet" href="css/index/index.css?v=e6de6b33">
+<link rel="stylesheet" href="css/index/index.css?v=2d161a7e">
 </head>
 <body>
 

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -129,43 +129,74 @@
 }
 
 /* community stats bar - mono numbers, hairline accent rule under each */
-.community-stats {
-  display: flex;
-  gap: 28px;
+/* Games-by-store snapshot. Three counts + a stacked bar showing the share
+   each store contributes, plus a link to the full stats page. Replaces
+   the old .community-stats block on the home page. */
+.store-counts {
+  display: grid;
+  grid-template-columns: repeat(3, auto) 1fr auto;
+  gap: 18px 24px;
+  align-items: center;
   margin-bottom: 28px;
   flex-wrap: wrap;
 }
-.cs-item {
+.store-count {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  padding: 6px 0 8px;
+  gap: 2px;
+  text-decoration: none;
+  color: inherit;
   position: relative;
-  min-width: 120px;
+  padding-bottom: 4px;
+  border-bottom: 2px solid transparent;
+  transition: border-color 0.15s ease;
 }
-.cs-item::after {
-  content: '';
-  position: absolute;
-  left: 0;
-  bottom: 0;
-  width: 32px;
-  height: 1px;
-  background: linear-gradient(90deg, var(--accent), transparent);
-}
-.cs-num {
+.store-count[data-store="steam"]:hover { border-bottom-color: #1689d0; }
+.store-count[data-store="gog"]:hover   { border-bottom-color: #7a3fcf; }
+.store-count[data-store="epic"]:hover  { border-bottom-color: #bbb; }
+.store-count-num {
   font-family: var(--mono);
-  font-size: 1.8rem;
+  font-size: 1.6rem;
   font-weight: 600;
   color: var(--accent-hi);
   letter-spacing: -0.02em;
   line-height: 1;
-  text-shadow: 0 0 18px var(--accent-glow);
 }
-.cs-label {
+.store-count-label {
   font-size: 0.66rem;
   text-transform: uppercase;
   letter-spacing: 0.14em;
   color: var(--muted);
+}
+.store-count-bar {
+  display: flex;
+  width: 100%;
+  height: 6px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: var(--s1);
+}
+.store-count-bar .seg {
+  height: 100%;
+  transition: width 0.4s ease;
+}
+.store-count-bar .seg--steam { background: #1689d0; }
+.store-count-bar .seg--gog   { background: #7a3fcf; }
+.store-count-bar .seg--epic  { background: #888; }
+.store-count-link {
+  font-size: 0.74rem;
+  color: var(--muted);
+  text-decoration: none;
+  white-space: nowrap;
+}
+.store-count-link:hover { color: var(--accent); }
+@media (max-width: 640px) {
+  .store-counts {
+    grid-template-columns: repeat(3, 1fr);
+    gap: 10px 16px;
+  }
+  .store-count-bar { grid-column: 1 / -1; order: 4; }
+  .store-count-link { grid-column: 1 / -1; order: 5; text-align: right; }
 }
 
 /* primary CTA row - keeps first load focused on the two essential actions
@@ -771,8 +802,8 @@
   .welcome-header .eyebrow { margin-bottom: 6px; }
   .welcome-title { font-size: 1.5rem; margin-bottom: 8px; }
   .welcome-sub { font-size: 0.82rem; line-height: 1.5; }
-  .community-stats { gap: 14px; margin-bottom: 18px; }
-  .cs-num { font-size: 1.3rem; }
+  .store-counts { margin-bottom: 18px; }
+  .store-count-num { font-size: 1.25rem; }
   .welcome-cta { margin-bottom: 8px; }
   .welcome-learn-more { margin-bottom: 14px; }
   .explore-grid { grid-template-columns: 1fr; }

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,7 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" fill="none">
-  <rect width="36" height="36" fill="#000000"/>
-  <ellipse cx="18" cy="18" rx="15" ry="5.5" stroke="#66c0f4" stroke-width="1.4"/>
-  <ellipse cx="18" cy="18" rx="15" ry="5.5" stroke="#66c0f4" stroke-width="1.4" transform="rotate(60 18 18)"/>
-  <ellipse cx="18" cy="18" rx="15" ry="5.5" stroke="#66c0f4" stroke-width="1.4" transform="rotate(-60 18 18)"/>
-  <circle cx="18" cy="18" r="3" fill="#66c0f4"/>
+  <!-- Brand-color rounded background so search engines (Google, Bing) do
+       not wrap the icon in their own white chip on light search results. -->
+  <rect width="36" height="36" rx="6" ry="6" fill="#0b1116"/>
+  <ellipse cx="18" cy="18" rx="15" ry="5.5" stroke="#beee11" stroke-width="1.6"/>
+  <ellipse cx="18" cy="18" rx="15" ry="5.5" stroke="#beee11" stroke-width="1.6" transform="rotate(60 18 18)"/>
+  <ellipse cx="18" cy="18" rx="15" ry="5.5" stroke="#beee11" stroke-width="1.6" transform="rotate(-60 18 18)"/>
+  <circle cx="18" cy="18" r="3.4" fill="#beee11"/>
 </svg>

--- a/favicon.svg
+++ b/favicon.svg
@@ -2,8 +2,8 @@
   <!-- Brand-color rounded background so search engines (Google, Bing) do
        not wrap the icon in their own white chip on light search results. -->
   <rect width="36" height="36" rx="6" ry="6" fill="#0b1116"/>
-  <ellipse cx="18" cy="18" rx="15" ry="5.5" stroke="#beee11" stroke-width="1.6"/>
-  <ellipse cx="18" cy="18" rx="15" ry="5.5" stroke="#beee11" stroke-width="1.6" transform="rotate(60 18 18)"/>
-  <ellipse cx="18" cy="18" rx="15" ry="5.5" stroke="#beee11" stroke-width="1.6" transform="rotate(-60 18 18)"/>
-  <circle cx="18" cy="18" r="3.4" fill="#beee11"/>
+  <ellipse cx="18" cy="18" rx="15" ry="5.5" stroke="#66c0f4" stroke-width="1.6"/>
+  <ellipse cx="18" cy="18" rx="15" ry="5.5" stroke="#66c0f4" stroke-width="1.6" transform="rotate(60 18 18)"/>
+  <ellipse cx="18" cy="18" rx="15" ry="5.5" stroke="#66c0f4" stroke-width="1.6" transform="rotate(-60 18 18)"/>
+  <circle cx="18" cy="18" r="3.4" fill="#66c0f4"/>
 </svg>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
 <link rel="stylesheet" href="css/shared/cards.css?v=b75e75b2">
-<link rel="stylesheet" href="css/index/index.css?v=e6de6b33">
+<link rel="stylesheet" href="css/index/index.css?v=2d161a7e">
 </head>
 <body>
 
@@ -129,28 +129,25 @@
       </p>
     </div>
 
-    <!-- Headline numbers. Populated by index.js:
-         - Pulse Reports comes from Supabase HEAD count
-         - The other three come from parsing coverage.html
-         long-term these should ship as a small coverage-summary.json
-         from the pipeline so we don't fetch 100KB of HTML for 3 numbers -->
-    <div class="community-stats">
-      <div class="cs-item">
-        <span class="cs-num" id="stat-steam-games">—</span>
-        <span class="cs-label">Steam games tracked</span>
-      </div>
-      <div class="cs-item">
-        <span class="cs-num" id="stat-protondb-games">—</span>
-        <span class="cs-label">With ProtonDB data</span>
-      </div>
-      <div class="cs-item">
-        <span class="cs-num" id="stat-indexed">—</span>
-        <span class="cs-label">Indexed locally</span>
-      </div>
-      <div class="cs-item">
-        <span class="cs-num" id="pulse-report-count">—</span>
-        <span class="cs-label">Pulse Reports</span>
-      </div>
+    <!-- Games-by-store snapshot. Populated by js/index/main.js from
+         search-index.json. The full numbers (Pulse Reports, ProtonDB
+         coverage, etc.) live on stats.html so the home page stays a
+         quick visual orientation rather than a dashboard. -->
+    <div class="store-counts" id="store-counts" aria-label="Games tracked per store" hidden>
+      <a class="store-count" data-store="steam" href="app.html#steam">
+        <span class="store-count-num" id="store-count-steam">—</span>
+        <span class="store-count-label">Steam</span>
+      </a>
+      <a class="store-count" data-store="gog" href="app.html#gog">
+        <span class="store-count-num" id="store-count-gog">—</span>
+        <span class="store-count-label">GOG</span>
+      </a>
+      <a class="store-count" data-store="epic" href="app.html#epic">
+        <span class="store-count-num" id="store-count-epic">—</span>
+        <span class="store-count-label">Epic</span>
+      </a>
+      <div class="store-count-bar" id="store-count-bar" aria-hidden="true"></div>
+      <a class="store-count-link" href="stats.html">See full stats &rarr;</a>
     </div>
 
     <!-- Primary CTAs: keep the landing focused on browse / get-plugin. The
@@ -221,6 +218,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=7e8205f8"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/index/main.js?v=5bc9db83"></script>
+<script type="module" src="js/index/main.js?v=80e0188b"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -6,9 +6,9 @@
 <meta http-equiv="Pragma" content="no-cache">
 <meta http-equiv="Expires" content="0">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Proton Pulse | Smart ProtonDB Launch Configurations for Steam Deck</title>
-<meta name="description" content="Stop copying and pasting launch flags. View weighted ProtonDB hardware scores, filter compatibility reports by your GPU and driver, and apply Proton launch options directly to your Steam Deck library.">
-<meta property="og:title" content="Proton Pulse | Smart ProtonDB Launch Configurations for Steam Deck">
+<title>Proton Pulse | Smart Proton Launch Configurations for Steam Deck</title>
+<meta name="description" content="Stop copying and pasting launch flags. View weighted hardware scores, filter compatibility reports by your GPU and driver, and apply Proton launch options directly to your Steam Deck library.">
+<meta property="og:title" content="Proton Pulse | Smart Proton Launch Configurations for Steam Deck">
 <meta property="og:description" content="Stop copying and pasting launch flags. View weighted ProtonDB hardware scores, filter compatibility reports by your GPU and driver, and apply Proton launch options directly to your Steam Deck library.">
 <meta property="og:type" content="website">
 <meta name="color-scheme" content="dark">

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -15,12 +15,17 @@ import { loadSearchIndex, searchIndex } from './search.js?v=28b593a1';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=e7fe3ce0';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=f5dda5b6';
+import { dataUrl } from '../../lib/data-url.js?v=3c2e7ac9';
 
 let _steamCatalogCache = null;
 async function _fetchSteamCatalog() {
   if (_steamCatalogCache !== null) return _steamCatalogCache;
   try {
-    const resp = await fetch(`${SITE_ROOT}/steam-catalog.json`);
+    // Route through dataUrl so the content hash invalidates the cache when
+    // the catalog actually changes (#119). The bare name resolves to the
+    // staging/local copy or the prod copy depending on USES_PROD_DATA.
+    const bustedName = await dataUrl('steam-catalog.json');
+    const resp = await fetch(`${SITE_ROOT}/${bustedName}`);
     _steamCatalogCache = resp.ok ? await resp.json() : {};
   } catch {
     _steamCatalogCache = {};
@@ -260,12 +265,21 @@ export async function renderGamePage(appId) {
     return;
   }
 
-  // Resolve a human-readable title: reports first (they almost always carry one),
-  // then configs, then fall back to the pre-loaded search-index which has the
-  // canonical Steam name per appId. Final fallback is the bare app id.
+  // Resolve a human-readable title. Order, most specific first:
+  //   1. report title (mirrored/local data carries it)
+  //   2. config appName (Pulse Reports carry the user's chosen title)
+  //   3. search-index hit (.[1] is the title column)
+  //   4. steam-catalog lookup (covers live-only apps that are not in our
+  //      search-index but still on Steam -- the #115 case)
+  //   5. bare "App <id>" -- last resort when nothing else can resolve a name
   await loadSearchIndex();
   const indexHit = (searchIndex || []).find(row => String(row[0]) === String(appId));
-  const title = reports[0]?.title || configs[0]?.appName || indexHit?.[1] || `App ${appId}`;
+  let resolvedTitle = reports[0]?.title || configs[0]?.appName || indexHit?.[1];
+  if (!resolvedTitle && /^\d+$/.test(String(appId))) {
+    const catalog = await _fetchSteamCatalog();
+    resolvedTitle = catalog?.[String(appId)] || null;
+  }
+  const title = resolvedTitle || `App ${appId}`;
   // Steam returned success=false from appdetails for this app: it has been
   // pulled from the store. Reports remain valid (people still own it via
   // family share, backups, or regional accounts) -- we just flag it so the

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=003f23c0';
-import { renderGamePage } from './game-page.js?v=565f22df';
+import { renderGamePage } from './game-page.js?v=8c173ecc';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=20b34baa';

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,6 +1,6 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=565f22df';
+import { renderGamePage } from './components/game-page.js?v=8c173ecc';
 import { renderHomePage } from './components/home.js?v=e2796a09';
 import { renderSearchPage } from './components/search.js?v=28b593a1';
 

--- a/js/index/main.js
+++ b/js/index/main.js
@@ -5,69 +5,38 @@ import { dataUrl } from '../lib/data-url.js?v=3c2e7ac9';
 // Homepage-only logic. Universal nav chrome (banner, nav row, mobile drawer,
 // search dropdown, auth indicator) lives in topbar.js.
 
-// Pulse report count. Uses HEAD + Content-Range so we don't care whether
-// PostgREST returns the aggregate in the body; the header is always there
-// when Prefer: count=exact is set. Range: 0-0 keeps the response tiny.
-(async function loadPulseStats() {
-  const SB = 'https://ilsgdshkaocrmibwdezk.supabase.co/rest/v1';
-  const KEY = 'sb_publishable_3Oqhm4JneafJNQw9BuUaxw_L9qZa-5V';
+// Games-by-store snapshot. Counts entries in search-index.json by appType
+// (column 5) and renders three numbers + a stacked bar showing the share
+// each store contributes. Replaces the older 4-stat block; the deeper
+// dashboard lives on stats.html.
+(async function loadStoreCounts() {
+  const root = document.getElementById('store-counts');
+  if (!root) return;
   try {
-    const resp = await fetch(`${SB}/user_configs?select=id`, {
-      method: 'HEAD',
-      headers: { apikey: KEY, Prefer: 'count=exact', Range: '0-0' },
-    });
-    // content-range looks like "0-0/1234" or "*/1234"
-    const range = resp.headers.get('content-range') || '';
-    const total = parseInt(range.split('/')[1], 10);
-    const count = Number.isFinite(total) ? total : 0;
-    const el = document.getElementById('pulse-report-count');
-    if (el) el.textContent = count.toLocaleString();
-  } catch (_) {}
-})();
-
-// Coverage stats. Prefers /coverage-summary.json (emitted by the data pipeline
-// in scripts/pipeline/finalize.py:generate_coverage_report) since it's tiny
-// and structured. Falls back to scraping coverage.html if the JSON isn't there
-// (e.g. an older deployment). In local vite dev both 404 -> em-dash stays.
-(async function loadCoverageStats() {
-  function setStat(id, value) {
-    if (value == null) return;
-    const el = document.getElementById(id);
-    if (el) el.textContent = typeof value === 'number' ? value.toLocaleString() : value;
-  }
-
-  // try the JSON summary first
-  try {
-    const resp = await fetch('coverage-summary.json', { cache: 'no-store' });
-    if (resp.ok) {
-      const ct = resp.headers.get('content-type') || '';
-      if (ct.includes('application/json') || ct.includes('text/plain')) {
-        const data = await resp.json();
-        setStat('stat-steam-games',    data.steam_games);
-        setStat('stat-protondb-games', data.protondb_games);
-        setStat('stat-indexed',        data.indexed);
-        return;
-      }
-    }
-  } catch (_) { /* fall through to HTML scrape */ }
-
-  // fallback: parse coverage.html for the same numbers
-  try {
-    const resp = await fetch('coverage.html');
+    const resp = await fetch(await dataUrl('search-index.json'));
     if (!resp.ok) return;
-    const html = await resp.text();
-    function pick(label) {
-      const safe = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      const re = new RegExp(
-        '<div class="label">' + safe + '<\\/div>\\s*<div class="value">([\\d,]+)<\\/div>'
-      );
-      const m = html.match(re);
-      return m ? m[1] : null;
+    const rows = await resp.json();
+    const counts = { steam: 0, gog: 0, epic: 0 };
+    for (const row of rows) {
+      const t = row[5];
+      if (t === 'steam' || t === 'gog' || t === 'epic') counts[t]++;
     }
-    setStat('stat-steam-games',    pick('Steam Games'));
-    setStat('stat-protondb-games', pick('ProtonDB Total'));
-    setStat('stat-indexed',        pick('Indexed (with data)'));
-  } catch (_) { /* leave em-dash placeholders */ }
+    const total = counts.steam + counts.gog + counts.epic;
+    if (!total) return;
+    document.getElementById('store-count-steam').textContent = counts.steam.toLocaleString();
+    document.getElementById('store-count-gog').textContent   = counts.gog.toLocaleString();
+    document.getElementById('store-count-epic').textContent  = counts.epic.toLocaleString();
+    const bar = document.getElementById('store-count-bar');
+    if (bar) {
+      const pct = (n) => (n / total) * 100;
+      bar.innerHTML = [
+        `<div class="seg seg--steam" style="width:${pct(counts.steam)}%"></div>`,
+        `<div class="seg seg--gog" style="width:${pct(counts.gog)}%"></div>`,
+        `<div class="seg seg--epic" style="width:${pct(counts.epic)}%"></div>`,
+      ].join('');
+    }
+    root.hidden = false;
+  } catch (_) { /* leave the section hidden if anything goes wrong */ }
 })();
 
 // Popular games on Steam. Reads most_played.json (produced by the pipeline:

--- a/privacy.html
+++ b/privacy.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/cards.css?v=b75e75b2">
-<link rel="stylesheet" href="css/index/index.css?v=e6de6b33">
+<link rel="stylesheet" href="css/index/index.css?v=2d161a7e">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/terms.html
+++ b/terms.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/cards.css?v=b75e75b2">
-<link rel="stylesheet" href="css/index/index.css?v=e6de6b33">
+<link rel="stylesheet" href="css/index/index.css?v=2d161a7e">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }


### PR DESCRIPTION
Rolls up the staging stack into one promotion to main.

Workflow:
- Copy data-versions.json to gh-pages on deploy. Pipeline wrote it but the deploy step skipped it -- manifest was 404 in prod after the first run. Added to the cp chain and the optional-files git add loop in all 3 deploy paths.

Frontend:
- #115 live-fallback title resolution falls through to steam-catalog.json for numeric Steam ids before bare 'App <id>'. Apps Steam still publicly lists (Prey 480490 etc.) pick up their canonical name even when local data is missing.
- Home page replaces the 4-stat coverage block with a games-by-store snapshot: count per store (Steam, GOG, Epic) + a stacked bar + a link to stats.html for the full dashboard. Counts come from search-index.json's appType column so we avoid the coverage-summary.json + coverage.html fallback dance entirely.
- Page title drops 'ProtonDB' (was 'Smart ProtonDB Launch Configurations', now 'Smart Proton Launch Configurations') so search results focus on the value not the backing source.
- favicon gets a dark rounded background with blue accent strokes so search engines (Google in particular) stop wrapping it in their own white chip.

After merge, no full pipeline run needed -- all changes are frontend or workflow-only. make gh-pages-only is enough.