### PR TITLE
v1.5.0: card layout overhaul, store icons, admin pending filter, framegen color fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Proton Pulse (web) should be recorded here.
 
+## v1.5.0
+
+- Card layout: a new bottom-bar tier strip is the site default, with the store badge sitting next to the rating as a brand-colored pill or round logo (Steam, GOG, Epic). Five placement options for the store badge (right, artwork, card corner, on bar next to rating, on bar split) and a separate text-or-icon display toggle
+- Site Options page: defaults are now labeled, a Reset button clears all browser-local preferences, and the signed-in/avatar header now renders correctly on options, privacy, scoring, stats, and terms (the supabase library wasn't being loaded on those pages)
+- GOG and Epic store glyphs redrawn so they keep their brand shape (white GOG disc, dark Epic shield) instead of being squashed into a generic circle
+- Admin Reports tab adds a "Pending approval" filter and approval-aware status badges: rows in user_configs without a matching `report_approvals` row now show as pending instead of being silently mixed in with "Clean"
+- Admin Reports App link goes to the specific report's permalink for approved-and-visible rows; pending, flagged, and hidden rows keep the game-level link since the permalink would 404 there
+- Report permalink anchor moved to wrap the whole report block so navigating to `#report-r<id>` lands on the top of the visible report instead of the footer area, with a topbar offset so the report header isn't tucked behind the fixed toolbar
+- Framegen signal icon now reads green when not required and red when required, matching how readers interpret "did this game need framegen help?"
+- My Reports page no longer shows the same report twice when one row stored `app_id` as a number and another as a string
+
 ## v1.4.1
 
 - GOG and Epic game pages now load their data from the correct directory (the pipeline writes `gog_123/` but five frontend call sites were requesting `gog:123/`)

--- a/about.html
+++ b/about.html
@@ -15,8 +15,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
-<link rel="stylesheet" href="css/index/index.css?v=f047d582">
+<link rel="stylesheet" href="css/shared/cards.css?v=17142038">
+<link rel="stylesheet" href="css/index/index.css?v=cef6764d">
 </head>
 <body>
 
@@ -194,7 +194,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=a47091a2"></script>
+<script src="js/lib/topbar.js?v=1d29a1b6"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/about/version.js?v=dd0d91d0"></script>
 </body>

--- a/about.html
+++ b/about.html
@@ -15,8 +15,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=9548e3dd">
-<link rel="stylesheet" href="css/index/index.css?v=b3faf0dd">
+<link rel="stylesheet" href="css/shared/cards.css?v=d1db1355">
+<link rel="stylesheet" href="css/index/index.css?v=ad77490b">
 </head>
 <body>
 
@@ -194,7 +194,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=522f6c3d"></script>
+<script src="js/lib/topbar.js?v=3585d26d"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/about/version.js?v=dd0d91d0"></script>
 </body>

--- a/about.html
+++ b/about.html
@@ -14,9 +14,9 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
-<link rel="stylesheet" href="css/shared/site.css?v=c581801e">
-<link rel="stylesheet" href="css/shared/cards.css?v=0092674d">
-<link rel="stylesheet" href="css/index/index.css?v=5ef799ac">
+<link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
+<link rel="stylesheet" href="css/shared/cards.css?v=ac2f4490">
+<link rel="stylesheet" href="css/index/index.css?v=a2de5ad7">
 </head>
 <body>
 

--- a/about.html
+++ b/about.html
@@ -15,8 +15,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=7b2b7e95">
-<link rel="stylesheet" href="css/index/index.css?v=e7a3bfb0">
+<link rel="stylesheet" href="css/shared/cards.css?v=9548e3dd">
+<link rel="stylesheet" href="css/index/index.css?v=b3faf0dd">
 </head>
 <body>
 

--- a/about.html
+++ b/about.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=17142038">
-<link rel="stylesheet" href="css/index/index.css?v=cef6764d">
+<link rel="stylesheet" href="css/index/index.css?v=6b16bc5f">
 </head>
 <body>
 

--- a/about.html
+++ b/about.html
@@ -15,8 +15,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=b48b5b18">
-<link rel="stylesheet" href="css/index/index.css?v=501c588c">
+<link rel="stylesheet" href="css/shared/cards.css?v=cb310e3b">
+<link rel="stylesheet" href="css/index/index.css?v=977253e5">
 </head>
 <body>
 
@@ -194,7 +194,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=f444bec4"></script>
+<script src="js/lib/topbar.js?v=2f8197e0"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/about/version.js?v=dd0d91d0"></script>
 </body>

--- a/about.html
+++ b/about.html
@@ -15,8 +15,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=cb310e3b">
-<link rel="stylesheet" href="css/index/index.css?v=977253e5">
+<link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
+<link rel="stylesheet" href="css/index/index.css?v=edf9e702">
 </head>
 <body>
 

--- a/about.html
+++ b/about.html
@@ -15,8 +15,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=4b548983">
-<link rel="stylesheet" href="css/index/index.css?v=39339c49">
+<link rel="stylesheet" href="css/shared/cards.css?v=5ec3c05a">
+<link rel="stylesheet" href="css/index/index.css?v=82445769">
 </head>
 <body>
 

--- a/about.html
+++ b/about.html
@@ -194,7 +194,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=1d29a1b6"></script>
+<script src="js/lib/topbar.js?v=a3dcfcd5"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/about/version.js?v=dd0d91d0"></script>
 </body>

--- a/about.html
+++ b/about.html
@@ -14,8 +14,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
-<link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=17c970a6">
+<link rel="stylesheet" href="css/shared/site.css?v=c581801e">
+<link rel="stylesheet" href="css/shared/cards.css?v=0092674d">
 <link rel="stylesheet" href="css/index/index.css?v=5ef799ac">
 </head>
 <body>

--- a/about.html
+++ b/about.html
@@ -15,7 +15,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=7906ae81">
+<link rel="stylesheet" href="css/shared/cards.css?v=4b548983">
 <link rel="stylesheet" href="css/index/index.css?v=39339c49">
 </head>
 <body>

--- a/about.html
+++ b/about.html
@@ -15,8 +15,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=ac2f4490">
-<link rel="stylesheet" href="css/index/index.css?v=a2de5ad7">
+<link rel="stylesheet" href="css/shared/cards.css?v=7906ae81">
+<link rel="stylesheet" href="css/index/index.css?v=39339c49">
 </head>
 <body>
 

--- a/about.html
+++ b/about.html
@@ -194,7 +194,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=2f8197e0"></script>
+<script src="js/lib/topbar.js?v=8c2f9356"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/about/version.js?v=dd0d91d0"></script>
 </body>

--- a/about.html
+++ b/about.html
@@ -15,8 +15,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=d1db1355">
-<link rel="stylesheet" href="css/index/index.css?v=ad77490b">
+<link rel="stylesheet" href="css/shared/cards.css?v=17c970a6">
+<link rel="stylesheet" href="css/index/index.css?v=5ef799ac">
 </head>
 <body>
 
@@ -194,7 +194,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=3585d26d"></script>
+<script src="js/lib/topbar.js?v=f444bec4"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/about/version.js?v=dd0d91d0"></script>
 </body>

--- a/about.html
+++ b/about.html
@@ -13,7 +13,7 @@
 <meta property="og:type" content="website">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
-<link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
+<link rel="stylesheet" href="css/shared/topbar.css?v=256d07b6">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <link rel="stylesheet" href="css/index/index.css?v=624d05bc">
@@ -194,7 +194,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=a3dcfcd5"></script>
+<script src="js/lib/topbar.js?v=c2fe26da"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/about/version.js?v=dd0d91d0"></script>
 </body>

--- a/about.html
+++ b/about.html
@@ -13,7 +13,7 @@
 <meta property="og:type" content="website">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
-<link rel="stylesheet" href="css/shared/topbar.css?v=256d07b6">
+<link rel="stylesheet" href="css/shared/topbar.css?v=2d6b5e52">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <link rel="stylesheet" href="css/index/index.css?v=624d05bc">
@@ -194,7 +194,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=c2fe26da"></script>
+<script src="js/lib/topbar.js?v=449040e3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/about/version.js?v=dd0d91d0"></script>
 </body>

--- a/about.html
+++ b/about.html
@@ -15,8 +15,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=17142038">
-<link rel="stylesheet" href="css/index/index.css?v=6b16bc5f">
+<link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
+<link rel="stylesheet" href="css/index/index.css?v=624d05bc">
 </head>
 <body>
 

--- a/about.html
+++ b/about.html
@@ -15,8 +15,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=b75e75b2">
-<link rel="stylesheet" href="css/index/index.css?v=2d161a7e">
+<link rel="stylesheet" href="css/shared/cards.css?v=7b2b7e95">
+<link rel="stylesheet" href="css/index/index.css?v=e7a3bfb0">
 </head>
 <body>
 
@@ -194,7 +194,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=7e8205f8"></script>
+<script src="js/lib/topbar.js?v=522f6c3d"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/about/version.js?v=dd0d91d0"></script>
 </body>

--- a/about.html
+++ b/about.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
-<link rel="stylesheet" href="css/index/index.css?v=edf9e702">
+<link rel="stylesheet" href="css/index/index.css?v=f047d582">
 </head>
 <body>
 
@@ -194,7 +194,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=8fe1c285"></script>
+<script src="js/lib/topbar.js?v=a47091a2"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/about/version.js?v=dd0d91d0"></script>
 </body>

--- a/about.html
+++ b/about.html
@@ -194,7 +194,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=8c2f9356"></script>
+<script src="js/lib/topbar.js?v=8fe1c285"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/about/version.js?v=dd0d91d0"></script>
 </body>

--- a/about.html
+++ b/about.html
@@ -15,8 +15,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=5ec3c05a">
-<link rel="stylesheet" href="css/index/index.css?v=82445769">
+<link rel="stylesheet" href="css/shared/cards.css?v=b48b5b18">
+<link rel="stylesheet" href="css/index/index.css?v=501c588c">
 </head>
 <body>
 

--- a/admin.html
+++ b/admin.html
@@ -322,7 +322,7 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/analytics.js?v=89bd7747"></script>
-<script src="js/lib/topbar.js?v=1d29a1b6"></script>
+<script src="js/lib/topbar.js?v=a3dcfcd5"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/admin/main.js?v=9ffcb709"></script>
 </body>

--- a/admin.html
+++ b/admin.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=cb310e3b">
+<link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
 <link rel="stylesheet" href="css/admin/admin.css?v=4609c726">
 </head>
 <body>

--- a/admin.html
+++ b/admin.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=7b2b7e95">
+<link rel="stylesheet" href="css/shared/cards.css?v=9548e3dd">
 <link rel="stylesheet" href="css/admin/admin.css?v=4609c726">
 </head>
 <body>

--- a/admin.html
+++ b/admin.html
@@ -9,7 +9,7 @@
 <title>Admin — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
-<link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
+<link rel="stylesheet" href="css/shared/topbar.css?v=256d07b6">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <link rel="stylesheet" href="css/admin/admin.css?v=fa00589e">
@@ -322,7 +322,7 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/analytics.js?v=89bd7747"></script>
-<script src="js/lib/topbar.js?v=a3dcfcd5"></script>
+<script src="js/lib/topbar.js?v=c2fe26da"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/admin/main.js?v=9ffcb709"></script>
 </body>

--- a/admin.html
+++ b/admin.html
@@ -9,7 +9,7 @@
 <title>Admin — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
-<link rel="stylesheet" href="css/shared/topbar.css?v=256d07b6">
+<link rel="stylesheet" href="css/shared/topbar.css?v=2d6b5e52">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <link rel="stylesheet" href="css/admin/admin.css?v=fa00589e">
@@ -322,7 +322,7 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/analytics.js?v=89bd7747"></script>
-<script src="js/lib/topbar.js?v=c2fe26da"></script>
+<script src="js/lib/topbar.js?v=449040e3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/admin/main.js?v=9ffcb709"></script>
 </body>

--- a/admin.html
+++ b/admin.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=d1db1355">
+<link rel="stylesheet" href="css/shared/cards.css?v=17c970a6">
 <link rel="stylesheet" href="css/admin/admin.css?v=4609c726">
 </head>
 <body>
@@ -320,7 +320,7 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/analytics.js?v=89bd7747"></script>
-<script src="js/lib/topbar.js?v=3585d26d"></script>
+<script src="js/lib/topbar.js?v=f444bec4"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/admin/main.js?v=9ffcb709"></script>
 </body>

--- a/admin.html
+++ b/admin.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=7906ae81">
+<link rel="stylesheet" href="css/shared/cards.css?v=4b548983">
 <link rel="stylesheet" href="css/admin/admin.css?v=4609c726">
 </head>
 <body>

--- a/admin.html
+++ b/admin.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=4b548983">
+<link rel="stylesheet" href="css/shared/cards.css?v=5ec3c05a">
 <link rel="stylesheet" href="css/admin/admin.css?v=4609c726">
 </head>
 <body>

--- a/admin.html
+++ b/admin.html
@@ -10,8 +10,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
-<link rel="stylesheet" href="css/shared/site.css?v=c581801e">
-<link rel="stylesheet" href="css/shared/cards.css?v=0092674d">
+<link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
+<link rel="stylesheet" href="css/shared/cards.css?v=ac2f4490">
 <link rel="stylesheet" href="css/admin/admin.css?v=4609c726">
 </head>
 <body>

--- a/admin.html
+++ b/admin.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
-<link rel="stylesheet" href="css/admin/admin.css?v=4609c726">
+<link rel="stylesheet" href="css/admin/admin.css?v=fa00589e">
 </head>
 <body>
 
@@ -54,7 +54,8 @@
           <input type="text" id="all-reports-search" class="admin-input admin-input--wide" placeholder="Search by app ID or title...">
           <select id="all-reports-status-filter" class="admin-select">
             <option value="">All statuses</option>
-            <option value="clean" selected>Clean</option>
+            <option value="clean" selected>Approved (clean)</option>
+            <option value="pending">Pending approval</option>
             <option value="flagged">Flagged</option>
             <option value="hidden">Hidden</option>
           </select>
@@ -70,9 +71,10 @@
           <button class="admin-btn" id="all-reports-refresh-btn">Refresh</button>
         </div>
         <div class="admin-legend">
+          <span class="admin-badge admin-badge--ok">approved</span> visible to the public &nbsp;&middot;&nbsp;
+          <span class="admin-badge admin-badge--info">pending</span> waiting on the daily approval pipeline &nbsp;&middot;&nbsp;
           <span class="admin-badge admin-badge--warn">flagged</span> queued for mod review &nbsp;&middot;&nbsp;
-          <span class="admin-badge admin-badge--muted">hidden</span> shadow-banned, not visible to users &nbsp;&middot;&nbsp;
-          blank = visible and clean
+          <span class="admin-badge admin-badge--muted">hidden</span> shadow-banned, not visible to users
         </div>
         <div id="all-reports-count" class="admin-counts" hidden></div>
         <div id="all-reports-loading" class="admin-loading">Loading reports...</div>

--- a/admin.html
+++ b/admin.html
@@ -10,8 +10,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
-<link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=17c970a6">
+<link rel="stylesheet" href="css/shared/site.css?v=c581801e">
+<link rel="stylesheet" href="css/shared/cards.css?v=0092674d">
 <link rel="stylesheet" href="css/admin/admin.css?v=4609c726">
 </head>
 <body>

--- a/admin.html
+++ b/admin.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
+<link rel="stylesheet" href="css/shared/cards.css?v=17142038">
 <link rel="stylesheet" href="css/admin/admin.css?v=fa00589e">
 </head>
 <body>
@@ -322,7 +322,7 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/analytics.js?v=89bd7747"></script>
-<script src="js/lib/topbar.js?v=a47091a2"></script>
+<script src="js/lib/topbar.js?v=1d29a1b6"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/admin/main.js?v=9ffcb709"></script>
 </body>

--- a/admin.html
+++ b/admin.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=b48b5b18">
+<link rel="stylesheet" href="css/shared/cards.css?v=cb310e3b">
 <link rel="stylesheet" href="css/admin/admin.css?v=4609c726">
 </head>
 <body>
@@ -320,7 +320,7 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/analytics.js?v=89bd7747"></script>
-<script src="js/lib/topbar.js?v=f444bec4"></script>
+<script src="js/lib/topbar.js?v=2f8197e0"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/admin/main.js?v=9ffcb709"></script>
 </body>

--- a/admin.html
+++ b/admin.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=9548e3dd">
+<link rel="stylesheet" href="css/shared/cards.css?v=d1db1355">
 <link rel="stylesheet" href="css/admin/admin.css?v=4609c726">
 </head>
 <body>
@@ -320,7 +320,7 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/analytics.js?v=89bd7747"></script>
-<script src="js/lib/topbar.js?v=522f6c3d"></script>
+<script src="js/lib/topbar.js?v=3585d26d"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/admin/main.js?v=9ffcb709"></script>
 </body>

--- a/admin.html
+++ b/admin.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=ac2f4490">
+<link rel="stylesheet" href="css/shared/cards.css?v=7906ae81">
 <link rel="stylesheet" href="css/admin/admin.css?v=4609c726">
 </head>
 <body>

--- a/admin.html
+++ b/admin.html
@@ -320,7 +320,7 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/analytics.js?v=89bd7747"></script>
-<script src="js/lib/topbar.js?v=2f8197e0"></script>
+<script src="js/lib/topbar.js?v=8c2f9356"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/admin/main.js?v=9ffcb709"></script>
 </body>

--- a/admin.html
+++ b/admin.html
@@ -322,7 +322,7 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/analytics.js?v=89bd7747"></script>
-<script src="js/lib/topbar.js?v=8fe1c285"></script>
+<script src="js/lib/topbar.js?v=a47091a2"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/admin/main.js?v=9ffcb709"></script>
 </body>

--- a/admin.html
+++ b/admin.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=b75e75b2">
+<link rel="stylesheet" href="css/shared/cards.css?v=7b2b7e95">
 <link rel="stylesheet" href="css/admin/admin.css?v=4609c726">
 </head>
 <body>
@@ -320,7 +320,7 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/analytics.js?v=89bd7747"></script>
-<script src="js/lib/topbar.js?v=7e8205f8"></script>
+<script src="js/lib/topbar.js?v=522f6c3d"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/admin/main.js?v=9ffcb709"></script>
 </body>

--- a/admin.html
+++ b/admin.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=5ec3c05a">
+<link rel="stylesheet" href="css/shared/cards.css?v=b48b5b18">
 <link rel="stylesheet" href="css/admin/admin.css?v=4609c726">
 </head>
 <body>

--- a/admin.html
+++ b/admin.html
@@ -320,7 +320,7 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/analytics.js?v=89bd7747"></script>
-<script src="js/lib/topbar.js?v=8c2f9356"></script>
+<script src="js/lib/topbar.js?v=8fe1c285"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/admin/main.js?v=9ffcb709"></script>
 </body>

--- a/admin.html
+++ b/admin.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=17142038">
+<link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <link rel="stylesheet" href="css/admin/admin.css?v=fa00589e">
 </head>
 <body>

--- a/app.html
+++ b/app.html
@@ -16,12 +16,12 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
+<link rel="stylesheet" href="css/shared/cards.css?v=17142038">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
-<link rel="stylesheet" href="css/app/home.css?v=b62dd0ac">
+<link rel="stylesheet" href="css/app/home.css?v=4ea20844">
 </head>
 <body>
 
@@ -55,7 +55,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=a47091a2"></script>
+<script src="js/lib/topbar.js?v=1d29a1b6"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
 <script type="module" src="js/app/main.js?v=7417f4a4"></script>

--- a/app.html
+++ b/app.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=ac2f4490">
+<link rel="stylesheet" href="css/shared/cards.css?v=7906ae81">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/app.html
+++ b/app.html
@@ -13,7 +13,7 @@
 <meta property="og:type" content="website">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
-<link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
+<link rel="stylesheet" href="css/shared/topbar.css?v=256d07b6">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
@@ -55,7 +55,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=a3dcfcd5"></script>
+<script src="js/lib/topbar.js?v=c2fe26da"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
 <script type="module" src="js/app/main.js?v=7417f4a4"></script>

--- a/app.html
+++ b/app.html
@@ -17,7 +17,7 @@
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
-<link rel="stylesheet" href="css/app/game-header.css?v=eae4ea27">
+<link rel="stylesheet" href="css/app/game-header.css?v=669186d7">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">

--- a/app.html
+++ b/app.html
@@ -55,7 +55,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=1d29a1b6"></script>
+<script src="js/lib/topbar.js?v=a3dcfcd5"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
 <script type="module" src="js/app/main.js?v=7417f4a4"></script>

--- a/app.html
+++ b/app.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=9548e3dd">
+<link rel="stylesheet" href="css/shared/cards.css?v=d1db1355">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
@@ -55,7 +55,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=522f6c3d"></script>
+<script src="js/lib/topbar.js?v=3585d26d"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
 <script type="module" src="js/app/main.js?v=7417f4a4"></script>

--- a/app.html
+++ b/app.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=4b548983">
+<link rel="stylesheet" href="css/shared/cards.css?v=5ec3c05a">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/app.html
+++ b/app.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=7b2b7e95">
+<link rel="stylesheet" href="css/shared/cards.css?v=9548e3dd">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/app.html
+++ b/app.html
@@ -13,7 +13,7 @@
 <meta property="og:type" content="website">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
-<link rel="stylesheet" href="css/shared/topbar.css?v=256d07b6">
+<link rel="stylesheet" href="css/shared/topbar.css?v=2d6b5e52">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
@@ -55,7 +55,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=c2fe26da"></script>
+<script src="js/lib/topbar.js?v=449040e3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
 <script type="module" src="js/app/main.js?v=7417f4a4"></script>

--- a/app.html
+++ b/app.html
@@ -14,9 +14,9 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
-<link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
+<link rel="stylesheet" href="css/shared/site.css?v=c581801e">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=17c970a6">
+<link rel="stylesheet" href="css/shared/cards.css?v=0092674d">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/app.html
+++ b/app.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=d1db1355">
+<link rel="stylesheet" href="css/shared/cards.css?v=17c970a6">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
@@ -55,7 +55,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=3585d26d"></script>
+<script src="js/lib/topbar.js?v=f444bec4"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
 <script type="module" src="js/app/main.js?v=7417f4a4"></script>

--- a/app.html
+++ b/app.html
@@ -14,9 +14,9 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
-<link rel="stylesheet" href="css/shared/site.css?v=c581801e">
+<link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=0092674d">
+<link rel="stylesheet" href="css/shared/cards.css?v=ac2f4490">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/app.html
+++ b/app.html
@@ -55,7 +55,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=2f8197e0"></script>
+<script src="js/lib/topbar.js?v=8c2f9356"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
 <script type="module" src="js/app/main.js?v=7417f4a4"></script>

--- a/app.html
+++ b/app.html
@@ -21,7 +21,7 @@
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
-<link rel="stylesheet" href="css/app/home.css?v=4ea20844">
+<link rel="stylesheet" href="css/app/home.css?v=d983b41a">
 </head>
 <body>
 

--- a/app.html
+++ b/app.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=cb310e3b">
+<link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/app.html
+++ b/app.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=b48b5b18">
+<link rel="stylesheet" href="css/shared/cards.css?v=cb310e3b">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
@@ -55,7 +55,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=f444bec4"></script>
+<script src="js/lib/topbar.js?v=2f8197e0"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
 <script type="module" src="js/app/main.js?v=7417f4a4"></script>

--- a/app.html
+++ b/app.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=7906ae81">
+<link rel="stylesheet" href="css/shared/cards.css?v=4b548983">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/app.html
+++ b/app.html
@@ -55,7 +55,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=8c2f9356"></script>
+<script src="js/lib/topbar.js?v=8fe1c285"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
 <script type="module" src="js/app/main.js?v=7417f4a4"></script>

--- a/app.html
+++ b/app.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=b75e75b2">
+<link rel="stylesheet" href="css/shared/cards.css?v=7b2b7e95">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
@@ -55,7 +55,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=7e8205f8"></script>
+<script src="js/lib/topbar.js?v=522f6c3d"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
 <script type="module" src="js/app/main.js?v=7417f4a4"></script>

--- a/app.html
+++ b/app.html
@@ -16,8 +16,8 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=17142038">
-<link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
+<link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
+<link rel="stylesheet" href="css/app/game-header.css?v=eae4ea27">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">

--- a/app.html
+++ b/app.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=5ec3c05a">
+<link rel="stylesheet" href="css/shared/cards.css?v=b48b5b18">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/app.html
+++ b/app.html
@@ -21,7 +21,7 @@
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
-<link rel="stylesheet" href="css/app/home.css?v=4bf8008f">
+<link rel="stylesheet" href="css/app/home.css?v=b62dd0ac">
 </head>
 <body>
 
@@ -55,7 +55,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=8fe1c285"></script>
+<script src="js/lib/topbar.js?v=a47091a2"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
 <script type="module" src="js/app/main.js?v=7417f4a4"></script>

--- a/auth.html
+++ b/auth.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=7906ae81">
+<link rel="stylesheet" href="css/shared/cards.css?v=4b548983">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/auth.html
+++ b/auth.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=cb310e3b">
+<link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/auth.html
+++ b/auth.html
@@ -10,8 +10,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
-<link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=17c970a6">
+<link rel="stylesheet" href="css/shared/site.css?v=c581801e">
+<link rel="stylesheet" href="css/shared/cards.css?v=0092674d">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/auth.html
+++ b/auth.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=7b2b7e95">
+<link rel="stylesheet" href="css/shared/cards.css?v=9548e3dd">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/auth.html
+++ b/auth.html
@@ -9,7 +9,7 @@
 <title>Sign In With Steam — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
-<link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
+<link rel="stylesheet" href="css/shared/topbar.css?v=256d07b6">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">

--- a/auth.html
+++ b/auth.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
+<link rel="stylesheet" href="css/shared/cards.css?v=17142038">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/auth.html
+++ b/auth.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=b48b5b18">
+<link rel="stylesheet" href="css/shared/cards.css?v=cb310e3b">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/auth.html
+++ b/auth.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=d1db1355">
+<link rel="stylesheet" href="css/shared/cards.css?v=17c970a6">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/auth.html
+++ b/auth.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=9548e3dd">
+<link rel="stylesheet" href="css/shared/cards.css?v=d1db1355">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/auth.html
+++ b/auth.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=4b548983">
+<link rel="stylesheet" href="css/shared/cards.css?v=5ec3c05a">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/auth.html
+++ b/auth.html
@@ -9,7 +9,7 @@
 <title>Sign In With Steam — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
-<link rel="stylesheet" href="css/shared/topbar.css?v=256d07b6">
+<link rel="stylesheet" href="css/shared/topbar.css?v=2d6b5e52">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">

--- a/auth.html
+++ b/auth.html
@@ -10,8 +10,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
-<link rel="stylesheet" href="css/shared/site.css?v=c581801e">
-<link rel="stylesheet" href="css/shared/cards.css?v=0092674d">
+<link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
+<link rel="stylesheet" href="css/shared/cards.css?v=ac2f4490">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/auth.html
+++ b/auth.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=ac2f4490">
+<link rel="stylesheet" href="css/shared/cards.css?v=7906ae81">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/auth.html
+++ b/auth.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=b75e75b2">
+<link rel="stylesheet" href="css/shared/cards.css?v=7b2b7e95">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/auth.html
+++ b/auth.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=17142038">
+<link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/auth.html
+++ b/auth.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=5ec3c05a">
+<link rel="stylesheet" href="css/shared/cards.css?v=b48b5b18">
 <link rel="stylesheet" href="css/auth/auth.css?v=ca512b85">
 </head>
 <body>

--- a/confidence.html
+++ b/confidence.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=9548e3dd">
+<link rel="stylesheet" href="css/shared/cards.css?v=d1db1355">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
@@ -203,7 +203,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=522f6c3d"></script>
+<script src="js/lib/topbar.js?v=3585d26d"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/confidence.html
+++ b/confidence.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
-<link rel="stylesheet" href="css/app/game-header.css?v=eae4ea27">
+<link rel="stylesheet" href="css/app/game-header.css?v=669186d7">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">

--- a/confidence.html
+++ b/confidence.html
@@ -10,7 +10,7 @@
 <meta name="description" content="Per-report and per-game confidence breakdown showing exactly how Proton Pulse computed its trust score.">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
-<link rel="stylesheet" href="css/shared/topbar.css?v=256d07b6">
+<link rel="stylesheet" href="css/shared/topbar.css?v=2d6b5e52">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <link rel="stylesheet" href="css/app/game-header.css?v=669186d7">
@@ -203,7 +203,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=c2fe26da"></script>
+<script src="js/lib/topbar.js?v=449040e3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/confidence.html
+++ b/confidence.html
@@ -11,8 +11,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
-<link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=17c970a6">
+<link rel="stylesheet" href="css/shared/site.css?v=c581801e">
+<link rel="stylesheet" href="css/shared/cards.css?v=0092674d">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/confidence.html
+++ b/confidence.html
@@ -203,7 +203,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=1d29a1b6"></script>
+<script src="js/lib/topbar.js?v=a3dcfcd5"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/confidence.html
+++ b/confidence.html
@@ -17,7 +17,7 @@
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
-<link rel="stylesheet" href="css/app/home.css?v=4ea20844">
+<link rel="stylesheet" href="css/app/home.css?v=d983b41a">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/confidence.html
+++ b/confidence.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=d1db1355">
+<link rel="stylesheet" href="css/shared/cards.css?v=17c970a6">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
@@ -203,7 +203,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=3585d26d"></script>
+<script src="js/lib/topbar.js?v=f444bec4"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/confidence.html
+++ b/confidence.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=7b2b7e95">
+<link rel="stylesheet" href="css/shared/cards.css?v=9548e3dd">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/confidence.html
+++ b/confidence.html
@@ -203,7 +203,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=2f8197e0"></script>
+<script src="js/lib/topbar.js?v=8c2f9356"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/confidence.html
+++ b/confidence.html
@@ -12,12 +12,12 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
+<link rel="stylesheet" href="css/shared/cards.css?v=17142038">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
-<link rel="stylesheet" href="css/app/home.css?v=b62dd0ac">
+<link rel="stylesheet" href="css/app/home.css?v=4ea20844">
 <style>
 h1 {
   font-family: var(--font-display);
@@ -203,7 +203,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=a47091a2"></script>
+<script src="js/lib/topbar.js?v=1d29a1b6"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/confidence.html
+++ b/confidence.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=7906ae81">
+<link rel="stylesheet" href="css/shared/cards.css?v=4b548983">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/confidence.html
+++ b/confidence.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=b48b5b18">
+<link rel="stylesheet" href="css/shared/cards.css?v=cb310e3b">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
@@ -203,7 +203,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=f444bec4"></script>
+<script src="js/lib/topbar.js?v=2f8197e0"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/confidence.html
+++ b/confidence.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=ac2f4490">
+<link rel="stylesheet" href="css/shared/cards.css?v=7906ae81">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/confidence.html
+++ b/confidence.html
@@ -10,7 +10,7 @@
 <meta name="description" content="Per-report and per-game confidence breakdown showing exactly how Proton Pulse computed its trust score.">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
-<link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
+<link rel="stylesheet" href="css/shared/topbar.css?v=256d07b6">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <link rel="stylesheet" href="css/app/game-header.css?v=669186d7">
@@ -203,7 +203,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=a3dcfcd5"></script>
+<script src="js/lib/topbar.js?v=c2fe26da"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/confidence.html
+++ b/confidence.html
@@ -11,8 +11,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
-<link rel="stylesheet" href="css/shared/site.css?v=c581801e">
-<link rel="stylesheet" href="css/shared/cards.css?v=0092674d">
+<link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
+<link rel="stylesheet" href="css/shared/cards.css?v=ac2f4490">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/confidence.html
+++ b/confidence.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=4b548983">
+<link rel="stylesheet" href="css/shared/cards.css?v=5ec3c05a">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/confidence.html
+++ b/confidence.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=cb310e3b">
+<link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/confidence.html
+++ b/confidence.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=b75e75b2">
+<link rel="stylesheet" href="css/shared/cards.css?v=7b2b7e95">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
@@ -203,7 +203,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=7e8205f8"></script>
+<script src="js/lib/topbar.js?v=522f6c3d"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/confidence.html
+++ b/confidence.html
@@ -17,7 +17,7 @@
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
-<link rel="stylesheet" href="css/app/home.css?v=4bf8008f">
+<link rel="stylesheet" href="css/app/home.css?v=b62dd0ac">
 <style>
 h1 {
   font-family: var(--font-display);
@@ -203,7 +203,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=8fe1c285"></script>
+<script src="js/lib/topbar.js?v=a47091a2"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/confidence.html
+++ b/confidence.html
@@ -203,7 +203,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=8c2f9356"></script>
+<script src="js/lib/topbar.js?v=8fe1c285"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/confidence.html
+++ b/confidence.html
@@ -12,8 +12,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=17142038">
-<link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
+<link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
+<link rel="stylesheet" href="css/app/game-header.css?v=eae4ea27">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">

--- a/confidence.html
+++ b/confidence.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=5ec3c05a">
+<link rel="stylesheet" href="css/shared/cards.css?v=b48b5b18">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/css/admin/admin.css
+++ b/css/admin/admin.css
@@ -988,6 +988,7 @@ pre.flag-raw-json {
 .admin-badge--warn  { background: rgba(212,168,67,0.18);  color: #d4a843; }
 .admin-badge--muted { background: rgba(255,255,255,0.07); color: var(--text-muted, #888); }
 .admin-badge--ok    { background: rgba(152,195,121,0.15); color: #98c379; }
+.admin-badge--info  { background: rgba(97,175,239,0.15);  color: #61afef; }
 .admin-badge--regex { background: rgba(97,175,239,0.15);  color: #61afef; }
 
 /* Cache status panel */

--- a/css/app/game-header.css
+++ b/css/app/game-header.css
@@ -581,18 +581,22 @@
 .source-summary-tier-row > * {
   border-radius: 3px;
 }
-.source-summary-tier-row > :first-child { flex: 7; }
+/* Widen the confidence slot just enough that 'Confidence: 95%' stays
+   on one line at the narrowest tile widths. Was 7:3; the conf pill
+   needs the extra share since its label is longer than the tier name. */
+.source-summary-tier-row > :first-child { flex: 9; }
 .source-summary-tier-row > :last-child  { flex: 3; }
 .source-summary-conf {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 5px 11px;
+  padding: 5px 10px;
   min-height: 31px;
   font-family: var(--mono);
   font-weight: 800;
   font-size: 0.74rem;
   letter-spacing: 0.04em;
+  white-space: nowrap;
 }
 .source-summary-meta {
   font-size: 0.82rem;

--- a/css/app/game-header.css
+++ b/css/app/game-header.css
@@ -682,7 +682,10 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  background: var(--green-hi, #beee11);
+  /* Subdued Steam-blue CTA. The previous neon-green pill (--green-hi /
+     #beee11) clashed with the dark blue theme and competed with the
+     hero atom's own brand-green accents. */
+  background: var(--accent, #66c0f4);
   border: 0;
   color: #0b1116;
   font-size: 0.78rem;
@@ -697,13 +700,13 @@
   font-family: inherit;
   text-decoration: none;
   white-space: nowrap;
-  box-shadow: 0 0 0 1px rgba(190, 238, 17, 0.35), 0 4px 18px var(--green-glow, rgba(190, 238, 17, 0.35));
+  box-shadow: 0 0 0 1px var(--accent-soft, rgba(102, 192, 244, 0.16)), 0 4px 18px var(--accent-glow, rgba(102, 192, 244, 0.35));
   transition: background 0.12s ease, transform 0.06s ease, box-shadow 0.12s ease;
 }
 .submit-report-btn:hover {
-  background: #d8ff3b;
+  background: var(--accent-hi, #aedcff);
   text-decoration: none;
-  box-shadow: 0 0 0 1px rgba(216, 255, 59, 0.55), 0 4px 22px var(--green-glow, rgba(190, 238, 17, 0.45));
+  box-shadow: 0 0 0 1px var(--accent-soft, rgba(102, 192, 244, 0.32)), 0 4px 22px var(--accent-glow, rgba(102, 192, 244, 0.45));
 }
 .submit-report-btn:active { transform: translateY(1px); }
 .submit-report-btn:disabled {

--- a/css/app/home.css
+++ b/css/app/home.css
@@ -210,48 +210,46 @@
 .home-tier-chip[data-tier="bronze"].active { color: #cd7f32; border-color: #cd7f32; background: rgba(205,127,50,0.08); }
 .home-tier-chip[data-tier="borked"].active { color: #e05; border-color: #e05; background: rgba(238,0,85,0.08); }
 .home-results-note { font-size: 0.72rem; color: var(--muted); text-align: center; margin: 8px 0 4px; }
-.home-cards-list { gap: 2px !important; }
-.home-list-row {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 8px 12px;
-  background: var(--s1);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  text-decoration: none;
-  color: var(--text);
-  transition: background .1s;
+/* Tile (grid) mode: Steam library look. The container becomes a CSS grid
+   of header-aspect thumbnails; each card re-flows into a vertical tile.
+   S/M/L/XL still applies -- it controls the minimum tile width and via
+   auto-fill, how many columns fit on screen. */
+.home-cards-tile-mode {
+  display: grid !important;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 12px;
+  align-items: stretch;
+}
+.home-cards-tile-mode.cards--sm { grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); }
+.home-cards-tile-mode.cards--md { grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); }
+.home-cards-tile-mode.cards--lg { grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+.home-cards-tile-mode.cards--xl { grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); }
+.home-cards-tile-mode .game-card { display: flex; flex-direction: column; min-width: 0; }
+.home-cards-tile-mode .game-card-row {
+  flex-direction: column;
+  gap: 0;
+  padding: 0;
+  align-items: stretch;
+}
+.home-cards-tile-mode .game-card-thumb-wrap { width: 100%; }
+.home-cards-tile-mode .game-card-thumb {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 460 / 215;
+  border-radius: 0;
+  display: block;
+}
+.home-cards-tile-mode .game-card-body { padding: 8px 10px; min-width: 0; }
+.home-cards-tile-mode .game-card-title {
+  font-size: 0.95rem;
+  line-height: 1.25;
   overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
-.home-list-row:hover { background: var(--s2); }
-.home-list-tier {
-  flex-shrink: 0;
-  font-size: 0.65rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  padding: 3px 8px;
-  border-radius: 3px;
-  min-width: 56px;
-  text-align: center;
-}
-.home-list-title {
-  flex: 1 1 auto;
-  min-width: 0;
-  font-size: 0.9rem;
-  font-weight: 500;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.home-list-meta {
-  flex-shrink: 0;
-  font-size: 0.72rem;
-  color: var(--muted);
-  font-family: var(--mono);
-  white-space: nowrap;
-}
+.home-cards-tile-mode .game-card-sub { font-size: 0.78rem; }
+.home-cards-tile-mode .game-card-right { display: none; }
 
 /* ---- Stub page (game with no reports yet) ---- */
 .stub-page { max-width: 640px; }

--- a/css/app/home.css
+++ b/css/app/home.css
@@ -167,25 +167,27 @@
   /* Keep large from overwhelming small screens. */
   .cards--lg .game-card-thumb { width: 150px; height: 70px; }
 }
-/* Desktop sizes: every step gets roomier than the mobile defaults so the
-   grid actually uses the wider viewport. Thumbnail width drives card
-   height (~2.14:1 Steam header ratio); title/sub scale up to match. */
+/* Desktop sizes: every step gets noticeably roomier than the mobile
+   defaults so the grid actually uses the wider viewport. Thumbnail width
+   drives card height (~2.14:1 Steam header ratio); title/sub scale up to
+   match. Default size on desktop is 'lg'. */
 @media (min-width: 760px) {
-  .cards--sm .game-card-thumb { width: 120px; height: 56px; }
-  .cards--md .game-card-thumb { width: 170px; height: 79px; }
-  .cards--lg .game-card-thumb { width: 240px; height: 112px; }
-  .cards--xl .game-card-thumb { width: 340px; height: 158px; }
-  .cards--sm .game-card-row { gap: 14px; padding: 10px 14px 10px 10px; }
-  .cards--md .game-card-row { gap: 18px; padding: 12px 18px 12px 12px; }
-  .cards--lg .game-card-row { gap: 22px; padding: 16px 22px 16px 14px; }
-  .cards--xl .game-card-row { gap: 28px; padding: 18px 26px 18px 16px; }
-  .cards--sm .game-card-title { font-size: 1rem; }
-  .cards--md .game-card-title { font-size: 1.1rem; }
-  .cards--lg .game-card-title { font-size: 1.22rem; }
-  .cards--xl .game-card-title { font-size: 1.38rem; }
-  .cards--md .game-card-sub { font-size: 0.85rem; }
-  .cards--lg .game-card-sub { font-size: 0.92rem; }
-  .cards--xl .game-card-sub { font-size: 1rem; }
+  .cards--sm .game-card-thumb { width: 140px; height: 65px; }
+  .cards--md .game-card-thumb { width: 200px; height: 93px; }
+  .cards--lg .game-card-thumb { width: 290px; height: 135px; }
+  .cards--xl .game-card-thumb { width: 400px; height: 187px; }
+  .cards--sm .game-card-row { gap: 16px; padding: 12px 16px 12px 10px; }
+  .cards--md .game-card-row { gap: 20px; padding: 14px 20px 14px 12px; }
+  .cards--lg .game-card-row { gap: 26px; padding: 18px 26px 18px 14px; }
+  .cards--xl .game-card-row { gap: 32px; padding: 22px 32px 22px 18px; }
+  .cards--sm .game-card-title { font-size: 1.05rem; }
+  .cards--md .game-card-title { font-size: 1.18rem; }
+  .cards--lg .game-card-title { font-size: 1.35rem; }
+  .cards--xl .game-card-title { font-size: 1.55rem; }
+  .cards--sm .game-card-sub { font-size: 0.82rem; }
+  .cards--md .game-card-sub { font-size: 0.9rem; }
+  .cards--lg .game-card-sub { font-size: 1rem; }
+  .cards--xl .game-card-sub { font-size: 1.1rem; }
 }
 .home-tier-chips { display: flex; gap: 5px; flex-wrap: wrap; margin-bottom: 12px; }
 .home-tier-chip {

--- a/css/app/home.css
+++ b/css/app/home.css
@@ -167,6 +167,26 @@
   /* Keep large from overwhelming small screens. */
   .cards--lg .game-card-thumb { width: 150px; height: 70px; }
 }
+/* Desktop sizes: every step gets roomier than the mobile defaults so the
+   grid actually uses the wider viewport. Thumbnail width drives card
+   height (~2.14:1 Steam header ratio); title/sub scale up to match. */
+@media (min-width: 760px) {
+  .cards--sm .game-card-thumb { width: 120px; height: 56px; }
+  .cards--md .game-card-thumb { width: 170px; height: 79px; }
+  .cards--lg .game-card-thumb { width: 240px; height: 112px; }
+  .cards--xl .game-card-thumb { width: 340px; height: 158px; }
+  .cards--sm .game-card-row { gap: 14px; padding: 10px 14px 10px 10px; }
+  .cards--md .game-card-row { gap: 18px; padding: 12px 18px 12px 12px; }
+  .cards--lg .game-card-row { gap: 22px; padding: 16px 22px 16px 14px; }
+  .cards--xl .game-card-row { gap: 28px; padding: 18px 26px 18px 16px; }
+  .cards--sm .game-card-title { font-size: 1rem; }
+  .cards--md .game-card-title { font-size: 1.1rem; }
+  .cards--lg .game-card-title { font-size: 1.22rem; }
+  .cards--xl .game-card-title { font-size: 1.38rem; }
+  .cards--md .game-card-sub { font-size: 0.85rem; }
+  .cards--lg .game-card-sub { font-size: 0.92rem; }
+  .cards--xl .game-card-sub { font-size: 1rem; }
+}
 .home-tier-chips { display: flex; gap: 5px; flex-wrap: wrap; margin-bottom: 12px; }
 .home-tier-chip {
   padding: 4px 11px;

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -373,6 +373,17 @@
   width: 16px;
   height: 16px;
 }
+/* Text mode: brand-colored pill behind the store label so it reads
+   cleanly on any tier-colored strip. */
+[data-card-layout="strip"][data-store-pill-pos="bar-inline"] .pg-card-strip-store > .store-text {
+  padding: 2px 8px;
+  border-radius: 999px;
+  color: #fff;
+  line-height: 1.4;
+}
+[data-card-layout="strip"][data-store-pill-pos="bar-inline"] .pg-card-strip[data-store="steam"] .pg-card-strip-store > .store-text { background: #1689d0; }
+[data-card-layout="strip"][data-store-pill-pos="bar-inline"] .pg-card-strip[data-store="gog"]   .pg-card-strip-store > .store-text { background: #7a3fcf; }
+[data-card-layout="strip"][data-store-pill-pos="bar-inline"] .pg-card-strip[data-store="epic"]  .pg-card-strip-store > .store-text { background: #2a2a2a; }
 
 /* Strip store segment for pg-cards. Hidden unless bar-segment is set. The
    strip-store span carries .store-icon so the SVG must be hidden in text

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -344,18 +344,19 @@
   padding: 2px 8px;
 }
 /* Hide the inline pill in the strip whenever the store badge lives
-   elsewhere (artwork overlay, card corner, round bar icon, or trailing
-   split segment). */
+   elsewhere (artwork overlay, card corner, inline next to tier, or
+   trailing split segment). */
 [data-card-layout="strip"][data-store-pill-pos="art"] .pg-card-strip .game-card-store-pill,
 [data-card-layout="strip"][data-store-pill-pos="art-corner"] .pg-card-strip .game-card-store-pill,
-[data-card-layout="strip"][data-store-pill-pos="bar-icon"] .pg-card-strip .game-card-store-pill,
+[data-card-layout="strip"][data-store-pill-pos="bar-inline"] .pg-card-strip .game-card-store-pill,
 [data-card-layout="strip"][data-store-pill-pos="bar-segment"] .pg-card-strip .game-card-store-pill { display: none; }
-/* bar-icon: round store glyph flush right of the tier label. No shadow,
-   no background -- the tier-color gradient is the backdrop. */
-[data-card-layout="strip"][data-store-pill-pos="bar-icon"] .pg-card-strip {
+/* bar-inline: store badge flush right of tier label. Honors the global
+   store-display pref so the text label shows in text mode and the round
+   glyph shows in icon mode. */
+[data-card-layout="strip"][data-store-pill-pos="bar-inline"] .pg-card-strip {
   gap: 6px;
 }
-[data-card-layout="strip"][data-store-pill-pos="bar-icon"] .pg-card-strip-store {
+[data-card-layout="strip"][data-store-pill-pos="bar-inline"] .pg-card-strip-store {
   display: inline-flex;
   align-items: center;
   background: none;
@@ -363,13 +364,15 @@
   padding: 0;
   margin: 0;
   border-radius: 0;
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
-[data-card-layout="strip"][data-store-pill-pos="bar-icon"] .pg-card-strip-store > svg {
-  display: block;
+[data-card-layout="strip"][data-store-pill-pos="bar-inline"] .pg-card-strip-store > svg {
   width: 16px;
   height: 16px;
 }
-[data-card-layout="strip"][data-store-pill-pos="bar-icon"] .pg-card-strip-store > .store-text { display: none; }
 
 /* Strip store segment for pg-cards. Hidden unless bar-segment is set. The
    strip-store span carries .store-icon so the SVG must be hidden in text

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -297,6 +297,7 @@
   box-sizing: border-box;
   border-bottom-left-radius: 10px;
   border-bottom-right-radius: 10px;
+  position: relative;
 }
 [data-card-layout="strip"] .pg-card-strip .game-card-store-pill {
   position: absolute;
@@ -327,16 +328,15 @@
 [data-card-layout="strip"][data-store-pill-pos="bar-right"] .pg-card-strip .game-card-store-pill,
 [data-card-layout="strip"][data-store-pill-pos="bar-segment"] .pg-card-strip .game-card-store-pill { display: none; }
 
-/* Strip store segment for pg-cards. Hidden unless a bar-* placement is set. */
+/* Strip store segment for pg-cards. Hidden unless a bar-* placement is set.
+   The strip is already display:flex so margin-left:auto pushes the chip to
+   the trailing edge instead of needing absolute positioning. */
 .pg-card-strip-store { display: none; }
 [data-card-layout="strip"][data-store-pill-pos="bar-right"] .pg-card-strip-store {
-  position: absolute;
-  right: 10px;
-  top: 50%;
-  transform: translateY(-50%);
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  margin-left: auto;
   font-size: 0.62rem;
   background: rgba(0, 0, 0, 0.22);
   padding: 2px 8px;

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -343,8 +343,10 @@
   font-size: 0.62rem;
   padding: 2px 8px;
 }
-/* Hide the inline pill on the bar when the split placement is on -- the
-   strip-store segment takes over the trailing quarter. */
+/* Hide the inline pill in the strip whenever the store badge lives
+   elsewhere (artwork overlay, card corner, or trailing split segment). */
+[data-card-layout="strip"][data-store-pill-pos="art"] .pg-card-strip .game-card-store-pill,
+[data-card-layout="strip"][data-store-pill-pos="art-corner"] .pg-card-strip .game-card-store-pill,
 [data-card-layout="strip"][data-store-pill-pos="bar-segment"] .pg-card-strip .game-card-store-pill { display: none; }
 
 /* Strip store segment for pg-cards. Hidden unless bar-segment is set. The

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -330,8 +330,13 @@
 
 /* Strip store segment for pg-cards. Hidden unless a bar-* placement is set.
    The strip is already display:flex so margin-left:auto pushes the chip to
-   the trailing edge instead of needing absolute positioning. */
+   the trailing edge instead of needing absolute positioning. The span also
+   carries .store-icon so we have to hide its SVG child explicitly in text
+   mode -- otherwise the round monogram circle paints behind the label. */
 .pg-card-strip-store { display: none; }
+.pg-card-strip-store > svg { display: none; }
+[data-store-display="icon"] .pg-card-strip-store > svg { display: block; }
+[data-store-display="icon"] .pg-card-strip-store > .store-text { display: none; }
 [data-card-layout="strip"][data-store-pill-pos="bar-right"] .pg-card-strip-store {
   display: inline-flex;
   align-items: center;

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -274,6 +274,26 @@
   overflow: hidden;
   text-decoration: none;
   transition: box-shadow 0.15s, background 0.15s, transform 0.05s;
+  /* position:relative anchors the card-corner tag's absolute box so the
+     'art-corner' placement can hug the top-right edge of the card. */
+  position: relative;
+}
+.pg-card-corner-tag { display: none; }
+[data-store-pill-pos="art-corner"] .pg-card-corner-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 4px 10px;
+  font-size: 0.62rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  border-radius: 0 10px 0 10px;
+  box-shadow: -1px 2px 5px rgba(0, 0, 0, 0.55);
+  z-index: 2;
 }
 .pg-card-row {
   display: flex;

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -344,10 +344,19 @@
   padding: 2px 8px;
 }
 /* Hide the inline pill in the strip whenever the store badge lives
-   elsewhere (artwork overlay, card corner, or trailing split segment). */
+   elsewhere (artwork overlay, card corner, round bar icon, or trailing
+   split segment). */
 [data-card-layout="strip"][data-store-pill-pos="art"] .pg-card-strip .game-card-store-pill,
 [data-card-layout="strip"][data-store-pill-pos="art-corner"] .pg-card-strip .game-card-store-pill,
+[data-card-layout="strip"][data-store-pill-pos="bar-icon"] .pg-card-strip .game-card-store-pill,
 [data-card-layout="strip"][data-store-pill-pos="bar-segment"] .pg-card-strip .game-card-store-pill { display: none; }
+/* bar-icon: round store glyph on the strip next to the tier label. */
+[data-card-layout="strip"][data-store-pill-pos="bar-icon"] .pg-card-strip-store {
+  display: inline-flex;
+  align-items: center;
+}
+[data-card-layout="strip"][data-store-pill-pos="bar-icon"] .pg-card-strip-store > svg { display: block; }
+[data-card-layout="strip"][data-store-pill-pos="bar-icon"] .pg-card-strip-store > .store-text { display: none; }
 
 /* Strip store segment for pg-cards. Hidden unless bar-segment is set. The
    strip-store span carries .store-icon so the SVG must be hidden in text

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -278,6 +278,44 @@
      'art-corner' placement can hug the top-right edge of the card. */
   position: relative;
 }
+/* Combined corner chip (rating + store) for pg-cards. Mirrors the
+   .game-card-combo-tag rules in css/shared/cards.css. Hidden unless
+   data-card-layout="combo" is set on <html>. */
+.pg-card-combo-tag { display: none; }
+[data-card-layout="combo"] .pg-card-combo-tag {
+  display: inline-flex;
+  align-items: stretch;
+  position: absolute;
+  top: 0;
+  right: 0;
+  font-size: 0.6rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  line-height: 1.2;
+  border-radius: 0 10px 0 10px;
+  overflow: hidden;
+  box-shadow: -1px 2px 5px rgba(0, 0, 0, 0.55);
+  z-index: 2;
+}
+[data-card-layout="combo"] .pg-card-combo-tag .combo-tier,
+[data-card-layout="combo"] .pg-card-combo-tag .combo-store {
+  padding: 4px 9px;
+  display: inline-flex;
+  align-items: center;
+}
+[data-card-layout="combo"] .pg-card-combo-tag .combo-tier { background: #3a4252; color: #d6dee8; }
+[data-card-layout="combo"] .pg-card-combo-tag[data-tier="platinum"] .combo-tier { background: #b4c7dc; color: #0a0c10; }
+[data-card-layout="combo"] .pg-card-combo-tag[data-tier="gold"]     .combo-tier { background: #c8a050; color: #111; }
+[data-card-layout="combo"] .pg-card-combo-tag[data-tier="silver"]   .combo-tier { background: #8fa0b0; color: #111; }
+[data-card-layout="combo"] .pg-card-combo-tag[data-tier="bronze"]   .combo-tier { background: #b07040; color: #fff; }
+[data-card-layout="combo"] .pg-card-combo-tag[data-tier="borked"]   .combo-tier { background: #c85050; color: #fff; }
+[data-card-layout="combo"] .pg-card-combo-tag .combo-store { background: #1689d0; color: #fff; }
+[data-card-layout="combo"] .pg-card-combo-tag[data-store="gog"]  .combo-store { background: #7a3fcf; }
+[data-card-layout="combo"] .pg-card-combo-tag[data-store="epic"] .combo-store { background: #2a2a2a; }
+[data-card-layout="combo"] .pg-right { display: none; }
+[data-card-layout="combo"] .pg-card-strip { display: none; }
+
 .pg-card-corner-tag { display: none; }
 [data-store-pill-pos="art-corner"] .pg-card-corner-tag {
   display: inline-flex;
@@ -575,23 +613,25 @@
   .pg-list--lg .pg-thumb { width: 100px; height: 47px; }
 }
 /* Desktop bump for each size step. Mirrors the matching .cards--XX rules
-   in css/app/home.css so home and app browser scale the same way. */
+   in css/app/home.css so home and app browser scale the same way.
+   Default size on desktop is 'lg'. */
 @media (min-width: 760px) {
-  .pg-list--sm .pg-thumb { width: 92px; height: 43px; }
-  .pg-list--md .pg-thumb { width: 120px; height: 56px; }
-  .pg-list--lg .pg-thumb { width: 170px; height: 79px; }
-  .pg-list--xl .pg-thumb { width: 240px; height: 112px; }
-  .pg-list--sm .pg-card-row { gap: 12px; padding: 8px 12px 8px 8px; }
-  .pg-list--md .pg-card-row { gap: 16px; padding: 10px 14px 10px 10px; }
-  .pg-list--lg .pg-card-row { gap: 22px; padding: 14px 20px 14px 12px; }
-  .pg-list--xl .pg-card-row { gap: 26px; padding: 18px 24px 18px 14px; }
-  .pg-list--sm .pg-title { font-size: 0.95rem; }
-  .pg-list--md .pg-title { font-size: 1.05rem; }
-  .pg-list--lg .pg-title { font-size: 1.18rem; }
-  .pg-list--xl .pg-title { font-size: 1.32rem; }
-  .pg-list--md .pg-sub { font-size: 0.82rem; }
-  .pg-list--lg .pg-sub { font-size: 0.9rem; }
-  .pg-list--xl .pg-sub { font-size: 0.98rem; }
+  .pg-list--sm .pg-thumb { width: 110px; height: 51px; }
+  .pg-list--md .pg-thumb { width: 150px; height: 70px; }
+  .pg-list--lg .pg-thumb { width: 220px; height: 103px; }
+  .pg-list--xl .pg-thumb { width: 320px; height: 149px; }
+  .pg-list--sm .pg-card-row { gap: 14px; padding: 10px 14px 10px 10px; }
+  .pg-list--md .pg-card-row { gap: 18px; padding: 12px 18px 12px 12px; }
+  .pg-list--lg .pg-card-row { gap: 24px; padding: 16px 24px 16px 14px; }
+  .pg-list--xl .pg-card-row { gap: 30px; padding: 20px 30px 20px 16px; }
+  .pg-list--sm .pg-title { font-size: 1rem; }
+  .pg-list--md .pg-title { font-size: 1.12rem; }
+  .pg-list--lg .pg-title { font-size: 1.3rem; }
+  .pg-list--xl .pg-title { font-size: 1.5rem; }
+  .pg-list--sm .pg-sub { font-size: 0.8rem; }
+  .pg-list--md .pg-sub { font-size: 0.88rem; }
+  .pg-list--lg .pg-sub { font-size: 0.98rem; }
+  .pg-list--xl .pg-sub { font-size: 1.08rem; }
 }
 
 /* List mode */

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -323,35 +323,17 @@
   font-size: 0.62rem;
   padding: 2px 8px;
 }
-/* Hide the inline pill on the bar when one of the bar-* placements is on --
-   either the chip on the trailing edge or the two-tone segment takes over. */
-[data-card-layout="strip"][data-store-pill-pos="bar-right"] .pg-card-strip .game-card-store-pill,
+/* Hide the inline pill on the bar when the split placement is on -- the
+   strip-store segment takes over the trailing quarter. */
 [data-card-layout="strip"][data-store-pill-pos="bar-segment"] .pg-card-strip .game-card-store-pill { display: none; }
 
-/* Strip store segment for pg-cards. Hidden unless a bar-* placement is set.
-   The strip is already display:flex so margin-left:auto pushes the chip to
-   the trailing edge instead of needing absolute positioning. The span also
-   carries .store-icon so we have to hide its SVG child explicitly in text
-   mode -- otherwise the round monogram circle paints behind the label. */
+/* Strip store segment for pg-cards. Hidden unless bar-segment is set. The
+   strip-store span carries .store-icon so the SVG must be hidden in text
+   mode or the round monogram circle paints behind the label. */
 .pg-card-strip-store { display: none; }
 .pg-card-strip-store > svg { display: none; }
 [data-store-display="icon"] .pg-card-strip-store > svg { display: block; }
 [data-store-display="icon"] .pg-card-strip-store > .store-text { display: none; }
-[data-card-layout="strip"][data-store-pill-pos="bar-right"] .pg-card-strip-store {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  margin-left: auto;
-  font-size: 0.62rem;
-  background: rgba(0, 0, 0, 0.22);
-  padding: 2px 8px;
-  border-radius: 999px;
-}
-[data-card-layout="strip"][data-store-pill-pos="bar-right"] .pg-card-strip-store .store-text {
-  font-weight: 800;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
 /* Two-tone segment: tier color in the leading 3/4, store color in the last
    1/4. The strip becomes a grid so the segment owns its own column. */
 [data-card-layout="strip"][data-store-pill-pos="bar-segment"] .pg-card-strip {

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -634,49 +634,54 @@
   .pg-list--xl .pg-sub { font-size: 1.08rem; }
 }
 
-/* List mode */
-.pg-list--list-mode { gap: 2px !important; }
-.pg-list--list-mode .pg-card { display: none; }
-.pg-list-row {
+/* Tile (grid) mode: Steam library look. The container becomes a CSS grid
+   of header-aspect thumbnails; each card re-flows into a vertical tile
+   with the thumbnail on top and the title row below. S/M/L/XL size still
+   applies -- it controls the minimum tile width (and via auto-fill, how
+   many columns fit). */
+.pg-list--tile-mode {
+  display: grid !important;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 12px;
+  align-items: stretch;
+}
+.pg-list--tile-mode.pg-list--sm { grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); }
+.pg-list--tile-mode.pg-list--md { grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); }
+.pg-list--tile-mode.pg-list--lg { grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+.pg-list--tile-mode.pg-list--xl { grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); }
+.pg-list--tile-mode .pg-card {
   display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 8px 12px;
-  background: var(--s1);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  text-decoration: none;
-  color: var(--text);
-  transition: background .1s;
-  overflow: hidden;
-}
-.pg-list-row:hover { background: var(--s2); }
-.pg-list-tier {
-  flex-shrink: 0;
-  font-size: 0.65rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  padding: 3px 8px;
-  border-radius: 3px;
-  min-width: 56px;
-  text-align: center;
-}
-.pg-list-title {
-  flex: 1 1 auto;
+  flex-direction: column;
   min-width: 0;
-  font-size: 0.9rem;
-  font-weight: 500;
-  white-space: nowrap;
+}
+.pg-list--tile-mode .pg-card-row {
+  flex-direction: column;
+  gap: 0;
+  padding: 0;
+  align-items: stretch;
+}
+.pg-list--tile-mode .pg-thumb-wrap { width: 100%; }
+.pg-list--tile-mode .pg-thumb {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 460 / 215;
+  border-radius: 0;
+  display: block;
+}
+.pg-list--tile-mode .pg-info { padding: 8px 10px; min-width: 0; }
+.pg-list--tile-mode .pg-title {
+  font-size: 0.95rem;
+  line-height: 1.25;
   overflow: hidden;
-  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
-.pg-list-meta {
-  flex-shrink: 0;
-  font-size: 0.72rem;
-  color: var(--muted);
-  font-family: var(--mono);
-}
+.pg-list--tile-mode .pg-sub { font-size: 0.78rem; }
+/* Right-column rating pill doesn't fit in a vertical tile -- the strip
+   (which the user's card layout already enables by default) carries the
+   tier across the tile bottom instead. */
+.pg-list--tile-mode .pg-right { display: none; }
 
 .pg-empty {
   padding: 24px 14px;

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -322,6 +322,63 @@
   font-size: 0.62rem;
   padding: 2px 8px;
 }
+/* Hide the inline pill on the bar when one of the bar-* placements is on --
+   either the chip on the trailing edge or the two-tone segment takes over. */
+[data-card-layout="strip"][data-store-pill-pos="bar-right"] .pg-card-strip .game-card-store-pill,
+[data-card-layout="strip"][data-store-pill-pos="bar-segment"] .pg-card-strip .game-card-store-pill { display: none; }
+
+/* Strip store segment for pg-cards. Hidden unless a bar-* placement is set. */
+.pg-card-strip-store { display: none; }
+[data-card-layout="strip"][data-store-pill-pos="bar-right"] .pg-card-strip-store {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.62rem;
+  background: rgba(0, 0, 0, 0.22);
+  padding: 2px 8px;
+  border-radius: 999px;
+}
+[data-card-layout="strip"][data-store-pill-pos="bar-right"] .pg-card-strip-store .store-text {
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+/* Two-tone segment: tier color in the leading 3/4, store color in the last
+   1/4. The strip becomes a grid so the segment owns its own column. */
+[data-card-layout="strip"][data-store-pill-pos="bar-segment"] .pg-card-strip {
+  display: grid;
+  grid-template-columns: 3fr 1fr;
+  padding: 0;
+  gap: 0;
+  align-items: stretch;
+}
+[data-card-layout="strip"][data-store-pill-pos="bar-segment"] .pg-card-strip-tier {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+[data-card-layout="strip"][data-store-pill-pos="bar-segment"] .pg-card-strip-store {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  color: #fff;
+  font-size: 0.62rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  border-bottom-right-radius: 10px;
+}
+[data-card-layout="strip"][data-store-pill-pos="bar-segment"] .pg-card-strip[data-store="steam"] .pg-card-strip-store { background: #1689d0; }
+[data-card-layout="strip"][data-store-pill-pos="bar-segment"] .pg-card-strip[data-store="gog"]   .pg-card-strip-store { background: #7a3fcf; }
+[data-card-layout="strip"][data-store-pill-pos="bar-segment"] .pg-card-strip[data-store="epic"]  .pg-card-strip-store { background: #2a2a2a; }
+/* When the user has store-display=icon AND bar-segment is on, hide the text
+   so the segment shows just the round icon. */
+[data-store-display="icon"][data-card-layout="strip"][data-store-pill-pos="bar-segment"] .pg-card-strip-store .store-text { display: none; }
 [data-card-layout="strip"] .pg-right { display: none; }
 /* Suppress link underline on the card AND every text-bearing descendant
    in every state. Browsers apply :focus underlines to the inner spans

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -574,6 +574,25 @@
 @media (max-width: 600px) {
   .pg-list--lg .pg-thumb { width: 100px; height: 47px; }
 }
+/* Desktop bump for each size step. Mirrors the matching .cards--XX rules
+   in css/app/home.css so home and app browser scale the same way. */
+@media (min-width: 760px) {
+  .pg-list--sm .pg-thumb { width: 92px; height: 43px; }
+  .pg-list--md .pg-thumb { width: 120px; height: 56px; }
+  .pg-list--lg .pg-thumb { width: 170px; height: 79px; }
+  .pg-list--xl .pg-thumb { width: 240px; height: 112px; }
+  .pg-list--sm .pg-card-row { gap: 12px; padding: 8px 12px 8px 8px; }
+  .pg-list--md .pg-card-row { gap: 16px; padding: 10px 14px 10px 10px; }
+  .pg-list--lg .pg-card-row { gap: 22px; padding: 14px 20px 14px 12px; }
+  .pg-list--xl .pg-card-row { gap: 26px; padding: 18px 24px 18px 14px; }
+  .pg-list--sm .pg-title { font-size: 0.95rem; }
+  .pg-list--md .pg-title { font-size: 1.05rem; }
+  .pg-list--lg .pg-title { font-size: 1.18rem; }
+  .pg-list--xl .pg-title { font-size: 1.32rem; }
+  .pg-list--md .pg-sub { font-size: 0.82rem; }
+  .pg-list--lg .pg-sub { font-size: 0.9rem; }
+  .pg-list--xl .pg-sub { font-size: 0.98rem; }
+}
 
 /* List mode */
 .pg-list--list-mode { gap: 2px !important; }

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -315,6 +315,12 @@
 [data-card-layout="combo"] .pg-card-combo-tag[data-store="epic"] .combo-store { background: #2a2a2a; }
 [data-card-layout="combo"] .pg-right { display: none; }
 [data-card-layout="combo"] .pg-card-strip { display: none; }
+/* Combo owns the rating + store presentation; suppress the artwork overlay
+   tag, dedicated card-corner tag, and any inline store pill so they don't
+   peek out from behind the chip. */
+[data-card-layout="combo"] .game-card-store-tag,
+[data-card-layout="combo"] .pg-card-corner-tag,
+[data-card-layout="combo"] .game-card-store-pill { display: none; }
 
 .pg-card-corner-tag { display: none; }
 [data-store-pill-pos="art-corner"] .pg-card-corner-tag {
@@ -504,7 +510,16 @@
   color: #c8a050;
   margin-top: 2px;
   font-family: var(--mono);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
+/* Drop the " peak players" suffix when the card is too narrow for it
+   (small list rows, all tile-mode tiles). Mobile drops the suffix at sm
+   only; tile mode always drops it because the column width can be as
+   tight as 140px. */
+.pg-list--sm .pg-sub-suffix,
+.pg-list--tile-mode .pg-sub-suffix { display: none; }
 .pg-right {
   display: flex;
   flex-direction: row;

--- a/css/index/index.css
+++ b/css/index/index.css
@@ -350,12 +350,25 @@
 [data-card-layout="strip"][data-store-pill-pos="art-corner"] .pg-card-strip .game-card-store-pill,
 [data-card-layout="strip"][data-store-pill-pos="bar-icon"] .pg-card-strip .game-card-store-pill,
 [data-card-layout="strip"][data-store-pill-pos="bar-segment"] .pg-card-strip .game-card-store-pill { display: none; }
-/* bar-icon: round store glyph on the strip next to the tier label. */
+/* bar-icon: round store glyph flush right of the tier label. No shadow,
+   no background -- the tier-color gradient is the backdrop. */
+[data-card-layout="strip"][data-store-pill-pos="bar-icon"] .pg-card-strip {
+  gap: 6px;
+}
 [data-card-layout="strip"][data-store-pill-pos="bar-icon"] .pg-card-strip-store {
   display: inline-flex;
   align-items: center;
+  background: none;
+  box-shadow: none;
+  padding: 0;
+  margin: 0;
+  border-radius: 0;
 }
-[data-card-layout="strip"][data-store-pill-pos="bar-icon"] .pg-card-strip-store > svg { display: block; }
+[data-card-layout="strip"][data-store-pill-pos="bar-icon"] .pg-card-strip-store > svg {
+  display: block;
+  width: 16px;
+  height: 16px;
+}
 [data-card-layout="strip"][data-store-pill-pos="bar-icon"] .pg-card-strip-store > .store-text { display: none; }
 
 /* Strip store segment for pg-cards. Hidden unless bar-segment is set. The

--- a/css/options/options.css
+++ b/css/options/options.css
@@ -81,3 +81,29 @@
 .option-radio:has(input:checked) { border-color: var(--accent); color: var(--accent); }
 .option-radio input { display: none; }
 .option-radio--disabled { opacity: 0.4; cursor: not-allowed; pointer-events: none; }
+.option-default-tag {
+  font-size: 0.78em;
+  font-weight: 500;
+  color: var(--muted);
+  margin-left: 2px;
+}
+.option-radio:has(input:checked) .option-default-tag { color: var(--accent); opacity: 0.7; }
+.option-default-note { font-size: 0.78rem; color: var(--muted); margin-top: 4px; flex-basis: 100%; }
+
+.options-reset { margin-top: 24px; display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+.options-reset-btn {
+  font: inherit;
+  background: transparent;
+  color: var(--text);
+  border: 1.5px solid var(--border);
+  border-radius: 999px;
+  padding: 8px 18px;
+  cursor: pointer;
+  transition: border-color 0.12s, color 0.12s;
+}
+.options-reset-btn:hover, .options-reset-btn:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
+  outline: none;
+}
+.options-reset-note { font-size: 0.82rem; color: var(--muted); }

--- a/css/options/options.css
+++ b/css/options/options.css
@@ -88,6 +88,11 @@
   margin-left: 2px;
 }
 .option-radio:has(input:checked) .option-default-tag { color: var(--accent); opacity: 0.7; }
+/* The viewport-specific default tags exist on both options at once in the
+   markup; CSS hides whichever one doesn't apply at the current width.
+   Mirrors the 760px breakpoint that topbar.js uses to pick the default. */
+@media (max-width: 759px) { .option-default-tag--desktop { display: none; } }
+@media (min-width: 760px) { .option-default-tag--mobile  { display: none; } }
 .option-default-note { font-size: 0.78rem; color: var(--muted); margin-top: 4px; flex-basis: 100%; }
 
 .options-reset { margin-top: 24px; display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }

--- a/css/options/options.css
+++ b/css/options/options.css
@@ -80,3 +80,4 @@
 }
 .option-radio:has(input:checked) { border-color: var(--accent); color: var(--accent); }
 .option-radio input { display: none; }
+.option-radio--disabled { opacity: 0.4; cursor: not-allowed; pointer-events: none; }

--- a/css/shared/cards.css
+++ b/css/shared/cards.css
@@ -341,6 +341,17 @@
   width: 16px;
   height: 16px;
 }
+/* Text mode: the store label gets a brand-colored pill so it stays
+   readable against any tier strip color. */
+[data-card-layout="strip"][data-store-pill-pos="bar-inline"] .game-card-strip-store > .store-text {
+  padding: 2px 8px;
+  border-radius: 999px;
+  color: #fff;
+  line-height: 1.4;
+}
+[data-card-layout="strip"][data-store-pill-pos="bar-inline"] .game-card-strip[data-store="steam"] .game-card-strip-store > .store-text { background: #1689d0; }
+[data-card-layout="strip"][data-store-pill-pos="bar-inline"] .game-card-strip[data-store="gog"]   .game-card-strip-store > .store-text { background: #7a3fcf; }
+[data-card-layout="strip"][data-store-pill-pos="bar-inline"] .game-card-strip[data-store="epic"]  .game-card-strip-store > .store-text { background: #2a2a2a; }
 .load-more-btn {
   display: block;
   margin: 12px auto 0;

--- a/css/shared/cards.css
+++ b/css/shared/cards.css
@@ -185,6 +185,13 @@
 .store-icon svg { width: 18px; height: 18px; display: block; }
 [data-store-display="icon"] .store-text { display: none; }
 [data-store-display="icon"] .store-icon { display: inline-flex; align-items: center; }
+/* The strip-store span also carries .store-icon so it can become a round
+   monogram in icon mode -- but only inside the bar-segment placement. For
+   every other placement the strip-store has no business showing up, so
+   the icon-mode reveal above must not turn it on. The bar-segment rule
+   lower in the file overrides this when needed. */
+[data-store-display="icon"] .game-card-strip-store,
+[data-store-display="icon"] .pg-card-strip-store { display: none; }
 /* Store pill chrome collapses to just the icon when display=icon so we do
    not paint a colored background around the icon's own circle. */
 [data-store-display="icon"] .game-card-store-pill,

--- a/css/shared/cards.css
+++ b/css/shared/cards.css
@@ -172,8 +172,14 @@
 }
 
 /* Bottom-bar strip store segment. Hidden by default; revealed by the
-   bar-right or bar-segment placement preferences. */
+   bar-right or bar-segment placement preferences. The strip-store span
+   carries the .store-icon class so it can render the round monogram when
+   the user picks the icon display mode -- but in text mode we need to hide
+   the SVG so the colored circle doesn't paint behind the store label. */
 .game-card-strip-store { display: none; }
+.game-card-strip-store > svg { display: none; }
+[data-store-display="icon"] .game-card-strip-store > svg { display: block; }
+[data-store-display="icon"] .game-card-strip-store > .store-text { display: none; }
 [data-card-layout="strip"][data-store-pill-pos="bar-right"] .game-card-strip-store {
   display: inline-flex;
   align-items: center;

--- a/css/shared/cards.css
+++ b/css/shared/cards.css
@@ -14,6 +14,29 @@
   color: inherit;
   cursor: pointer;
   transition: box-shadow 0.15s, background 0.15s, transform 0.05s;
+  /* position:relative anchors the .game-card-corner-tag's absolute box to
+     the card itself (not the row or thumbnail), so it can sit at the top
+     right edge of the entire card under the 'art-corner' placement. */
+  position: relative;
+}
+.game-card-corner-tag { display: none; }
+[data-store-pill-pos="art-corner"] .game-card-corner-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 4px 10px;
+  font-size: 0.62rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  /* Top-right matches the card's 10px corner radius so it tucks cleanly
+     into the rounded edge. Bottom-left rounds into the card body. */
+  border-radius: 0 10px 0 10px;
+  box-shadow: -1px 2px 5px rgba(0, 0, 0, 0.55);
+  z-index: 2;
 }
 .game-card-row {
   display: flex;

--- a/css/shared/cards.css
+++ b/css/shared/cards.css
@@ -172,29 +172,14 @@
 }
 
 /* Bottom-bar strip store segment. Hidden by default; revealed by the
-   bar-right or bar-segment placement preferences. The strip-store span
-   carries the .store-icon class so it can render the round monogram when
-   the user picks the icon display mode -- but in text mode we need to hide
-   the SVG so the colored circle doesn't paint behind the store label. */
+   bar-segment placement (split bar). The strip-store span carries the
+   .store-icon class so it can render the round monogram in icon mode --
+   the SVG is hidden in text mode so the colored circle doesn't paint
+   behind the store label. */
 .game-card-strip-store { display: none; }
 .game-card-strip-store > svg { display: none; }
 [data-store-display="icon"] .game-card-strip-store > svg { display: block; }
 [data-store-display="icon"] .game-card-strip-store > .store-text { display: none; }
-[data-card-layout="strip"][data-store-pill-pos="bar-right"] .game-card-strip-store {
-  display: inline-flex;
-  align-items: center;
-  margin-left: auto;
-  margin-right: 12px;
-  font-size: 0.6rem;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
-[data-card-layout="strip"][data-store-pill-pos="bar-right"] .game-card-strip-store .store-text {
-  background: rgba(0, 0, 0, 0.22);
-  padding: 2px 8px;
-  border-radius: 999px;
-}
 [data-card-layout="strip"][data-store-pill-pos="bar-segment"] .game-card-strip {
   /* Two-tone strip: tier color fills the leading 75%, store color fills
      the trailing 25%. The store segment's background overrides the strip's
@@ -286,9 +271,9 @@
   padding: 2px 8px;
 }
 [data-card-layout="strip"] .game-card-right { display: none; }
-/* When a bar-* placement is active the strip-store segment is shown -- hide
-   the inline pill inside the strip so we don't render the store twice. */
-[data-card-layout="strip"][data-store-pill-pos="bar-right"] .game-card-strip .game-card-store-pill,
+/* When bar-segment is active the strip-store segment owns the trailing
+   quarter -- hide the inline pill inside the strip so we don't render the
+   store twice. */
 [data-card-layout="strip"][data-store-pill-pos="bar-segment"] .game-card-strip .game-card-store-pill { display: none; }
 .load-more-btn {
   display: block;

--- a/css/shared/cards.css
+++ b/css/shared/cards.css
@@ -19,6 +19,50 @@
      right edge of the entire card under the 'art-corner' placement. */
   position: relative;
 }
+/* Combined corner chip (rating + store) for the 'combo' card layout.
+   Two segments side by side: tier color on the left with the tier label,
+   store color on the right with the store name. Hidden unless
+   data-card-layout="combo" is set on <html>. Rounded only on the inner
+   corner so it tucks into the card's top-right outline. */
+.game-card-combo-tag { display: none; }
+[data-card-layout="combo"] .game-card-combo-tag {
+  display: inline-flex;
+  align-items: stretch;
+  position: absolute;
+  top: 0;
+  right: 0;
+  font-size: 0.6rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  line-height: 1.2;
+  border-radius: 0 10px 0 10px;
+  overflow: hidden;
+  box-shadow: -1px 2px 5px rgba(0, 0, 0, 0.55);
+  z-index: 2;
+}
+[data-card-layout="combo"] .game-card-combo-tag .combo-tier,
+[data-card-layout="combo"] .game-card-combo-tag .combo-store {
+  padding: 4px 9px;
+  display: inline-flex;
+  align-items: center;
+}
+/* Tier color block (default subdued grey for unrated / no-tier rows). */
+[data-card-layout="combo"] .game-card-combo-tag .combo-tier { background: #3a4252; color: #d6dee8; }
+[data-card-layout="combo"] .game-card-combo-tag[data-tier="platinum"] .combo-tier { background: #b4c7dc; color: #0a0c10; }
+[data-card-layout="combo"] .game-card-combo-tag[data-tier="gold"]     .combo-tier { background: #c8a050; color: #111; }
+[data-card-layout="combo"] .game-card-combo-tag[data-tier="silver"]   .combo-tier { background: #8fa0b0; color: #111; }
+[data-card-layout="combo"] .game-card-combo-tag[data-tier="bronze"]   .combo-tier { background: #b07040; color: #fff; }
+[data-card-layout="combo"] .game-card-combo-tag[data-tier="borked"]   .combo-tier { background: #c85050; color: #fff; }
+/* Store color block. */
+[data-card-layout="combo"] .game-card-combo-tag .combo-store { background: #1689d0; color: #fff; }
+[data-card-layout="combo"] .game-card-combo-tag[data-store="gog"]  .combo-store { background: #7a3fcf; }
+[data-card-layout="combo"] .game-card-combo-tag[data-store="epic"] .combo-store { background: #2a2a2a; }
+/* Combo owns the rating + store -- hide the column rating and the
+   bottom strip so they don't compete with the corner chip. */
+[data-card-layout="combo"] .game-card-right { display: none; }
+[data-card-layout="combo"] .game-card-strip { display: none; }
+
 .game-card-corner-tag { display: none; }
 [data-store-pill-pos="art-corner"] .game-card-corner-tag {
   display: inline-flex;

--- a/css/shared/cards.css
+++ b/css/shared/cards.css
@@ -183,14 +183,19 @@
 [data-card-layout="strip"][data-store-pill-pos="bar-segment"] .game-card-strip {
   /* Two-tone strip: tier color fills the leading 75%, store color fills
      the trailing 25%. The store segment's background overrides the strip's
-     own tier background via specificity. */
+     own tier background via specificity. gap:0 + align-items:stretch make
+     the cells butt up against each other and fill the strip vertically so
+     there's no visible tier color between them. */
   display: grid;
   grid-template-columns: 3fr 1fr;
   padding: 0;
+  gap: 0;
+  align-items: stretch;
 }
 [data-card-layout="strip"][data-store-pill-pos="bar-segment"] .game-card-strip-tier {
-  align-self: center;
-  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   padding: 0 14px;
 }
 [data-card-layout="strip"][data-store-pill-pos="bar-segment"] .game-card-strip-store {
@@ -203,6 +208,7 @@
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: #fff;
+  border-bottom-right-radius: 10px;
 }
 [data-card-layout="strip"][data-store-pill-pos="bar-segment"] .game-card-strip[data-store="steam"] .game-card-strip-store { background: #1689d0; }
 [data-card-layout="strip"][data-store-pill-pos="bar-segment"] .game-card-strip[data-store="gog"] .game-card-strip-store   { background: #7a3fcf; }

--- a/css/shared/cards.css
+++ b/css/shared/cards.css
@@ -251,6 +251,7 @@
   box-sizing: border-box;
   border-bottom-left-radius: 10px;
   border-bottom-right-radius: 10px;
+  position: relative;
 }
 [data-card-layout="strip"] .game-card-strip .game-card-store-pill {
   position: absolute;

--- a/css/shared/cards.css
+++ b/css/shared/cards.css
@@ -300,9 +300,13 @@
   padding: 2px 8px;
 }
 [data-card-layout="strip"] .game-card-right { display: none; }
-/* When bar-segment is active the strip-store segment owns the trailing
-   quarter -- hide the inline pill inside the strip so we don't render the
-   store twice. */
+/* Hide the inline pill inside the strip whenever the store badge lives
+   somewhere else: on the artwork ('art'), as a card-level corner piece
+   ('art-corner'), or as the trailing strip segment ('bar-segment'). The
+   default 'right' placement keeps the pill in the strip since the right
+   column is hidden in strip mode and the strip is the only spot left. */
+[data-card-layout="strip"][data-store-pill-pos="art"] .game-card-strip .game-card-store-pill,
+[data-card-layout="strip"][data-store-pill-pos="art-corner"] .game-card-strip .game-card-store-pill,
 [data-card-layout="strip"][data-store-pill-pos="bar-segment"] .game-card-strip .game-card-store-pill { display: none; }
 .load-more-btn {
   display: block;

--- a/css/shared/cards.css
+++ b/css/shared/cards.css
@@ -309,24 +309,22 @@
 [data-card-layout="strip"] .game-card-right { display: none; }
 /* Hide the inline pill inside the strip whenever the store badge lives
    somewhere else: on the artwork ('art'), as a card-level corner piece
-   ('art-corner'), as a round bar icon ('bar-icon'), or as the trailing
-   strip segment ('bar-segment'). The default 'right' placement keeps the
-   pill in the strip since the right column is hidden in strip mode and
-   the strip is the only spot left. */
+   ('art-corner'), inline next to the tier ('bar-inline'), or as the
+   trailing strip segment ('bar-segment'). The default 'right' placement
+   keeps the pill in the strip since the right column is hidden in strip
+   mode and the strip is the only spot left. */
 [data-card-layout="strip"][data-store-pill-pos="art"] .game-card-strip .game-card-store-pill,
 [data-card-layout="strip"][data-store-pill-pos="art-corner"] .game-card-strip .game-card-store-pill,
-[data-card-layout="strip"][data-store-pill-pos="bar-icon"] .game-card-strip .game-card-store-pill,
+[data-card-layout="strip"][data-store-pill-pos="bar-inline"] .game-card-strip .game-card-store-pill,
 [data-card-layout="strip"][data-store-pill-pos="bar-segment"] .game-card-strip .game-card-store-pill { display: none; }
-/* bar-icon: round store glyph sits flush to the right of the tier
-   label. Icon-only (no text) regardless of the global store-display
-   pref, since this placement is specifically about the icon look.
-   No shadow, no background, no padding -- just the glyph next to the
-   text. The tier-color gradient on the strip already provides the
-   backdrop. */
-[data-card-layout="strip"][data-store-pill-pos="bar-icon"] .game-card-strip {
+/* bar-inline: store badge sits flush to the right of the tier label.
+   Honors the global store-display pref -- shows the text label by
+   default, the round glyph when display=icon. No shadow, no background,
+   no padding; the tier-color gradient is the backdrop. */
+[data-card-layout="strip"][data-store-pill-pos="bar-inline"] .game-card-strip {
   gap: 6px;
 }
-[data-card-layout="strip"][data-store-pill-pos="bar-icon"] .game-card-strip-store {
+[data-card-layout="strip"][data-store-pill-pos="bar-inline"] .game-card-strip-store {
   display: inline-flex;
   align-items: center;
   background: none;
@@ -334,13 +332,15 @@
   padding: 0;
   margin: 0;
   border-radius: 0;
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
-[data-card-layout="strip"][data-store-pill-pos="bar-icon"] .game-card-strip-store > svg {
-  display: block;
+[data-card-layout="strip"][data-store-pill-pos="bar-inline"] .game-card-strip-store > svg {
   width: 16px;
   height: 16px;
 }
-[data-card-layout="strip"][data-store-pill-pos="bar-icon"] .game-card-strip-store > .store-text { display: none; }
 .load-more-btn {
   display: block;
   margin: 12px auto 0;

--- a/css/shared/cards.css
+++ b/css/shared/cards.css
@@ -309,12 +309,23 @@
 [data-card-layout="strip"] .game-card-right { display: none; }
 /* Hide the inline pill inside the strip whenever the store badge lives
    somewhere else: on the artwork ('art'), as a card-level corner piece
-   ('art-corner'), or as the trailing strip segment ('bar-segment'). The
-   default 'right' placement keeps the pill in the strip since the right
-   column is hidden in strip mode and the strip is the only spot left. */
+   ('art-corner'), as a round bar icon ('bar-icon'), or as the trailing
+   strip segment ('bar-segment'). The default 'right' placement keeps the
+   pill in the strip since the right column is hidden in strip mode and
+   the strip is the only spot left. */
 [data-card-layout="strip"][data-store-pill-pos="art"] .game-card-strip .game-card-store-pill,
 [data-card-layout="strip"][data-store-pill-pos="art-corner"] .game-card-strip .game-card-store-pill,
+[data-card-layout="strip"][data-store-pill-pos="bar-icon"] .game-card-strip .game-card-store-pill,
 [data-card-layout="strip"][data-store-pill-pos="bar-segment"] .game-card-strip .game-card-store-pill { display: none; }
+/* bar-icon: round store glyph sits inside the strip next to the tier
+   label. Icon-only (no text) regardless of the global store-display
+   pref, since this placement is specifically about the icon look. */
+[data-card-layout="strip"][data-store-pill-pos="bar-icon"] .game-card-strip-store {
+  display: inline-flex;
+  align-items: center;
+}
+[data-card-layout="strip"][data-store-pill-pos="bar-icon"] .game-card-strip-store > svg { display: block; }
+[data-card-layout="strip"][data-store-pill-pos="bar-icon"] .game-card-strip-store > .store-text { display: none; }
 .load-more-btn {
   display: block;
   margin: 12px auto 0;

--- a/css/shared/cards.css
+++ b/css/shared/cards.css
@@ -317,14 +317,29 @@
 [data-card-layout="strip"][data-store-pill-pos="art-corner"] .game-card-strip .game-card-store-pill,
 [data-card-layout="strip"][data-store-pill-pos="bar-icon"] .game-card-strip .game-card-store-pill,
 [data-card-layout="strip"][data-store-pill-pos="bar-segment"] .game-card-strip .game-card-store-pill { display: none; }
-/* bar-icon: round store glyph sits inside the strip next to the tier
+/* bar-icon: round store glyph sits flush to the right of the tier
    label. Icon-only (no text) regardless of the global store-display
-   pref, since this placement is specifically about the icon look. */
+   pref, since this placement is specifically about the icon look.
+   No shadow, no background, no padding -- just the glyph next to the
+   text. The tier-color gradient on the strip already provides the
+   backdrop. */
+[data-card-layout="strip"][data-store-pill-pos="bar-icon"] .game-card-strip {
+  gap: 6px;
+}
 [data-card-layout="strip"][data-store-pill-pos="bar-icon"] .game-card-strip-store {
   display: inline-flex;
   align-items: center;
+  background: none;
+  box-shadow: none;
+  padding: 0;
+  margin: 0;
+  border-radius: 0;
 }
-[data-card-layout="strip"][data-store-pill-pos="bar-icon"] .game-card-strip-store > svg { display: block; }
+[data-card-layout="strip"][data-store-pill-pos="bar-icon"] .game-card-strip-store > svg {
+  display: block;
+  width: 16px;
+  height: 16px;
+}
 [data-card-layout="strip"][data-store-pill-pos="bar-icon"] .game-card-strip-store > .store-text { display: none; }
 .load-more-btn {
   display: block;

--- a/css/shared/cards.css
+++ b/css/shared/cards.css
@@ -62,6 +62,12 @@
    bottom strip so they don't compete with the corner chip. */
 [data-card-layout="combo"] .game-card-right { display: none; }
 [data-card-layout="combo"] .game-card-strip { display: none; }
+/* Combo owns the entire rating + store presentation, so suppress every
+   other store placement (artwork overlay tag, dedicated card-corner tag,
+   and any stray inline store pill) so the chip stands alone. */
+[data-card-layout="combo"] .game-card-store-tag,
+[data-card-layout="combo"] .game-card-corner-tag,
+[data-card-layout="combo"] .game-card-store-pill { display: none; }
 
 .game-card-corner-tag { display: none; }
 [data-store-pill-pos="art-corner"] .game-card-corner-tag {

--- a/css/shared/cards.css
+++ b/css/shared/cards.css
@@ -153,6 +153,72 @@
 .game-card-store-pill--gog   { background: #7a3fcf; color: #fff; }
 .game-card-store-pill--epic  { background: #555; color: #eee; }
 .game-card-store-pill--non-steam { background: #444; color: #ddd; }
+
+/* Round store icon -- the .store-icon span wraps the SVG glyph and gets a
+   tight square footprint. By default it is hidden inside the store pill;
+   the data-store-display="icon" attribute on <html> hides the text instead
+   and shows the icon. */
+.store-icon { display: none; }
+.store-icon svg { width: 18px; height: 18px; display: block; }
+[data-store-display="icon"] .store-text { display: none; }
+[data-store-display="icon"] .store-icon { display: inline-flex; align-items: center; }
+/* Store pill chrome collapses to just the icon when display=icon so we do
+   not paint a colored background around the icon's own circle. */
+[data-store-display="icon"] .game-card-store-pill,
+[data-store-display="icon"] .game-card-store-tag {
+  background: transparent !important;
+  padding: 0;
+  border-radius: 0;
+}
+
+/* Bottom-bar strip store segment. Hidden by default; revealed by the
+   bar-right or bar-segment placement preferences. */
+.game-card-strip-store { display: none; }
+[data-card-layout="strip"][data-store-pill-pos="bar-right"] .game-card-strip-store {
+  display: inline-flex;
+  align-items: center;
+  margin-left: auto;
+  margin-right: 12px;
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+[data-card-layout="strip"][data-store-pill-pos="bar-right"] .game-card-strip-store .store-text {
+  background: rgba(0, 0, 0, 0.22);
+  padding: 2px 8px;
+  border-radius: 999px;
+}
+[data-card-layout="strip"][data-store-pill-pos="bar-segment"] .game-card-strip {
+  /* Two-tone strip: tier color fills the leading 75%, store color fills
+     the trailing 25%. The store segment's background overrides the strip's
+     own tier background via specificity. */
+  display: grid;
+  grid-template-columns: 3fr 1fr;
+  padding: 0;
+}
+[data-card-layout="strip"][data-store-pill-pos="bar-segment"] .game-card-strip-tier {
+  align-self: center;
+  text-align: center;
+  padding: 0 14px;
+}
+[data-card-layout="strip"][data-store-pill-pos="bar-segment"] .game-card-strip-store {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 8px;
+  font-size: 0.62rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #fff;
+}
+[data-card-layout="strip"][data-store-pill-pos="bar-segment"] .game-card-strip[data-store="steam"] .game-card-strip-store { background: #1689d0; }
+[data-card-layout="strip"][data-store-pill-pos="bar-segment"] .game-card-strip[data-store="gog"] .game-card-strip-store   { background: #7a3fcf; }
+[data-card-layout="strip"][data-store-pill-pos="bar-segment"] .game-card-strip[data-store="epic"] .game-card-strip-store  { background: #2a2a2a; }
+/* When the icon preference is on inside the segment, hide the text label
+   and let the round icon do the talking. */
+[data-store-display="icon"][data-card-layout="strip"][data-store-pill-pos="bar-segment"] .game-card-strip-store .store-text { display: none; }
 @media (max-width: 600px) {
   .game-card-pills { flex-direction: column; align-items: flex-end; gap: 4px; }
 }
@@ -213,6 +279,10 @@
   padding: 2px 8px;
 }
 [data-card-layout="strip"] .game-card-right { display: none; }
+/* When a bar-* placement is active the strip-store segment is shown -- hide
+   the inline pill inside the strip so we don't render the store twice. */
+[data-card-layout="strip"][data-store-pill-pos="bar-right"] .game-card-strip .game-card-store-pill,
+[data-card-layout="strip"][data-store-pill-pos="bar-segment"] .game-card-strip .game-card-store-pill { display: none; }
 .load-more-btn {
   display: block;
   margin: 12px auto 0;

--- a/css/shared/site.css
+++ b/css/shared/site.css
@@ -431,19 +431,10 @@
 /* Store pill position preference (pp:store-pill-pos).
    Default ('right'): pill in the rating column, overlay hidden.
    'art': overlay on the thumbnail bottom-right, right-column pill hidden.
-   'art-corner': overlay anchored to the artwork's top-right corner, squared
-   off against the outer edges (corner piece look). */
+   'art-corner': card-level corner piece pinned to the whole card's
+   top-right edge (uses .game-card-corner-tag, styled in cards.css /
+   index.css; the thumbnail overlay and right-column pill are hidden). */
 .game-card-store-tag { display: none; }
 [data-store-pill-pos="art"] .game-card-store-tag { display: inline; }
 [data-store-pill-pos="art"] .game-card-store-pill { display: none; }
-[data-store-pill-pos="art-corner"] .game-card-store-tag {
-  display: inline;
-  top: 0;
-  right: 0;
-  bottom: auto;
-  left: auto;
-  padding: 3px 9px;
-  border-radius: 0 6px 0 8px;
-  box-shadow: -1px 1px 4px rgba(0, 0, 0, 0.55);
-}
 [data-store-pill-pos="art-corner"] .game-card-store-pill { display: none; }

--- a/css/shared/site.css
+++ b/css/shared/site.css
@@ -430,7 +430,20 @@
 
 /* Store pill position preference (pp:store-pill-pos).
    Default ('right'): pill in the rating column, overlay hidden.
-   'art': overlay on the thumbnail, right-column pill hidden. */
+   'art': overlay on the thumbnail bottom-right, right-column pill hidden.
+   'art-corner': overlay anchored to the artwork's top-right corner, squared
+   off against the outer edges (corner piece look). */
 .game-card-store-tag { display: none; }
 [data-store-pill-pos="art"] .game-card-store-tag { display: inline; }
 [data-store-pill-pos="art"] .game-card-store-pill { display: none; }
+[data-store-pill-pos="art-corner"] .game-card-store-tag {
+  display: inline;
+  top: 0;
+  right: 0;
+  bottom: auto;
+  left: auto;
+  padding: 3px 9px;
+  border-radius: 0 6px 0 8px;
+  box-shadow: -1px 1px 4px rgba(0, 0, 0, 0.55);
+}
+[data-store-pill-pos="art-corner"] .game-card-store-pill { display: none; }

--- a/css/shared/topbar.css
+++ b/css/shared/topbar.css
@@ -540,29 +540,17 @@ html[data-motion="off"] .banner-atoms {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.search-dropdown .sd-counts {
+/* App id is the row-two subline now (the old report-count line went away).
+   Mono + muted so long Epic / GOG ids stay readable without competing
+   with the title. */
+.search-dropdown .sd-appid {
   font-family: var(--mono);
-  font-size: 0.68rem;
+  font-size: 0.7rem;
   color: var(--muted);
   letter-spacing: 0.04em;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-/* App id now sits on the LEFT of the row (between thumbnail and title),
-   in mono so long Epic / GOG ids stay readable but don't push the title
-   around. */
-.search-dropdown .sd-appid--left {
-  flex-shrink: 0;
-  font-family: var(--mono);
-  font-size: 0.66rem;
-  color: var(--muted);
-  max-width: 90px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  align-self: center;
-  margin-left: 2px;
 }
 /* Split chip on the trailing edge of the row -- tier color on the left,
    store color on the right. Mirrors the .game-card-combo-tag styling on
@@ -598,7 +586,7 @@ html[data-motion="off"] .banner-atoms {
 .search-dropdown .sd-combo[data-store="gog"]  .sd-combo-store { background: #7a3fcf; }
 .search-dropdown .sd-combo[data-store="epic"] .sd-combo-store { background: #2a2a2a; }
 @media (max-width: 540px) {
-  .search-dropdown .sd-appid--left { max-width: 56px; font-size: 0.58rem; }
+  .search-dropdown .sd-appid { font-size: 0.62rem; }
   .search-dropdown .sd-combo { font-size: 0.55rem; }
   .search-dropdown .sd-combo .sd-combo-tier,
   .search-dropdown .sd-combo .sd-combo-store { padding: 3px 6px; }

--- a/css/shared/topbar.css
+++ b/css/shared/topbar.css
@@ -549,50 +549,59 @@ html[data-motion="off"] .banner-atoms {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.search-dropdown .sd-tier {
+/* App id now sits on the LEFT of the row (between thumbnail and title),
+   in mono so long Epic / GOG ids stay readable but don't push the title
+   around. */
+.search-dropdown .sd-appid--left {
   flex-shrink: 0;
-  font-family: var(--mono);
-  font-size: 0.62rem;
-  font-weight: 700;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  padding: 3px 8px;
-  align-self: center;
-}
-.search-dropdown .sd-appid {
   font-family: var(--mono);
   font-size: 0.66rem;
   color: var(--muted);
-  flex-shrink: 1;
-  max-width: 96px;
+  max-width: 90px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-.search-dropdown .sd-store {
-  flex-shrink: 0;
   align-self: center;
+  margin-left: 2px;
+}
+/* Split chip on the trailing edge of the row -- tier color on the left,
+   store color on the right. Mirrors the .game-card-combo-tag styling on
+   the cards so the dropdown stays visually consistent. */
+.search-dropdown .sd-combo {
+  flex-shrink: 0;
   display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 52px;
-  height: 20px;
-  margin-left: 4px;
-  font-size: 0.6rem;
-  font-weight: 700;
+  align-self: center;
+  align-items: stretch;
+  border-radius: 4px;
+  overflow: hidden;
+  font-family: var(--mono);
+  font-size: 0.62rem;
+  font-weight: 800;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  padding: 0 10px;
-  border-radius: 999px;
-  color: #fff;
-  line-height: 1;
+  line-height: 1.1;
+  box-shadow: 0 0 0 1px rgba(0,0,0,0.35);
 }
-.search-dropdown .sd-store--steam { background: #1689d0; }
-.search-dropdown .sd-store--gog   { background: #7a3fcf; }
-.search-dropdown .sd-store--epic  { background: #555; color: #eee; }
+.search-dropdown .sd-combo .sd-combo-tier,
+.search-dropdown .sd-combo .sd-combo-store {
+  padding: 4px 8px;
+  display: inline-flex;
+  align-items: center;
+}
+.search-dropdown .sd-combo .sd-combo-tier { background: #3a4252; color: #d6dee8; }
+.search-dropdown .sd-combo[data-tier="platinum"] .sd-combo-tier { background: #b4c7dc; color: #0a0c10; }
+.search-dropdown .sd-combo[data-tier="gold"]     .sd-combo-tier { background: #c8a050; color: #111; }
+.search-dropdown .sd-combo[data-tier="silver"]   .sd-combo-tier { background: #8fa0b0; color: #111; }
+.search-dropdown .sd-combo[data-tier="bronze"]   .sd-combo-tier { background: #b07040; color: #fff; }
+.search-dropdown .sd-combo[data-tier="borked"]   .sd-combo-tier { background: #c85050; color: #fff; }
+.search-dropdown .sd-combo .sd-combo-store { background: #1689d0; color: #fff; }
+.search-dropdown .sd-combo[data-store="gog"]  .sd-combo-store { background: #7a3fcf; }
+.search-dropdown .sd-combo[data-store="epic"] .sd-combo-store { background: #2a2a2a; }
 @media (max-width: 540px) {
-  .search-dropdown .sd-appid { max-width: 60px; font-size: 0.6rem; }
-  .search-dropdown .sd-store { font-size: 0.55rem; padding: 2px 6px; }
+  .search-dropdown .sd-appid--left { max-width: 56px; font-size: 0.58rem; }
+  .search-dropdown .sd-combo { font-size: 0.55rem; }
+  .search-dropdown .sd-combo .sd-combo-tier,
+  .search-dropdown .sd-combo .sd-combo-store { padding: 3px 6px; }
 }
 .search-dropdown .sd-empty {
   padding: 14px 12px;

--- a/game-stats.html
+++ b/game-stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
-<link rel="stylesheet" href="css/app/game-header.css?v=eae4ea27">
+<link rel="stylesheet" href="css/app/game-header.css?v=669186d7">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">

--- a/game-stats.html
+++ b/game-stats.html
@@ -11,8 +11,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
-<link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=17c970a6">
+<link rel="stylesheet" href="css/shared/site.css?v=c581801e">
+<link rel="stylesheet" href="css/shared/cards.css?v=0092674d">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/game-stats.html
+++ b/game-stats.html
@@ -17,7 +17,7 @@
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
-<link rel="stylesheet" href="css/app/home.css?v=4ea20844">
+<link rel="stylesheet" href="css/app/home.css?v=d983b41a">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/game-stats.html
+++ b/game-stats.html
@@ -10,7 +10,7 @@
 <meta name="description" content="Per-game Proton compatibility analysis with confidence breakdown, monthly report trends, working status, version success rates, and proven launch options.">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
-<link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
+<link rel="stylesheet" href="css/shared/topbar.css?v=256d07b6">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <link rel="stylesheet" href="css/app/game-header.css?v=669186d7">
@@ -309,7 +309,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=a3dcfcd5"></script>
+<script src="js/lib/topbar.js?v=c2fe26da"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/game-stats.html
+++ b/game-stats.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=7b2b7e95">
+<link rel="stylesheet" href="css/shared/cards.css?v=9548e3dd">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/game-stats.html
+++ b/game-stats.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=d1db1355">
+<link rel="stylesheet" href="css/shared/cards.css?v=17c970a6">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
@@ -309,7 +309,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=3585d26d"></script>
+<script src="js/lib/topbar.js?v=f444bec4"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/game-stats.html
+++ b/game-stats.html
@@ -309,7 +309,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=2f8197e0"></script>
+<script src="js/lib/topbar.js?v=8c2f9356"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/game-stats.html
+++ b/game-stats.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=7906ae81">
+<link rel="stylesheet" href="css/shared/cards.css?v=4b548983">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/game-stats.html
+++ b/game-stats.html
@@ -12,12 +12,12 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
+<link rel="stylesheet" href="css/shared/cards.css?v=17142038">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
-<link rel="stylesheet" href="css/app/home.css?v=b62dd0ac">
+<link rel="stylesheet" href="css/app/home.css?v=4ea20844">
 <style>
 h1 {
   font-family: var(--font-display);
@@ -309,7 +309,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=a47091a2"></script>
+<script src="js/lib/topbar.js?v=1d29a1b6"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/game-stats.html
+++ b/game-stats.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=9548e3dd">
+<link rel="stylesheet" href="css/shared/cards.css?v=d1db1355">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
@@ -309,7 +309,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=522f6c3d"></script>
+<script src="js/lib/topbar.js?v=3585d26d"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/game-stats.html
+++ b/game-stats.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=ac2f4490">
+<link rel="stylesheet" href="css/shared/cards.css?v=7906ae81">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/game-stats.html
+++ b/game-stats.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=b48b5b18">
+<link rel="stylesheet" href="css/shared/cards.css?v=cb310e3b">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
@@ -309,7 +309,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=f444bec4"></script>
+<script src="js/lib/topbar.js?v=2f8197e0"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/game-stats.html
+++ b/game-stats.html
@@ -309,7 +309,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=1d29a1b6"></script>
+<script src="js/lib/topbar.js?v=a3dcfcd5"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/game-stats.html
+++ b/game-stats.html
@@ -10,7 +10,7 @@
 <meta name="description" content="Per-game Proton compatibility analysis with confidence breakdown, monthly report trends, working status, version success rates, and proven launch options.">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
-<link rel="stylesheet" href="css/shared/topbar.css?v=256d07b6">
+<link rel="stylesheet" href="css/shared/topbar.css?v=2d6b5e52">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <link rel="stylesheet" href="css/app/game-header.css?v=669186d7">
@@ -309,7 +309,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=c2fe26da"></script>
+<script src="js/lib/topbar.js?v=449040e3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/game-stats.html
+++ b/game-stats.html
@@ -11,8 +11,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
-<link rel="stylesheet" href="css/shared/site.css?v=c581801e">
-<link rel="stylesheet" href="css/shared/cards.css?v=0092674d">
+<link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
+<link rel="stylesheet" href="css/shared/cards.css?v=ac2f4490">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/game-stats.html
+++ b/game-stats.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=4b548983">
+<link rel="stylesheet" href="css/shared/cards.css?v=5ec3c05a">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/game-stats.html
+++ b/game-stats.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=cb310e3b">
+<link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/game-stats.html
+++ b/game-stats.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=b75e75b2">
+<link rel="stylesheet" href="css/shared/cards.css?v=7b2b7e95">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
@@ -309,7 +309,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=7e8205f8"></script>
+<script src="js/lib/topbar.js?v=522f6c3d"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/game-stats.html
+++ b/game-stats.html
@@ -17,7 +17,7 @@
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
-<link rel="stylesheet" href="css/app/home.css?v=4bf8008f">
+<link rel="stylesheet" href="css/app/home.css?v=b62dd0ac">
 <style>
 h1 {
   font-family: var(--font-display);
@@ -309,7 +309,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=8fe1c285"></script>
+<script src="js/lib/topbar.js?v=a47091a2"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/game-stats.html
+++ b/game-stats.html
@@ -309,7 +309,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=8c2f9356"></script>
+<script src="js/lib/topbar.js?v=8fe1c285"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/game-stats.html
+++ b/game-stats.html
@@ -12,8 +12,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=17142038">
-<link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
+<link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
+<link rel="stylesheet" href="css/app/game-header.css?v=eae4ea27">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">

--- a/game-stats.html
+++ b/game-stats.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=5ec3c05a">
+<link rel="stylesheet" href="css/shared/cards.css?v=b48b5b18">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=7b2b7e95">
-<link rel="stylesheet" href="css/index/index.css?v=e7a3bfb0">
+<link rel="stylesheet" href="css/shared/cards.css?v=9548e3dd">
+<link rel="stylesheet" href="css/index/index.css?v=b3faf0dd">
 </head>
 <body>
 

--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
-<link rel="stylesheet" href="css/index/index.css?v=f047d582">
+<link rel="stylesheet" href="css/shared/cards.css?v=17142038">
+<link rel="stylesheet" href="css/index/index.css?v=cef6764d">
 </head>
 <body>
 
@@ -216,8 +216,8 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=a47091a2"></script>
+<script src="js/lib/topbar.js?v=1d29a1b6"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/index/main.js?v=60162448"></script>
+<script type="module" src="js/index/main.js?v=2e295ec1"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 <meta property="og:type" content="website">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
-<link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
+<link rel="stylesheet" href="css/shared/topbar.css?v=256d07b6">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
@@ -216,7 +216,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=a3dcfcd5"></script>
+<script src="js/lib/topbar.js?v=c2fe26da"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/index/main.js?v=25784617"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 <meta property="og:type" content="website">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
-<link rel="stylesheet" href="css/shared/topbar.css?v=256d07b6">
+<link rel="stylesheet" href="css/shared/topbar.css?v=2d6b5e52">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
@@ -216,7 +216,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=c2fe26da"></script>
+<script src="js/lib/topbar.js?v=449040e3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/index/main.js?v=25784617"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=9548e3dd">
-<link rel="stylesheet" href="css/index/index.css?v=b3faf0dd">
+<link rel="stylesheet" href="css/shared/cards.css?v=d1db1355">
+<link rel="stylesheet" href="css/index/index.css?v=ad77490b">
 </head>
 <body>
 
@@ -216,7 +216,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=522f6c3d"></script>
+<script src="js/lib/topbar.js?v=3585d26d"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/index/main.js?v=ba83398e"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
 <link rel="stylesheet" href="css/shared/cards.css?v=17142038">
-<link rel="stylesheet" href="css/index/index.css?v=cef6764d">
+<link rel="stylesheet" href="css/index/index.css?v=6b16bc5f">
 </head>
 <body>
 
@@ -192,8 +192,8 @@
             <button class="pg-size-btn pg-size-btn--desktop-only" data-size="xl" type="button" title="Extra large cards">XL</button>
           </div>
           <div class="pg-layout-toggle">
-            <button class="pg-layout-btn active" data-layout="grid" title="Grid view">Grid</button>
-            <button class="pg-layout-btn" data-layout="list" title="List view">List</button>
+            <button class="pg-layout-btn active" data-layout="list" title="List of horizontal cards (default)">List</button>
+            <button class="pg-layout-btn" data-layout="grid" title="Grid of Steam-style tiles">Grid</button>
           </div>
         </div>
       </div>
@@ -218,6 +218,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=1d29a1b6"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/index/main.js?v=2e295ec1"></script>
+<script type="module" src="js/index/main.js?v=b574bd85"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=7906ae81">
+<link rel="stylesheet" href="css/shared/cards.css?v=4b548983">
 <link rel="stylesheet" href="css/index/index.css?v=39339c49">
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -216,7 +216,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=2f8197e0"></script>
+<script src="js/lib/topbar.js?v=8c2f9356"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/index/main.js?v=60162448"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=4b548983">
-<link rel="stylesheet" href="css/index/index.css?v=39339c49">
+<link rel="stylesheet" href="css/shared/cards.css?v=5ec3c05a">
+<link rel="stylesheet" href="css/index/index.css?v=82445769">
 </head>
 <body>
 

--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=d1db1355">
-<link rel="stylesheet" href="css/index/index.css?v=ad77490b">
+<link rel="stylesheet" href="css/shared/cards.css?v=17c970a6">
+<link rel="stylesheet" href="css/index/index.css?v=5ef799ac">
 </head>
 <body>
 
@@ -216,7 +216,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=3585d26d"></script>
+<script src="js/lib/topbar.js?v=f444bec4"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/index/main.js?v=ba83398e"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -216,7 +216,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=1d29a1b6"></script>
+<script src="js/lib/topbar.js?v=a3dcfcd5"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/index/main.js?v=25784617"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=cb310e3b">
-<link rel="stylesheet" href="css/index/index.css?v=977253e5">
+<link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
+<link rel="stylesheet" href="css/index/index.css?v=edf9e702">
 </head>
 <body>
 

--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=b48b5b18">
-<link rel="stylesheet" href="css/index/index.css?v=501c588c">
+<link rel="stylesheet" href="css/shared/cards.css?v=cb310e3b">
+<link rel="stylesheet" href="css/index/index.css?v=977253e5">
 </head>
 <body>
 
@@ -216,7 +216,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=f444bec4"></script>
+<script src="js/lib/topbar.js?v=2f8197e0"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/index/main.js?v=60162448"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -14,10 +14,10 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
-<link rel="stylesheet" href="css/shared/site.css?v=c581801e">
+<link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=0092674d">
-<link rel="stylesheet" href="css/index/index.css?v=5ef799ac">
+<link rel="stylesheet" href="css/shared/cards.css?v=ac2f4490">
+<link rel="stylesheet" href="css/index/index.css?v=a2de5ad7">
 </head>
 <body>
 
@@ -218,6 +218,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=f444bec4"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/index/main.js?v=ba83398e"></script>
+<script type="module" src="js/index/main.js?v=60162448"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -14,9 +14,9 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
-<link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
+<link rel="stylesheet" href="css/shared/site.css?v=c581801e">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=17c970a6">
+<link rel="stylesheet" href="css/shared/cards.css?v=0092674d">
 <link rel="stylesheet" href="css/index/index.css?v=5ef799ac">
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=ac2f4490">
-<link rel="stylesheet" href="css/index/index.css?v=a2de5ad7">
+<link rel="stylesheet" href="css/shared/cards.css?v=7906ae81">
+<link rel="stylesheet" href="css/index/index.css?v=39339c49">
 </head>
 <body>
 

--- a/index.html
+++ b/index.html
@@ -216,7 +216,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=8c2f9356"></script>
+<script src="js/lib/topbar.js?v=8fe1c285"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/index/main.js?v=60162448"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=17142038">
-<link rel="stylesheet" href="css/index/index.css?v=6b16bc5f">
+<link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
+<link rel="stylesheet" href="css/index/index.css?v=624d05bc">
 </head>
 <body>
 
@@ -218,6 +218,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=1d29a1b6"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/index/main.js?v=237f73be"></script>
+<script type="module" src="js/index/main.js?v=25784617"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=b75e75b2">
-<link rel="stylesheet" href="css/index/index.css?v=2d161a7e">
+<link rel="stylesheet" href="css/shared/cards.css?v=7b2b7e95">
+<link rel="stylesheet" href="css/index/index.css?v=e7a3bfb0">
 </head>
 <body>
 
@@ -216,8 +216,8 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=7e8205f8"></script>
+<script src="js/lib/topbar.js?v=522f6c3d"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/index/main.js?v=80e0188b"></script>
+<script type="module" src="js/index/main.js?v=ba83398e"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
 <link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
-<link rel="stylesheet" href="css/index/index.css?v=edf9e702">
+<link rel="stylesheet" href="css/index/index.css?v=f047d582">
 </head>
 <body>
 
@@ -216,7 +216,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=8fe1c285"></script>
+<script src="js/lib/topbar.js?v=a47091a2"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/index/main.js?v=60162448"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=5ec3c05a">
-<link rel="stylesheet" href="css/index/index.css?v=82445769">
+<link rel="stylesheet" href="css/shared/cards.css?v=b48b5b18">
+<link rel="stylesheet" href="css/index/index.css?v=501c588c">
 </head>
 <body>
 

--- a/index.html
+++ b/index.html
@@ -192,8 +192,8 @@
             <button class="pg-size-btn pg-size-btn--desktop-only" data-size="xl" type="button" title="Extra large cards">XL</button>
           </div>
           <div class="pg-layout-toggle">
-            <button class="pg-layout-btn active" data-layout="list" title="List of horizontal cards (default)">List</button>
-            <button class="pg-layout-btn" data-layout="grid" title="Grid of Steam-style tiles">Grid</button>
+            <button class="pg-layout-btn" data-layout="list" title="List of horizontal cards">List</button>
+            <button class="pg-layout-btn active" data-layout="grid" title="Grid of Steam-style tiles (default)">Grid</button>
           </div>
         </div>
       </div>
@@ -218,6 +218,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=1d29a1b6"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/index/main.js?v=b574bd85"></script>
+<script type="module" src="js/index/main.js?v=237f73be"></script>
 </body>
 </html>

--- a/js/admin/api/allReports.js
+++ b/js/admin/api/allReports.js
@@ -5,13 +5,21 @@ const COLS = 'id,app_id,title,client_id,proton_pulse_user_id,rating,source,app_t
 const DETAIL_COLS = 'id,app_id,title,client_id,proton_pulse_user_id,rating,proton_version,cpu,gpu,gpu_driver,gpu_vendor,gpu_architecture,ram,vram_mb,os,kernel,duration,duration_minutes,notes,form_responses,config_key,game_owned,source,app_type,is_flagged,is_hidden,created_at,updated_at';
 
 export async function fetchReportById(session, id) {
-  const res = await fetch(
-    `${SUPABASE_URL}/rest/v1/user_configs?id=eq.${encodeURIComponent(id)}&select=${DETAIL_COLS}&limit=1`,
-    { headers: supabaseHeaders(session) },
-  );
+  const [res, approvalRes] = await Promise.all([
+    fetch(
+      `${SUPABASE_URL}/rest/v1/user_configs?id=eq.${encodeURIComponent(id)}&select=${DETAIL_COLS}&limit=1`,
+      { headers: supabaseHeaders(session) },
+    ),
+    fetch(
+      `${SUPABASE_URL}/rest/v1/report_approvals?report_id=eq.${encodeURIComponent(id)}&select=report_id&limit=1`,
+      { headers: supabaseHeaders(session) },
+    ).catch(() => ({ ok: false })),
+  ]);
   if (!res.ok) throw new Error(`Failed to fetch report: ${res.status}`);
   const rows = await res.json();
   if (!rows.length) throw new Error('Report not found');
+  const approvals = approvalRes.ok ? await approvalRes.json() : [];
+  rows[0].is_pending = approvals.length === 0;
   return rows[0];
 }
 
@@ -23,18 +31,39 @@ export async function fetchAllReports(session, { search = '', status = 'clean', 
     url += `&or=(app_id.eq.${q},title.ilike.*${q}*)`;
   }
 
+  // Hard server-side filters (cheap). 'pending' and 'clean' both need to know
+  // about report_approvals, so they're applied client-side below.
   if (status === 'flagged') url += '&is_flagged=eq.true';
   if (status === 'hidden')  url += '&is_hidden=eq.true';
-  if (status === 'clean')   url += '&is_flagged=eq.false&is_hidden=eq.false';
+  if (status === 'clean' || status === 'pending') url += '&is_flagged=eq.false&is_hidden=eq.false';
 
   if (appType) url += `&app_type=eq.${encodeURIComponent(appType)}`;
 
   if (dateFrom) url += `&created_at=gte.${encodeURIComponent(dateFrom)}`;
   if (dateTo)   url += `&created_at=lte.${encodeURIComponent(dateTo + 'T23:59:59')}`;
 
-  const res = await fetch(url, { headers: supabaseHeaders(session) });
+  const [res, approvalRes] = await Promise.all([
+    fetch(url, { headers: supabaseHeaders(session) }),
+    // Approval rows are keyed by report_id. Existence = approved at least once.
+    // The public app additionally compares the stored hash to the row's current
+    // content (and hides the report on mismatch); the admin view treats any
+    // approval row as "approved" so moderators can see edit history without
+    // a stale-hash false negative.
+    fetch(`${SUPABASE_URL}/rest/v1/report_approvals?select=report_id`, {
+      headers: supabaseHeaders(session),
+    }).catch(() => ({ ok: false })),
+  ]);
   if (!res.ok) throw new Error(`Failed to fetch reports: ${res.status}`);
-  return res.json();
+
+  const rows = await res.json();
+  const approvals = approvalRes.ok ? await approvalRes.json() : [];
+  const approvedIds = new Set(approvals.map(a => a.report_id));
+
+  for (const row of rows) row.is_pending = !approvedIds.has(row.id);
+
+  if (status === 'pending') return rows.filter(r => r.is_pending);
+  if (status === 'clean')   return rows.filter(r => !r.is_pending);
+  return rows;
 }
 
 export async function patchReportFlags(session, id, patch) {

--- a/js/admin/components/allReports.js
+++ b/js/admin/components/allReports.js
@@ -1,14 +1,18 @@
 import { escapeHtml, fmtDateTime } from '../utils.js?v=bd5a67c2';
-import { fetchAllReports } from '../api/allReports.js?v=3540a5a1';
+import { fetchAllReports } from '../api/allReports.js?v=805161ee';
 
-function statusBadges(isF, isH) {
+function statusBadges(isF, isH, isP) {
+  // Flagged and hidden take precedence (moderator action). Pending is shown
+  // only when the row is neither -- a fresh or edited report still waiting
+  // for the daily approval pipeline.
   if (isF || isH) {
     return [
       isF ? '<span class="admin-badge admin-badge--warn">flagged</span>' : '',
       isH ? '<span class="admin-badge admin-badge--muted">hidden</span>'  : '',
     ].filter(Boolean).join(' ');
   }
-  return '';
+  if (isP) return '<span class="admin-badge admin-badge--info">pending</span>';
+  return '<span class="admin-badge admin-badge--ok">approved</span>';
 }
 
 function actionBtns(id, isF, isH) {
@@ -74,7 +78,7 @@ export async function renderAllReports(session) {
       const userObj = escapeHtml(JSON.stringify({ proton_pulse_user_id: uid, client_id: cid, username: uid || cid || 'anon' }));
       const userBtn = `<button class="admin-btn admin-btn--ghost admin-btn--sm" data-action="view-user-detail" data-userobj='${userObj}'>Details</button>`;
 
-      return `<tr data-rid="${rid}">
+      return `<tr data-rid="${rid}" data-pending="${r.is_pending ? '1' : '0'}">
         <td><button class="admin-link-btn" data-action="ar-view-detail" data-rid="${rid}">#${rid}</button></td>
         <td>${appLink}</td>
         <td>${title}</td>
@@ -82,7 +86,7 @@ export async function renderAllReports(session) {
         <td>${appType}</td>
         <td>${userBtn}</td>
         <td>${date}</td>
-        <td class="ar-status">${statusBadges(r.is_flagged, r.is_hidden)}</td>
+        <td class="ar-status">${statusBadges(r.is_flagged, r.is_hidden, r.is_pending)}</td>
         <td class="ar-actions">${actionBtns(r.id, r.is_flagged, r.is_hidden)}</td>
       </tr>`;
     }).join('');
@@ -98,9 +102,10 @@ export async function renderAllReports(session) {
 export function updateAllReportsRow(id, isF, isH) {
   const row = document.querySelector(`#all-reports-tbody tr[data-rid="${CSS.escape(String(id))}"]`);
   if (!row) return;
+  const isP = row.dataset.pending === '1';
   const statusCell  = row.querySelector('.ar-status');
   const actionsCell = row.querySelector('.ar-actions');
-  if (statusCell)  statusCell.innerHTML  = statusBadges(isF, isH);
+  if (statusCell)  statusCell.innerHTML  = statusBadges(isF, isH, isP);
   if (actionsCell) actionsCell.innerHTML = actionBtns(id, isF, isH);
 }
 
@@ -143,6 +148,7 @@ export function renderAllReportsDetail(report, { onAction, onBack } = {}) {
 
   const isF = report.is_flagged;
   const isH = report.is_hidden;
+  const isP = report.is_pending === true;
   const rid = escapeHtml(String(report.id));
   const actionHtml = (isF || isH)
     ? `<button class="admin-btn admin-btn--ok" data-action="ar-release" data-rid="${rid}">Release</button>`
@@ -153,7 +159,7 @@ export function renderAllReportsDetail(report, { onAction, onBack } = {}) {
     <button class="admin-btn admin-btn--sm admin-btn--ghost" data-action="ar-back" style="margin-bottom:12px">&#8592; Back to list</button>
     <div class="admin-card">
       <div class="admin-subhead">Report Detail</div>
-      <div id="ar-detail-status" style="margin-bottom:10px">${statusBadges(isF, isH)}</div>
+      <div id="ar-detail-status" style="margin-bottom:10px">${statusBadges(isF, isH, isP)}</div>
       <table class="admin-table" style="margin-bottom:16px">
         <tbody>
           ${fields.map(([label, value]) => `

--- a/js/admin/components/allReports.js
+++ b/js/admin/components/allReports.js
@@ -65,8 +65,14 @@ export async function renderAllReports(session) {
 
     tbody.innerHTML = reports.map(r => {
       const appId   = r.app_id ? escapeHtml(String(r.app_id)) : null;
+      // Public-app permalink only resolves when the report is actually
+      // visible there: approved, not flagged, not hidden. For pending,
+      // flagged, or hidden rows fall back to the game's report list.
+      const isPublic = appId && !r.is_pending && !r.is_flagged && !r.is_hidden;
       const appLink = appId
-        ? `<a class="admin-link" href="app.html#/app/${appId}" target="_blank">App ${appId}</a>`
+        ? (isPublic
+            ? `<a class="admin-link" href="app.html#/app/${appId}#report-r${escapeHtml(String(r.id))}" target="_blank" title="Open this report on the public page">App ${appId}</a>`
+            : `<a class="admin-link" href="app.html#/app/${appId}" target="_blank" title="Open the game's report list">App ${appId}</a>`)
         : 'Unknown';
       const rid    = escapeHtml(String(r.id));
       const title  = escapeHtml(r.title || '');

--- a/js/admin/main.js
+++ b/js/admin/main.js
@@ -17,8 +17,8 @@ import { renderUserDetail } from './components/userDetail.js?v=62542337';
 import { fetchAnalytics } from './api/analytics.js?v=79ced8b7';
 import { renderAnalytics } from './components/analytics.js?v=878b5818';
 import { renderCacheStatus } from './components/cache-status.js?v=0c6c0cb7';
-import { renderAllReports, updateAllReportsRow, renderAllReportsDetail } from './components/allReports.js?v=84b0746c';
-import { patchReportFlags, fetchReportById } from './api/allReports.js?v=3540a5a1';
+import { renderAllReports, updateAllReportsRow, renderAllReportsDetail } from './components/allReports.js?v=1c339724';
+import { patchReportFlags, fetchReportById } from './api/allReports.js?v=805161ee';
 
 // ---------------------------------------------------------------------------
 // State

--- a/js/admin/main.js
+++ b/js/admin/main.js
@@ -17,7 +17,7 @@ import { renderUserDetail } from './components/userDetail.js?v=62542337';
 import { fetchAnalytics } from './api/analytics.js?v=79ced8b7';
 import { renderAnalytics } from './components/analytics.js?v=878b5818';
 import { renderCacheStatus } from './components/cache-status.js?v=0c6c0cb7';
-import { renderAllReports, updateAllReportsRow, renderAllReportsDetail } from './components/allReports.js?v=1c339724';
+import { renderAllReports, updateAllReportsRow, renderAllReportsDetail } from './components/allReports.js?v=ff236263';
 import { patchReportFlags, fetchReportById } from './api/allReports.js?v=805161ee';
 
 // ---------------------------------------------------------------------------

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -10,7 +10,7 @@ import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=aba6619f
 import { enhanceAuthorBlocks } from './author.js?v=2316d334';
 import { renderConfigCard } from './config-cards.js?v=c67740f8';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=48037483';
-import { renderCard } from './report-card.js?v=ec94c31c';
+import { renderCard } from './report-card.js?v=f6d301ed';
 import { loadSearchIndex, searchIndex } from './search.js?v=28b593a1';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=e7fe3ce0';
@@ -870,11 +870,20 @@ export async function renderGamePage(appId) {
     _showFlagModal(btn);
   });
 
-  // Scroll to a specific report if the URL has #report-{id} after the app hash
+  // Scroll to a specific report if the URL has #report-{id} after the app hash.
+  // The fixed topbar would cover the report's top edge under plain
+  // scrollIntoView, so compute the scroll target manually and back the
+  // position off by the topbar height plus a small gap. The anchor now sits
+  // on the .report-block wrapper around the header card + summary, so the
+  // top of the visible report aligns with the top of the viewport.
   const anchorMatch = location.hash.match(/#(report-[a-z0-9]+)$/i);
   if (anchorMatch) {
     setTimeout(() => {
-      el.querySelector(`#${anchorMatch[1]}`)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      const target = el.querySelector(`#${anchorMatch[1]}`);
+      if (!target) return;
+      const topbarH = document.querySelector('.topbar')?.getBoundingClientRect().height || 0;
+      const top = target.getBoundingClientRect().top + window.scrollY - topbarH - 12;
+      window.scrollTo({ top: Math.max(0, top), behavior: 'smooth' });
     }, 150);
   }
 }

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -4,7 +4,7 @@ import { fetchRecentPulseReports } from '../api/reports.js?v=003f23c0';
 import { loadSearchIndex, searchIndex } from './search.js?v=28b593a1';
 import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '../config.js?v=df5b5024';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
-import { renderGameCard } from '../lib/card.js?v=0ac206f6';
+import { renderGameCard } from '../lib/card.js?v=373798af';
 import { dataUrl } from '../../lib/data-url.js?v=3c2e7ac9';
 
 const LOAD_COUNT_KEY = 'pp:load-count';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -243,8 +243,8 @@ export async function renderHomePage() {
             <button class="home-size-btn home-size-btn--desktop-only" data-size="xl" type="button" title="Extra large cards">XL</button>
           </div>
           <div class="home-layout-toggle">
-            <button class="home-layout-btn active" data-layout="grid" title="Grid view">Grid</button>
-            <button class="home-layout-btn" data-layout="list" title="List view">List</button>
+            <button class="home-layout-btn active" data-layout="list" title="List of horizontal cards (default)">List</button>
+            <button class="home-layout-btn" data-layout="grid" title="Grid of Steam-style tiles">Grid</button>
           </div>
         </div>
       </div>
@@ -270,18 +270,10 @@ export async function renderHomePage() {
     let storeSel = new Set();  // empty => all stores
     let currentLayout = 'grid';
 
-    function _listRowHtml(r) {
-      const tier = String(r.tier || '').toLowerCase();
-      const total = (r.protondbCount || 0) + (r.pulseCount || 0);
-      const countStr = total > 0 ? `${total.toLocaleString()} reports` : '';
-      const store = storeLabel(r.appType || appTypeFromAppId(r.appId));
-      return `<a class="home-list-row" href="#/app/${r.appId}">
-        <span class="home-list-tier tier-badge tier-badge--${tier || 'pending'}">${tier || '?'}</span>
-        <span class="home-list-store game-card-store-pill game-card-store-pill--${store.toLowerCase()}">${store}</span>
-        <span class="home-list-title">${r.title || r.appId}</span>
-        <span class="home-list-meta">${[r.lastReportDate, countStr].filter(Boolean).join(' \u00b7 ')}</span>
-      </a>`;
-    }
+    // The previous super-condensed list-row renderer is gone -- the two
+    // layouts now are 'list' (horizontal cards from _recentCardHtml /
+    // popular item) and 'grid' (the same cards re-flowed into Steam-
+    // style vertical tiles by CSS via .home-cards-tile-mode).
 
     function _popularSectionLabel(sel) {
       if (!sel || sel.size === 0 || sel.has('all') || sel.has('steam')) return 'Popular on Steam';
@@ -364,10 +356,9 @@ export async function renderHomePage() {
       }
     }
 
-    // Render a popular game honoring the current view type: a slim list row in
-    // List mode (same as recent reports), or a sized card in Grid mode.
+    // Render a popular game as a card. Both layouts use the same markup;
+    // CSS reshapes it for the tile grid mode.
     function _popularItemHtml(g) {
-      if (currentLayout === 'list') return _listRowHtml(g);
       return renderGameCard({
         href: `#/app/${g.appId}`, appId: g.appId, imgUrl: g.headerImage || undefined,
         title: g.title,
@@ -390,7 +381,7 @@ export async function renderHomePage() {
       const sectionEl = document.getElementById('recent-section');
       const cardsEl = document.getElementById('cards-recent');
       const loadMoreEl = document.getElementById('load-more-recent');
-      const renderFn = currentLayout === 'list' ? _listRowHtml : _recentCardHtml;
+      const renderFn = _recentCardHtml;
       const queue = filtered.slice(PAGE_SIZE);
       const initial = filtered.slice(0, PAGE_SIZE);
       // Hide the whole recent section when empty so there's no blank state box.
@@ -559,19 +550,23 @@ export async function renderHomePage() {
       document.getElementById('home-size-toggle')?.classList.toggle('home-size-toggle--disabled', !enabled);
     }
 
-    // List/Grid is a saved user preference, like card size. Default grid.
+    // Layout: 'list' (horizontal cards, default) or 'grid' (Steam-style
+    // vertical tile grid). Both layouts use the same card markup; CSS
+    // reshapes the container into a tile grid for 'grid' mode. Shared
+    // storage key with the home page.
     const LAYOUT_KEY = 'pp:grid-layout';
     function _savedLayout() {
-      try { const l = localStorage.getItem(LAYOUT_KEY); return (l === 'list' || l === 'grid') ? l : 'grid'; } catch { return 'grid'; }
+      try { const l = localStorage.getItem(LAYOUT_KEY); return (l === 'list' || l === 'grid') ? l : 'list'; } catch { return 'list'; }
     }
     function applyLayout(layout) {
       currentLayout = layout;
-      const isList = layout === 'list';
+      const isTile = layout === 'grid';
       document.querySelectorAll('.home-layout-btn').forEach(b => b.classList.toggle('active', b.dataset.layout === layout));
-      // List view applies to BOTH sections so they stay consistent.
-      document.getElementById('cards-recent')?.classList.toggle('home-cards-list', isList);
-      document.getElementById('cards-popular')?.classList.toggle('home-cards-list', isList);
-      _setSizeEnabled(!isList);
+      document.getElementById('cards-recent')?.classList.toggle('home-cards-tile-mode', isTile);
+      document.getElementById('cards-popular')?.classList.toggle('home-cards-tile-mode', isTile);
+      // S/M/L/XL stay enabled in both modes -- in tile mode the size
+      // controls the column width, in list mode it controls row height.
+      _setSizeEnabled(true);
     }
     document.querySelectorAll('.home-layout-btn').forEach(btn => {
       btn.addEventListener('click', () => {

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -4,7 +4,7 @@ import { fetchRecentPulseReports } from '../api/reports.js?v=003f23c0';
 import { loadSearchIndex, searchIndex } from './search.js?v=28b593a1';
 import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '../config.js?v=df5b5024';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
-import { renderGameCard } from '../lib/card.js?v=373798af';
+import { renderGameCard } from '../lib/card.js?v=754da47b';
 import { dataUrl } from '../../lib/data-url.js?v=3c2e7ac9';
 
 const LOAD_COUNT_KEY = 'pp:load-count';
@@ -586,8 +586,11 @@ export async function renderHomePage() {
     // class to both card lists; default medium.
     const SIZE_KEY = 'pp:grid-size';
     const SIZES = ['sm', 'md', 'lg', 'xl'];
+    // Desktop has the room for larger cards, so the default steps up to 'lg'
+    // there; mobile stays on 'md' to keep more rows on screen.
+    const _DEFAULT_SIZE = window.matchMedia('(min-width: 760px)').matches ? 'lg' : 'md';
     function _savedSize() {
-      try { const s = localStorage.getItem(SIZE_KEY); return SIZES.includes(s) ? s : 'md'; } catch { return 'md'; }
+      try { const s = localStorage.getItem(SIZE_KEY); return SIZES.includes(s) ? s : _DEFAULT_SIZE; } catch { return _DEFAULT_SIZE; }
     }
     function applyGridSize(size) {
       ['cards-recent', 'cards-popular'].forEach(id => {

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -4,7 +4,7 @@ import { fetchRecentPulseReports } from '../api/reports.js?v=003f23c0';
 import { loadSearchIndex, searchIndex } from './search.js?v=28b593a1';
 import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '../config.js?v=df5b5024';
 import { daysAgo, latestPerApp } from '../utils.js?v=f5dda5b6';
-import { renderGameCard } from '../lib/card.js?v=20b34baa';
+import { renderGameCard } from '../lib/card.js?v=0ac206f6';
 import { dataUrl } from '../../lib/data-url.js?v=3c2e7ac9';
 
 const LOAD_COUNT_KEY = 'pp:load-count';

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -243,8 +243,8 @@ export async function renderHomePage() {
             <button class="home-size-btn home-size-btn--desktop-only" data-size="xl" type="button" title="Extra large cards">XL</button>
           </div>
           <div class="home-layout-toggle">
-            <button class="home-layout-btn active" data-layout="list" title="List of horizontal cards (default)">List</button>
-            <button class="home-layout-btn" data-layout="grid" title="Grid of Steam-style tiles">Grid</button>
+            <button class="home-layout-btn" data-layout="list" title="List of horizontal cards">List</button>
+            <button class="home-layout-btn active" data-layout="grid" title="Grid of Steam-style tiles (default)">Grid</button>
           </div>
         </div>
       </div>
@@ -556,7 +556,7 @@ export async function renderHomePage() {
     // storage key with the home page.
     const LAYOUT_KEY = 'pp:grid-layout';
     function _savedLayout() {
-      try { const l = localStorage.getItem(LAYOUT_KEY); return (l === 'list' || l === 'grid') ? l : 'list'; } catch { return 'list'; }
+      try { const l = localStorage.getItem(LAYOUT_KEY); return (l === 'list' || l === 'grid') ? l : 'grid'; } catch { return 'grid'; }
     }
     function applyLayout(layout) {
       currentLayout = layout;

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -5,7 +5,7 @@ import { getWebClientId } from '../../shared/submit.js?v=1a4ae53c';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
 import { renderAuthorBlock } from './author.js?v=2316d334';
 import { buildFormRows } from './config-cards.js?v=c67740f8';
-import { renderSignalStrip } from './signals.js?v=a918ea75';
+import { renderSignalStrip } from './signals.js?v=a23da3df';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=df5b5024';
 import { confColor, confTextColor, configKey, daysAgo, esc, fmtDuration, fmtMinutes, hashReportKey, reportKey } from '../utils.js?v=f5dda5b6';
 
@@ -49,8 +49,17 @@ export function renderCard(r, votes, userVotes = {}, configPlaytimeTotals = []) 
   // Source badge used to render top-right of each card (Pulse / ProtonDB).
   // Removed - the same info already appears in the "Source" row at the bottom
   // of the card, so two pills said the same thing and crowded the right column.
+  // Anchor id wraps the whole report (header card + summary body) so
+  // scrolling to a permalink lands on the top of the visible block, not
+  // partway through where the .card header used to carry the id. Header
+  // and body keep their existing classes/styling.
+  const _anchorId = (() => {
+    const id = r.reportId != null ? `r${r.reportId}` : (r.clientId ? `c${r.clientId.slice(0, 8)}` : '');
+    return id ? `report-${id}` : '';
+  })();
   return `
-    <div class="card" id="${(() => { const id = r.reportId != null ? `r${r.reportId}` : (r.clientId ? `c${r.clientId.slice(0, 8)}` : ''); return id ? `report-${id}` : ''; })()}">
+    <div class="report-block"${_anchorId ? ` id="${_anchorId}"` : ''}>
+    <div class="card">
       ${renderAuthorBlock(r)}
       <div class="card-body">
         <div class="proton">${esc(r.protonVersion || 'Unknown')}</div>
@@ -104,6 +113,7 @@ export function renderCard(r, votes, userVotes = {}, configPlaytimeTotals = []) 
         ${renderPermalink(r)}
         ${r.clientId && r.clientId === getWebClientId() ? `<button class="action-btn action-btn-danger delete-report-btn" data-app-id="${r.appId || ''}" title="Delete your report">Delete</button>` : ''}
       </div>
+    </div>
     </div>`;
 }
 

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -5,7 +5,7 @@ import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../ap
 import { renderGamePage } from './game-page.js?v=8c173ecc';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
-import { renderGameCard } from '../lib/card.js?v=0ac206f6';
+import { renderGameCard } from '../lib/card.js?v=373798af';
 import { dataUrl } from '../../lib/data-url.js?v=3c2e7ac9';
 
 // Search index + results UX -- factored out of app.js.

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -5,7 +5,7 @@ import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../ap
 import { renderGamePage } from './game-page.js?v=d79ce4b8';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
-import { renderGameCard } from '../lib/card.js?v=373798af';
+import { renderGameCard } from '../lib/card.js?v=754da47b';
 import { dataUrl } from '../../lib/data-url.js?v=3c2e7ac9';
 
 // Search index + results UX -- factored out of app.js.

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=003f23c0';
-import { renderGamePage } from './game-page.js?v=8c173ecc';
+import { renderGamePage } from './game-page.js?v=d79ce4b8';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
 import { renderGameCard } from '../lib/card.js?v=373798af';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -5,7 +5,7 @@ import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../ap
 import { renderGamePage } from './game-page.js?v=8c173ecc';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=f5dda5b6';
-import { renderGameCard } from '../lib/card.js?v=20b34baa';
+import { renderGameCard } from '../lib/card.js?v=0ac206f6';
 import { dataUrl } from '../../lib/data-url.js?v=3c2e7ac9';
 
 // Search index + results UX -- factored out of app.js.

--- a/js/app/components/signals.js
+++ b/js/app/components/signals.js
@@ -94,8 +94,11 @@ export function renderSignalStrip(r) {
         neutralLabel: (r.source || '').toLowerCase() === 'protondb'
           ? 'Anonymous report - cannot be verified'
           : 'Not confirmed' }),
+    // Framegen flips the usual yes=good convention: "yes, required" means the
+    // game can't hold a frame rate on its own (bad), "no, not required" means
+    // it runs smoothly without help (good). Matches how the user reads it.
     renderSignalIcon('framegen', fr.requiresFramegen, 'Framegen required for smooth play',
-      { positiveState: 'warn', neutralLabel: formNeutral }),
+      { positiveState: 'bad', negativeState: 'good', neutralLabel: formNeutral }),
   ].filter(Boolean);
   return `<div class="signal-strip">${icons.join('')}</div>`;
 }

--- a/js/app/lib/card.js
+++ b/js/app/lib/card.js
@@ -72,7 +72,14 @@ export function renderGameCard({ href, appId, title, sub, tier, badge, badgeBg, 
     : '';
   const stripHtml = `<div class="game-card-strip" data-tier="${esc(stripTier)}" data-store="${storeKey}"><span class="game-card-strip-tier">${esc(stripLabel)}</span>${storePillHtml}${stripStoreHtml}</div>`;
 
+  // Card-level corner tag for the 'art-corner' placement. Direct child of
+  // <a class="game-card"> so absolute positioning anchors to the card's
+  // top-right edge (not just the thumbnail). Hidden by default; shown when
+  // data-store-pill-pos="art-corner".
+  const cornerTagHtml = storePill
+    ? `<span class="game-card-corner-tag game-card-store-pill--${storeKey}"><span class="store-text">${esc(storePill)}</span>${storeIcon}</span>`
+    : '';
   // Strip is a sibling of the row (not inside the body) so it can extend
   // the full card width including under the thumbnail when strip mode is on.
-  return `<a class="game-card" href="${href}"><div class="game-card-row">${thumbHtml}<div class="game-card-body"><div class="game-card-title">${esc(title)}</div><div class="game-card-sub">${sub}</div></div>${rightHtml}</div>${stripHtml}</a>`;
+  return `<a class="game-card" href="${href}">${cornerTagHtml}<div class="game-card-row">${thumbHtml}<div class="game-card-body"><div class="game-card-title">${esc(title)}</div><div class="game-card-sub">${sub}</div></div>${rightHtml}</div>${stripHtml}</a>`;
 }

--- a/js/app/lib/card.js
+++ b/js/app/lib/card.js
@@ -79,7 +79,16 @@ export function renderGameCard({ href, appId, title, sub, tier, badge, badgeBg, 
   const cornerTagHtml = storePill
     ? `<span class="game-card-corner-tag game-card-store-pill--${storeKey}"><span class="store-text">${esc(storePill)}</span>${storeIcon}</span>`
     : '';
+  // Combined corner chip for the 'combo' card layout. Two-tone pill at the
+  // top-right edge of the card with the tier on the left and the store on
+  // the right. CSS picks per-tier and per-store colors via data-* attrs.
+  // Hidden unless data-card-layout="combo" is set on <html>.
+  const comboTier = tier ? String(tier).toLowerCase() : '';
+  const comboTierLabel = tier ? tier.toUpperCase() : (badge || 'NO RATING');
+  const comboTagHtml = (storePill || tier || badge)
+    ? `<span class="game-card-combo-tag" data-tier="${esc(comboTier)}" data-store="${storeKey}"><span class="combo-tier">${esc(comboTierLabel)}</span>${storePill ? `<span class="combo-store">${esc(storePill)}</span>` : ''}</span>`
+    : '';
   // Strip is a sibling of the row (not inside the body) so it can extend
   // the full card width including under the thumbnail when strip mode is on.
-  return `<a class="game-card" href="${href}">${cornerTagHtml}<div class="game-card-row">${thumbHtml}<div class="game-card-body"><div class="game-card-title">${esc(title)}</div><div class="game-card-sub">${sub}</div></div>${rightHtml}</div>${stripHtml}</a>`;
+  return `<a class="game-card" href="${href}">${cornerTagHtml}${comboTagHtml}<div class="game-card-row">${thumbHtml}<div class="game-card-body"><div class="game-card-title">${esc(title)}</div><div class="game-card-sub">${sub}</div></div>${rightHtml}</div>${stripHtml}</a>`;
 }

--- a/js/app/lib/card.js
+++ b/js/app/lib/card.js
@@ -29,8 +29,13 @@ export function renderGameCard({ href, appId, title, sub, tier, badge, badgeBg, 
   // Both positions are rendered; CSS (driven by data-store-pill-pos on <html>)
   // shows one and hides the other based on the site preference.
   const storeKey = storePill ? esc(String(storePill).toLowerCase()) : '';
+  const storeIcon = storeKey === 'steam' || storeKey === 'gog' || storeKey === 'epic'
+    ? `<span class="store-icon store-icon--${storeKey}" title="${esc(storePill)}" aria-label="${esc(storePill)}"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="#icon-store-${storeKey}"/></svg></span>`
+    : '';
+  // Both the text pill (game-card-store-tag) and the round icon are rendered
+  // so CSS can pick which the user prefers via data-store-display on <html>.
   const storeTag = storePill
-    ? `<span class="game-card-store-tag game-card-store-pill--${storeKey}">${esc(storePill)}</span>`
+    ? `<span class="game-card-store-tag game-card-store-pill--${storeKey}"><span class="store-text">${esc(storePill)}</span>${storeIcon}</span>`
     : '';
   const thumbHtml = `<div class="game-card-thumb-wrap">${thumbInner}${storeTag}</div>`;
 
@@ -45,7 +50,7 @@ export function renderGameCard({ href, appId, title, sub, tier, badge, badgeBg, 
   }
   const badgeHtml = `<span class="game-card-badge${isNoRating ? ' game-card-badge--unrated' : ''}" ${badgeStyle}>${esc(label)}</span>`;
   const storePillHtml = storePill
-    ? `<span class="game-card-store-pill game-card-store-pill--${storeKey}">${esc(storePill)}</span>`
+    ? `<span class="game-card-store-pill game-card-store-pill--${storeKey}"><span class="store-text">${esc(storePill)}</span>${storeIcon}</span>`
     : '';
   const pillsRowHtml = `<div class="game-card-pills">${badgeHtml}${storePillHtml}</div>`;
   const sourceLabelHtml = sourceLabel
@@ -58,7 +63,14 @@ export function renderGameCard({ href, appId, title, sub, tier, badge, badgeBg, 
   // <html> flips it in for both visibility and the right-column hide.
   const stripTier = tier ? String(tier).toLowerCase() : '';
   const stripLabel = tier ? tier.toUpperCase() : 'NO RATING';
-  const stripHtml = `<div class="game-card-strip" data-tier="${esc(stripTier)}"><span class="game-card-strip-tier">${esc(stripLabel)}</span>${storePillHtml}</div>`;
+  // Store segment inside the strip. CSS hides it by default and reveals it
+  // when data-store-pill-pos is 'bar-right' (chip on the trailing edge) or
+  // 'bar-segment' (last 1/4 of the bar in the store color, two-tone with
+  // the tier).
+  const stripStoreHtml = storePill
+    ? `<span class="game-card-strip-store store-icon store-icon--${storeKey}"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="#icon-store-${storeKey}"/></svg><span class="store-text">${esc(storePill)}</span></span>`
+    : '';
+  const stripHtml = `<div class="game-card-strip" data-tier="${esc(stripTier)}" data-store="${storeKey}"><span class="game-card-strip-tier">${esc(stripLabel)}</span>${storePillHtml}${stripStoreHtml}</div>`;
 
   // Strip is a sibling of the row (not inside the body) so it can extend
   // the full card width including under the thumbnail when strip mode is on.

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,7 +1,7 @@
 // router (entry) for the app page. Relocated from app.js.
 
 import { renderGamePage } from './components/game-page.js?v=d79ce4b8';
-import { renderHomePage } from './components/home.js?v=e2796a09';
+import { renderHomePage } from './components/home.js?v=8509167b';
 import { renderSearchPage } from './components/search.js?v=28b593a1';
 
 export function getRoute() {

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,7 +1,7 @@
 // router (entry) for the app page. Relocated from app.js.
 
 import { renderGamePage } from './components/game-page.js?v=d79ce4b8';
-import { renderHomePage } from './components/home.js?v=8509167b';
+import { renderHomePage } from './components/home.js?v=ccddf3fe';
 import { renderSearchPage } from './components/search.js?v=28b593a1';
 
 export function getRoute() {

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,7 +1,7 @@
 // router (entry) for the app page. Relocated from app.js.
 
 import { renderGamePage } from './components/game-page.js?v=d79ce4b8';
-import { renderHomePage } from './components/home.js?v=ccddf3fe';
+import { renderHomePage } from './components/home.js?v=68af2471';
 import { renderSearchPage } from './components/search.js?v=28b593a1';
 
 export function getRoute() {

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,6 +1,6 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=8c173ecc';
+import { renderGamePage } from './components/game-page.js?v=d79ce4b8';
 import { renderHomePage } from './components/home.js?v=e2796a09';
 import { renderSearchPage } from './components/search.js?v=28b593a1';
 

--- a/js/index/main.js
+++ b/js/index/main.js
@@ -102,6 +102,17 @@ import { dataUrl } from '../lib/data-url.js?v=3c2e7ac9';
     const label = STORE_LABEL[t] || 'Steam';
     return `<span class="pg-card-strip-store game-card-strip-store store-icon store-icon--${t}"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="#icon-store-${t}"/></svg><span class="store-text">${label}</span></span>`;
   }
+  // Two-tone combined corner chip for the 'combo' card layout. Tier on the
+  // left, store on the right, both colored. CSS hides this unless
+  // data-card-layout="combo" is set on <html>.
+  function comboTag(rating, appType) {
+    const t = appType || 'steam';
+    const storeLabel = STORE_LABEL[t] || 'Steam';
+    const rated = KNOWN_TIERS.has(rating);
+    const tier = rated ? rating : '';
+    const tierLabel = rated ? RATING_LABEL[rating].toUpperCase() : 'NO RATING';
+    return `<span class="pg-card-combo-tag game-card-combo-tag" data-tier="${tier}" data-store="${t}"><span class="combo-tier">${tierLabel}</span><span class="combo-store">${storeLabel}</span></span>`;
+  }
   const SECTION_LABEL = { steam: 'Popular on Steam', gog: 'Popular GOG Games', epic: 'Popular Epic Games' };
   const SECTION_SUB = {
     steam: "Steam's most-played games and how they run on Linux through Proton.",
@@ -143,6 +154,7 @@ import { dataUrl } from '../lib/data-url.js?v=3c2e7ac9';
     return `
       <a class="pg-card" href="app.html#/app/${encodeURIComponent(g.appId)}">
         ${cornerTag(g.appType)}
+        ${comboTag(rating, g.appType)}
         <div class="pg-card-row">
           <div class="pg-thumb-wrap">
             <img class="pg-thumb" src="${img}" data-appid="${g.appId}" alt="" loading="lazy" onerror="window.__steamImgLoad(this)">
@@ -377,8 +389,11 @@ import { dataUrl } from '../lib/data-url.js?v=3c2e7ac9';
     // S/M/L card size (saved preference, shared key with app page)
     const SIZE_KEY = 'pp:grid-size';
     const SIZES = ['sm', 'md', 'lg', 'xl'];
+    // Default 'lg' on desktop so wider viewports get roomier cards by default;
+    // mobile stays on 'md' to keep more rows on screen.
+    const DEFAULT_SIZE = window.matchMedia('(min-width: 760px)').matches ? 'lg' : 'md';
     function savedSize() {
-      try { const s = localStorage.getItem(SIZE_KEY); return SIZES.includes(s) ? s : 'md'; } catch { return 'md'; }
+      try { const s = localStorage.getItem(SIZE_KEY); return SIZES.includes(s) ? s : DEFAULT_SIZE; } catch { return DEFAULT_SIZE; }
     }
     function applySize(size) {
       SIZES.forEach(s => list.classList.remove(`pg-list--${s}`));

--- a/js/index/main.js
+++ b/js/index/main.js
@@ -139,7 +139,6 @@ import { dataUrl } from '../lib/data-url.js?v=3c2e7ac9';
   }
 
   function pgCardHtml(g) {
-    if (currentLayout === 'list') return pgListRowHtml(g);
     const img = `https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/${encodeURIComponent(g.appId)}/header.jpg`;
     const peak = fmtPeak(g.peak);
     const rating = String(g.rating || '').toLowerCase();
@@ -177,17 +176,9 @@ import { dataUrl } from '../lib/data-url.js?v=3c2e7ac9';
       </a>`;
   }
 
-  function pgListRowHtml(g) {
-    const rating = String(g.rating || '').toLowerCase();
-    const rated = KNOWN_TIERS.has(rating);
-    const rLabel = rated ? RATING_LABEL[rating] : '?';
-    const peak = fmtPeak(g.peak);
-    return `<a class="pg-list-row" href="app.html#/app/${encodeURIComponent(g.appId)}">
-      <span class="pg-list-tier pg-badge ${rated ? `pg-${rating}` : 'pg-unrated'}">${rLabel}</span>
-      <span class="pg-list-title">${esc(g.title)}</span>
-      <span class="pg-list-meta">${storePill(g.appType)}${peak ? ' ' + peak + ' peak' : ''}</span>
-    </a>`;
-  }
+  // The previous super-condensed pgListRowHtml is gone -- the two layouts
+  // now are 'list' (horizontal cards from pgCardHtml) and 'grid' (the same
+  // cards re-flowed into Steam-style vertical tiles by CSS).
 
   try {
     const resp = await fetch(await dataUrl('most_played.json'));
@@ -411,17 +402,20 @@ import { dataUrl } from '../lib/data-url.js?v=3c2e7ac9';
       });
     });
 
-    // Grid/List layout (saved preference, shared key with app page)
+    // Layout: 'list' (horizontal cards, the new default) or 'grid'
+    // (Steam-style vertical tile grid). Both layouts use the same card
+    // markup; CSS reshapes them. Storage key is shared with the app page.
     const LAYOUT_KEY = 'pp:grid-layout';
     function savedLayout() {
-      try { const l = localStorage.getItem(LAYOUT_KEY); return (l === 'list' || l === 'grid') ? l : 'grid'; } catch { return 'grid'; }
+      try { const l = localStorage.getItem(LAYOUT_KEY); return (l === 'list' || l === 'grid') ? l : 'list'; } catch { return 'list'; }
     }
     function applyLayout(layout) {
       currentLayout = layout;
-      const isList = layout === 'list';
-      list.classList.toggle('pg-list--list-mode', isList);
+      list.classList.toggle('pg-list--tile-mode', layout === 'grid');
       document.querySelectorAll('.pg-layout-btn').forEach(b => b.classList.toggle('active', b.dataset.layout === layout));
-      setSizeEnabled(!isList);
+      // S/M/L/XL sizing stays available in both layouts now -- it controls
+      // tile column width in grid mode.
+      setSizeEnabled(true);
       renderPopular();
     }
     document.querySelectorAll('.pg-layout-btn').forEach(btn => {

--- a/js/index/main.js
+++ b/js/index/main.js
@@ -86,6 +86,15 @@ import { dataUrl } from '../lib/data-url.js?v=3c2e7ac9';
     const cls = storeColorClass(t);
     return `<span class="game-card-store-tag ${cls}"><span class="store-text">${label}</span>${storeIconHtml(t, label)}</span>`;
   }
+  // Card-level corner piece for the 'art-corner' placement. Rendered as a
+  // direct child of <a class="pg-card"> so it anchors to the whole card's
+  // top-right edge instead of the thumbnail.
+  function cornerTag(appType) {
+    const t = appType || 'steam';
+    const label = STORE_LABEL[t] || 'Steam';
+    const cls = storeColorClass(t);
+    return `<span class="pg-card-corner-tag game-card-corner-tag ${cls}"><span class="store-text">${label}</span>${storeIconHtml(t, label)}</span>`;
+  }
   // Store segment that sits inside the bottom-bar strip. CSS controls
   // visibility based on data-store-pill-pos (bar-right / bar-segment).
   function stripStoreHtml(appType) {
@@ -133,6 +142,7 @@ import { dataUrl } from '../lib/data-url.js?v=3c2e7ac9';
     const stripLabel = rated ? RATING_LABEL[rating].toUpperCase() : 'NO RATING';
     return `
       <a class="pg-card" href="app.html#/app/${encodeURIComponent(g.appId)}">
+        ${cornerTag(g.appType)}
         <div class="pg-card-row">
           <div class="pg-thumb-wrap">
             <img class="pg-thumb" src="${img}" data-appid="${g.appId}" alt="" loading="lazy" onerror="window.__steamImgLoad(this)">

--- a/js/index/main.js
+++ b/js/index/main.js
@@ -407,7 +407,7 @@ import { dataUrl } from '../lib/data-url.js?v=3c2e7ac9';
     // markup; CSS reshapes them. Storage key is shared with the app page.
     const LAYOUT_KEY = 'pp:grid-layout';
     function savedLayout() {
-      try { const l = localStorage.getItem(LAYOUT_KEY); return (l === 'list' || l === 'grid') ? l : 'list'; } catch { return 'list'; }
+      try { const l = localStorage.getItem(LAYOUT_KEY); return (l === 'list' || l === 'grid') ? l : 'grid'; } catch { return 'grid'; }
     }
     function applyLayout(layout) {
       currentLayout = layout;

--- a/js/index/main.js
+++ b/js/index/main.js
@@ -67,17 +67,31 @@ import { dataUrl } from '../lib/data-url.js?v=3c2e7ac9';
     const t = appType || 'steam';
     return STORE_PILL_CLASS[t] || 'game-card-store-pill--steam';
   }
+  // The store badge renders both a text label and an icon every time. CSS on
+  // <html data-store-display="icon"> hides .store-text and shows .store-icon
+  // so the user pref can swap between the two without re-rendering cards.
+  function storeIconHtml(t, label) {
+    if (t !== 'steam' && t !== 'gog' && t !== 'epic') return '';
+    return `<span class="store-icon store-icon--${t}" title="${label}" aria-label="${label}"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="#icon-store-${t}"/></svg></span>`;
+  }
   function storePill(appType) {
     const t = appType || 'steam';
     const label = STORE_LABEL[t] || 'Steam';
     const cls = storeColorClass(t);
-    return `<span class="game-card-store-pill ${cls}">${label}</span>`;
+    return `<span class="game-card-store-pill ${cls}"><span class="store-text">${label}</span>${storeIconHtml(t, label)}</span>`;
   }
   function storeTag(appType) {
     const t = appType || 'steam';
     const label = STORE_LABEL[t] || 'Steam';
     const cls = storeColorClass(t);
-    return `<span class="game-card-store-tag ${cls}">${label}</span>`;
+    return `<span class="game-card-store-tag ${cls}"><span class="store-text">${label}</span>${storeIconHtml(t, label)}</span>`;
+  }
+  // Store segment that sits inside the bottom-bar strip. CSS controls
+  // visibility based on data-store-pill-pos (bar-right / bar-segment).
+  function stripStoreHtml(appType) {
+    const t = appType || 'steam';
+    const label = STORE_LABEL[t] || 'Steam';
+    return `<span class="pg-card-strip-store game-card-strip-store store-icon store-icon--${t}"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="#icon-store-${t}"/></svg><span class="store-text">${label}</span></span>`;
   }
   const SECTION_LABEL = { steam: 'Popular on Steam', gog: 'Popular GOG Games', epic: 'Popular Epic Games' };
   const SECTION_SUB = {
@@ -133,9 +147,10 @@ import { dataUrl } from '../lib/data-url.js?v=3c2e7ac9';
             ${storePill(g.appType)}
           </div>
         </div>
-        <div class="pg-card-strip" data-tier="${stripTier}">
+        <div class="pg-card-strip" data-tier="${stripTier}" data-store="${g.appType || 'steam'}">
           <span class="pg-card-strip-tier">${stripLabel}</span>
           ${storePill(g.appType)}
+          ${stripStoreHtml(g.appType)}
         </div>
       </a>`;
   }

--- a/js/index/main.js
+++ b/js/index/main.js
@@ -161,7 +161,7 @@ import { dataUrl } from '../lib/data-url.js?v=3c2e7ac9';
           </div>
           <div class="pg-info">
             <div class="pg-title">${esc(g.title)}</div>
-            ${peak ? `<div class="pg-sub">${peak} peak players</div>` : ''}
+            ${peak ? `<div class="pg-sub"><span class="pg-sub-count">${peak}</span><span class="pg-sub-suffix"> peak players</span></div>` : ''}
           </div>
           <div class="pg-right">
             <span class="pg-badge ${badgeClass}">${rLabel}</span>

--- a/js/lib/topbar.js
+++ b/js/lib/topbar.js
@@ -387,14 +387,16 @@
   // (avoids a flash of the wrong mode / running animations).
   initTheme();
   initMotion();
-  // Store pill position preference: 'art' = thumbnail overlay, 'right' (default) = rating column.
-  // Store badge placement: 'art' (overlay on thumbnail), 'right' (default
-   // pill column), 'bar-right' (sits at the trailing edge of the bottom-bar
-   // strip), 'bar-segment' (last quarter of the bottom-bar strip in store
-   // color, two-tone with the tier). The bar-* values only paint when
-   // data-card-layout="strip" is also set; they fall back to 'right'
-   // otherwise (no visual change). */
-  const storePillPos = localStorage.getItem('pp:store-pill-pos');
+  // Store badge placement: 'art' (overlay on thumbnail), 'right' (default,
+  // pill column), 'bar-segment' (the bottom-bar strip splits, last 1/4 in
+  // the store color). bar-segment only paints when data-card-layout="strip"
+  // is also set; otherwise it falls back to the default column placement.
+  // Migrate the dropped 'bar-right' chip value to 'bar-segment'.
+  let storePillPos = localStorage.getItem('pp:store-pill-pos');
+  if (storePillPos === 'bar-right') {
+    storePillPos = 'bar-segment';
+    localStorage.setItem('pp:store-pill-pos', 'bar-segment');
+  }
   if (storePillPos && storePillPos !== 'right') {
     document.documentElement.setAttribute('data-store-pill-pos', storePillPos);
   }

--- a/js/lib/topbar.js
+++ b/js/lib/topbar.js
@@ -390,11 +390,11 @@
   // (avoids a flash of the wrong mode / running animations).
   initTheme();
   initMotion();
-  // Defaults differ by viewport. Mobile loses too much width to a corner
-  // tag, so the bar-inline badge next to the rating reads better; desktop
-  // has plenty of room for an art-corner tag + a full text label, which
-  // is more skim-friendly when scanning a dense grid. User picks override
-  // both defaults via the options page.
+  // Defaults: store badge sits in the bar (bar-inline) on mobile, in the
+  // card corner (art-corner) on desktop. Both viewports default to the
+  // text label until the round brand glyphs read consistently across
+  // stores. Mobile picks bar-inline because the card-corner tag steals
+  // useful width from the title row at narrow screens.
   const _isDesktop = window.matchMedia('(min-width: 760px)').matches;
 
   // Store badge placement. Other values: 'right' (legacy column), 'art'
@@ -422,10 +422,10 @@
   if (cardLayoutPref === 'strip' || cardLayoutPref === 'combo') {
     document.documentElement.setAttribute('data-card-layout', cardLayoutPref);
   }
-  // Store badge display. Default depends on viewport: 'icon' on mobile
-  // (saves space next to the rating), 'text' on desktop (room for the
-  // full STEAM/GOG/EPIC label, easier to scan).
-  const storeDisplayPref = localStorage.getItem('pp:store-display') || (_isDesktop ? 'text' : 'icon');
+  // Store badge display. Default is 'text' on both viewports until the
+  // round brand glyphs read consistently at small sizes; 'icon' is still
+  // available as an opt-in for users who want the compact look.
+  const storeDisplayPref = localStorage.getItem('pp:store-display') || 'text';
   if (storeDisplayPref === 'icon') {
     document.documentElement.setAttribute('data-store-display', 'icon');
   }

--- a/js/lib/topbar.js
+++ b/js/lib/topbar.js
@@ -416,10 +416,11 @@
   }
   // Card layout preference. Default is 'strip' on both viewports (tier in
   // a colored bar across the full bottom of the card). 'right' falls back
-  // to the column pill.
+  // to the column pill; 'combo' shows the tier + store as a two-tone
+  // corner chip and hides the strip / right column entirely.
   const cardLayoutPref = localStorage.getItem('pp:card-layout') || 'strip';
-  if (cardLayoutPref === 'strip') {
-    document.documentElement.setAttribute('data-card-layout', 'strip');
+  if (cardLayoutPref === 'strip' || cardLayoutPref === 'combo') {
+    document.documentElement.setAttribute('data-card-layout', cardLayoutPref);
   }
   // Store badge display. Default depends on viewport: 'icon' on mobile
   // (saves space next to the rating), 'text' on desktop (room for the

--- a/js/lib/topbar.js
+++ b/js/lib/topbar.js
@@ -391,11 +391,15 @@
   // pill column), 'bar-segment' (the bottom-bar strip splits, last 1/4 in
   // the store color). bar-segment only paints when data-card-layout="strip"
   // is also set; otherwise it falls back to the default column placement.
-  // Migrate the dropped 'bar-right' chip value to 'bar-segment'.
+  // Migrations: dropped 'bar-right' -> 'bar-segment'; renamed 'bar-icon'
+  // -> 'bar-inline' once it started honoring the store-display pref.
   let storePillPos = localStorage.getItem('pp:store-pill-pos');
   if (storePillPos === 'bar-right') {
     storePillPos = 'bar-segment';
     localStorage.setItem('pp:store-pill-pos', 'bar-segment');
+  } else if (storePillPos === 'bar-icon') {
+    storePillPos = 'bar-inline';
+    localStorage.setItem('pp:store-pill-pos', 'bar-inline');
   }
   if (storePillPos && storePillPos !== 'right') {
     document.documentElement.setAttribute('data-store-pill-pos', storePillPos);

--- a/js/lib/topbar.js
+++ b/js/lib/topbar.js
@@ -760,15 +760,6 @@
         const safe = display.replace(/[<>&]/g, function (c) {
           return { '<': '&lt;', '>': '&gt;', '&': '&amp;' }[c];
         });
-        // Build the counts subline only if either count is present; older
-        // search-index.json deployments without these fields render the old
-        // way (no subline, no tier badge)
-        const counts = [];
-        if (r.protondbCount) counts.push(r.protondbCount + ' ProtonDB');
-        if (r.pulseCount) counts.push(r.pulseCount + ' Pulse');
-        const countsHtml = counts.length
-          ? '<span class="sd-counts">' + counts.join(' + ') + '</span>'
-          : '';
         const idStr = String(r.appId);
         const inferredStore = r.appType
           ? r.appType
@@ -778,10 +769,10 @@
         const storeLabel = inferredStore === 'gog' ? 'GOG'
                          : inferredStore === 'epic' ? 'Epic'
                          : 'Steam';
-        // Single split chip on the right edge that mirrors the .game-card
-        // combined corner chip (tier color on the left, store color on the
-        // right). App id moves to the left of the title so the right edge
-        // belongs entirely to the chip.
+        // Split chip on the trailing edge that mirrors the .game-card combo
+        // corner chip (tier color on the left, store color on the right).
+        // The app id is the row-two subline (replacing the old report-count
+        // line) so the thumbnail flows straight into the title.
         const tierAttr = r.tier ? r.tier.toLowerCase() : '';
         const tierLabel = r.tier ? r.tier.toUpperCase() : 'NO RATING';
         const comboHtml = '<span class="sd-combo" data-tier="' + tierAttr + '" data-store="' + inferredStore + '">' +
@@ -791,10 +782,9 @@
         return '<a href="app.html#/app/' + r.appId + '" role="option" data-idx="' + idx + '">' +
                '<img loading="lazy" data-appid="' + r.appId + '" src="' + steamHeader(r.appId) + '" alt="" ' +
                  'onerror="window.__steamImgLoad && window.__steamImgLoad(this)">' +
-               '<span class="sd-appid sd-appid--left" title="' + idStr + '">' + idStr + '</span>' +
                '<span class="sd-meta">' +
                  '<span class="sd-title">' + safe + '</span>' +
-                 countsHtml +
+                 '<span class="sd-appid" title="' + idStr + '">' + idStr + '</span>' +
                '</span>' +
                comboHtml +
                '</a>';

--- a/js/lib/topbar.js
+++ b/js/lib/topbar.js
@@ -58,20 +58,28 @@
       <circle cx="9.5" cy="11.5" r="1.2" fill="currentColor" stroke="none"/>
       <circle cx="14.5" cy="11.5" r="1.2" fill="currentColor" stroke="none"/>
     </symbol>
-    <!-- Round store glyphs for the "store badge: icon" preference. Each is a
-         filled circle in the brand color with a white monogram on top. SVG
-         viewBox 0 0 24 24, used inline via <use href="#icon-store-..."/>. -->
+    <!-- Round store glyphs for the "store badge: icon" preference. Filled
+         circle in the brand color with the brand glyph centered on top.
+         Glyph paths are the simpleicons.org SVG paths (24x24 viewBox)
+         scaled into a 16x16 area centered at (4,4) so they sit cleanly
+         inside the colored circle. -->
     <symbol id="icon-store-steam" viewBox="0 0 24 24">
       <circle cx="12" cy="12" r="12" fill="#1689d0"/>
-      <text x="12" y="17" text-anchor="middle" font-family="-apple-system, sans-serif" font-weight="800" font-size="15" fill="#fff">S</text>
+      <g transform="translate(4 4) scale(0.667)" fill="#fff">
+        <path d="M11.979 0C5.678 0 .511 4.86.022 11.037l6.432 2.658a3.37 3.37 0 011.912-.59c.063 0 .125.004.188.006l2.861-4.142V8.91c0-2.495 2.028-4.524 4.524-4.524 2.494 0 4.524 2.031 4.524 4.527s-2.03 4.525-4.524 4.525h-.105l-4.076 2.911c0 .052.004.105.004.159 0 1.875-1.515 3.396-3.39 3.396-1.635 0-3.016-1.173-3.331-2.727L.436 15.27C1.862 20.307 6.486 24 11.979 24c6.627 0 11.999-5.373 11.999-12S18.605 0 11.979 0zM7.54 18.21l-1.473-.61a2.563 2.563 0 001.314 1.25 2.557 2.557 0 003.337-1.375 2.534 2.534 0 00-1.373-3.331 2.567 2.567 0 00-1.878-.03l1.523.63a1.885 1.885 0 011.013 2.455 1.892 1.892 0 01-2.463 1.011zm11.415-9.301a3.014 3.014 0 00-3.015-3.014 3.013 3.013 0 100 6.027 3.013 3.013 0 003.015-3.013zm-5.273-.004a2.26 2.26 0 014.521 0 2.26 2.26 0 01-4.521 0z"/>
+      </g>
     </symbol>
     <symbol id="icon-store-gog" viewBox="0 0 24 24">
       <circle cx="12" cy="12" r="12" fill="#7a3fcf"/>
-      <text x="12" y="17" text-anchor="middle" font-family="-apple-system, sans-serif" font-weight="800" font-size="15" fill="#fff">G</text>
+      <g transform="translate(4 4) scale(0.667)" fill="#fff">
+        <path d="M5.866 2.064C2.63 2.064 0 4.696 0 7.93v8.142c0 3.234 2.63 5.864 5.866 5.864h12.27c3.234 0 5.864-2.63 5.864-5.864V7.93c0-3.234-2.63-5.866-5.864-5.866H5.866zm-.16 2.97h2.756c1.07 0 1.937.867 1.937 1.935V13.4c0 1.07-.867 1.937-1.937 1.937h-.812V13.4h.812V7H5.706v6.4h1.94v3.42H5.706c-1.07 0-1.94-.866-1.94-1.937V6.969c0-1.068.87-1.935 1.94-1.935zm6.66 0h2.756c1.069 0 1.937.867 1.937 1.935V13.4c0 1.07-.868 1.937-1.937 1.937h-2.755c-1.071 0-1.94-.866-1.94-1.937V6.969c0-1.068.869-1.935 1.94-1.935zm.812 1.965v6.4h1.13V7h-1.13zm5.92 0h2.756v1.93H20.07v6.402h1.939V11.4h-1.124V9.467h3.063v5.87c0 1.071-.86 1.938-1.93 1.938H19.1c-1.071 0-1.94-.867-1.94-1.937V6.969c0-1.068.869-1.935 1.94-1.935z"/>
+      </g>
     </symbol>
     <symbol id="icon-store-epic" viewBox="0 0 24 24">
       <circle cx="12" cy="12" r="12" fill="#2a2a2a"/>
-      <text x="12" y="17" text-anchor="middle" font-family="-apple-system, sans-serif" font-weight="800" font-size="15" fill="#fff">E</text>
+      <g transform="translate(4 4) scale(0.667)" fill="#fff">
+        <path d="M3.537 0C2.165 0 1.66.506 1.66 1.879v15.732c0 .28 0 .43.018.604 0 .078 0 .15.05.224.07.36.279.434.836.633l4.853 1.92c.726.279 1.024.4 1.301.4.28 0 .555-.121 1.305-.4l4.846-1.92c.563-.198.78-.273.836-.633a.92.92 0 0 0 .05-.224 5.72 5.72 0 0 0 .022-.604V1.882c0-1.373-.512-1.879-1.881-1.879H3.537zm14.92 4.715h.961v8.519h-.961V4.715zM6.057 4.978h2.16c.781 0 1.198.42 1.198 1.205v3.9c0 .785-.417 1.205-1.198 1.205h-1.05v3.064h-1.11V4.978zm5.41 0h2.745v.985h-1.635v8.39h-1.11V4.978zm-4.3.985v3.34h.844c.26 0 .346-.103.346-.366V6.328c0-.262-.085-.365-.346-.365h-.844z"/>
+      </g>
     </symbol>
   </defs>
 </svg>`;

--- a/js/lib/topbar.js
+++ b/js/lib/topbar.js
@@ -387,10 +387,10 @@
   // (avoids a flash of the wrong mode / running animations).
   initTheme();
   initMotion();
-  // Store badge placement: 'art' (overlay on thumbnail), 'right' (default,
-  // pill column), 'bar-segment' (the bottom-bar strip splits, last 1/4 in
-  // the store color). bar-segment only paints when data-card-layout="strip"
-  // is also set; otherwise it falls back to the default column placement.
+  // Store badge placement. Default is 'bar-inline' (paired with the strip
+  // card layout, the store sits flush right of the tier label as a brand
+  // pill or icon). Other values: 'right' (legacy column), 'art' (thumbnail
+  // overlay), 'art-corner' (card top-right), 'bar-segment' (split strip).
   // Migrations: dropped 'bar-right' -> 'bar-segment'; renamed 'bar-icon'
   // -> 'bar-inline' once it started honoring the store-display pref.
   let storePillPos = localStorage.getItem('pp:store-pill-pos');
@@ -401,17 +401,21 @@
     storePillPos = 'bar-inline';
     localStorage.setItem('pp:store-pill-pos', 'bar-inline');
   }
-  if (storePillPos && storePillPos !== 'right') {
+  if (!storePillPos) storePillPos = 'bar-inline';
+  if (storePillPos !== 'right') {
     document.documentElement.setAttribute('data-store-pill-pos', storePillPos);
   }
-  // Card layout preference: 'strip' = rating row under title (more title width
-  // on mobile), default = rating pill in right column.
-  if (localStorage.getItem('pp:card-layout') === 'strip') {
+  // Card layout preference. Default is 'strip' (tier in a colored bar across
+  // the full bottom of the card -- better on mobile because the title row
+  // gets the full card width). 'right' falls back to the column pill.
+  const cardLayoutPref = localStorage.getItem('pp:card-layout') || 'strip';
+  if (cardLayoutPref === 'strip') {
     document.documentElement.setAttribute('data-card-layout', 'strip');
   }
-  // Store badge display preference: 'icon' = round colored glyph, default
-  // = text pill ('STEAM', 'GOG', 'EPIC').
-  if (localStorage.getItem('pp:store-display') === 'icon') {
+  // Store badge display. Default is 'icon' (round brand glyph). 'text' uses
+  // the text label ('STEAM', 'GOG', 'EPIC').
+  const storeDisplayPref = localStorage.getItem('pp:store-display') || 'icon';
+  if (storeDisplayPref === 'icon') {
     document.documentElement.setAttribute('data-store-display', 'icon');
   }
 

--- a/js/lib/topbar.js
+++ b/js/lib/topbar.js
@@ -769,12 +769,6 @@
         const countsHtml = counts.length
           ? '<span class="sd-counts">' + counts.join(' + ') + '</span>'
           : '';
-        const tierHtml = r.tier
-          ? '<span class="sd-tier tier-' + r.tier + '">' + r.tier + '</span>'
-          : '';
-        // Store badge + appId on the right edge. Long ids (e.g. epic hashes)
-        // would otherwise dominate the row -- the pill + truncated mono text
-        // is the same visual treatment used on the app.html cards.
         const idStr = String(r.appId);
         const inferredStore = r.appType
           ? r.appType
@@ -784,20 +778,25 @@
         const storeLabel = inferredStore === 'gog' ? 'GOG'
                          : inferredStore === 'epic' ? 'Epic'
                          : 'Steam';
-        const storeHtml = '<span class="sd-store sd-store--' + inferredStore + '">' + storeLabel + '</span>';
-        // Order on the right side: appId (truncated) -> store badge (far right).
-        // Store pill goes last so it sits at the trailing edge of the row, in
-        // line with the convention on the app.html cards.
+        // Single split chip on the right edge that mirrors the .game-card
+        // combined corner chip (tier color on the left, store color on the
+        // right). App id moves to the left of the title so the right edge
+        // belongs entirely to the chip.
+        const tierAttr = r.tier ? r.tier.toLowerCase() : '';
+        const tierLabel = r.tier ? r.tier.toUpperCase() : 'NO RATING';
+        const comboHtml = '<span class="sd-combo" data-tier="' + tierAttr + '" data-store="' + inferredStore + '">' +
+                          '<span class="sd-combo-tier">' + tierLabel + '</span>' +
+                          '<span class="sd-combo-store">' + storeLabel + '</span>' +
+                          '</span>';
         return '<a href="app.html#/app/' + r.appId + '" role="option" data-idx="' + idx + '">' +
                '<img loading="lazy" data-appid="' + r.appId + '" src="' + steamHeader(r.appId) + '" alt="" ' +
                  'onerror="window.__steamImgLoad && window.__steamImgLoad(this)">' +
+               '<span class="sd-appid sd-appid--left" title="' + idStr + '">' + idStr + '</span>' +
                '<span class="sd-meta">' +
                  '<span class="sd-title">' + safe + '</span>' +
                  countsHtml +
                '</span>' +
-               tierHtml +
-               '<span class="sd-appid" title="' + idStr + '">' + idStr + '</span>' +
-               storeHtml +
+               comboHtml +
                '</a>';
       }).join('');
       dropdown.innerHTML = html;

--- a/js/lib/topbar.js
+++ b/js/lib/topbar.js
@@ -390,10 +390,16 @@
   // (avoids a flash of the wrong mode / running animations).
   initTheme();
   initMotion();
-  // Store badge placement. Default is 'bar-inline' (paired with the strip
-  // card layout, the store sits flush right of the tier label as a brand
-  // pill or icon). Other values: 'right' (legacy column), 'art' (thumbnail
-  // overlay), 'art-corner' (card top-right), 'bar-segment' (split strip).
+  // Defaults differ by viewport. Mobile loses too much width to a corner
+  // tag, so the bar-inline badge next to the rating reads better; desktop
+  // has plenty of room for an art-corner tag + a full text label, which
+  // is more skim-friendly when scanning a dense grid. User picks override
+  // both defaults via the options page.
+  const _isDesktop = window.matchMedia('(min-width: 760px)').matches;
+
+  // Store badge placement. Other values: 'right' (legacy column), 'art'
+  // (thumbnail overlay), 'art-corner' (card top-right), 'bar-inline'
+  // (next to tier in the strip), 'bar-segment' (split strip).
   // Migrations: dropped 'bar-right' -> 'bar-segment'; renamed 'bar-icon'
   // -> 'bar-inline' once it started honoring the store-display pref.
   let storePillPos = localStorage.getItem('pp:store-pill-pos');
@@ -404,20 +410,21 @@
     storePillPos = 'bar-inline';
     localStorage.setItem('pp:store-pill-pos', 'bar-inline');
   }
-  if (!storePillPos) storePillPos = 'bar-inline';
+  if (!storePillPos) storePillPos = _isDesktop ? 'art-corner' : 'bar-inline';
   if (storePillPos !== 'right') {
     document.documentElement.setAttribute('data-store-pill-pos', storePillPos);
   }
-  // Card layout preference. Default is 'strip' (tier in a colored bar across
-  // the full bottom of the card -- better on mobile because the title row
-  // gets the full card width). 'right' falls back to the column pill.
+  // Card layout preference. Default is 'strip' on both viewports (tier in
+  // a colored bar across the full bottom of the card). 'right' falls back
+  // to the column pill.
   const cardLayoutPref = localStorage.getItem('pp:card-layout') || 'strip';
   if (cardLayoutPref === 'strip') {
     document.documentElement.setAttribute('data-card-layout', 'strip');
   }
-  // Store badge display. Default is 'icon' (round brand glyph). 'text' uses
-  // the text label ('STEAM', 'GOG', 'EPIC').
-  const storeDisplayPref = localStorage.getItem('pp:store-display') || 'icon';
+  // Store badge display. Default depends on viewport: 'icon' on mobile
+  // (saves space next to the rating), 'text' on desktop (room for the
+  // full STEAM/GOG/EPIC label, easier to scan).
+  const storeDisplayPref = localStorage.getItem('pp:store-display') || (_isDesktop ? 'text' : 'icon');
   if (storeDisplayPref === 'icon') {
     document.documentElement.setAttribute('data-store-display', 'icon');
   }

--- a/js/lib/topbar.js
+++ b/js/lib/topbar.js
@@ -58,6 +58,21 @@
       <circle cx="9.5" cy="11.5" r="1.2" fill="currentColor" stroke="none"/>
       <circle cx="14.5" cy="11.5" r="1.2" fill="currentColor" stroke="none"/>
     </symbol>
+    <!-- Round store glyphs for the "store badge: icon" preference. Each is a
+         filled circle in the brand color with a white monogram on top. SVG
+         viewBox 0 0 24 24, used inline via <use href="#icon-store-..."/>. -->
+    <symbol id="icon-store-steam" viewBox="0 0 24 24">
+      <circle cx="12" cy="12" r="12" fill="#1689d0"/>
+      <text x="12" y="17" text-anchor="middle" font-family="-apple-system, sans-serif" font-weight="800" font-size="15" fill="#fff">S</text>
+    </symbol>
+    <symbol id="icon-store-gog" viewBox="0 0 24 24">
+      <circle cx="12" cy="12" r="12" fill="#7a3fcf"/>
+      <text x="12" y="17" text-anchor="middle" font-family="-apple-system, sans-serif" font-weight="800" font-size="15" fill="#fff">G</text>
+    </symbol>
+    <symbol id="icon-store-epic" viewBox="0 0 24 24">
+      <circle cx="12" cy="12" r="12" fill="#2a2a2a"/>
+      <text x="12" y="17" text-anchor="middle" font-family="-apple-system, sans-serif" font-weight="800" font-size="15" fill="#fff">E</text>
+    </symbol>
   </defs>
 </svg>`;
 
@@ -365,13 +380,25 @@
   initTheme();
   initMotion();
   // Store pill position preference: 'art' = thumbnail overlay, 'right' (default) = rating column.
-  if (localStorage.getItem('pp:store-pill-pos') === 'art') {
-    document.documentElement.setAttribute('data-store-pill-pos', 'art');
+  // Store badge placement: 'art' (overlay on thumbnail), 'right' (default
+   // pill column), 'bar-right' (sits at the trailing edge of the bottom-bar
+   // strip), 'bar-segment' (last quarter of the bottom-bar strip in store
+   // color, two-tone with the tier). The bar-* values only paint when
+   // data-card-layout="strip" is also set; they fall back to 'right'
+   // otherwise (no visual change). */
+  const storePillPos = localStorage.getItem('pp:store-pill-pos');
+  if (storePillPos && storePillPos !== 'right') {
+    document.documentElement.setAttribute('data-store-pill-pos', storePillPos);
   }
   // Card layout preference: 'strip' = rating row under title (more title width
   // on mobile), default = rating pill in right column.
   if (localStorage.getItem('pp:card-layout') === 'strip') {
     document.documentElement.setAttribute('data-card-layout', 'strip');
+  }
+  // Store badge display preference: 'icon' = round colored glyph, default
+  // = text pill ('STEAM', 'GOG', 'EPIC').
+  if (localStorage.getItem('pp:store-display') === 'icon') {
+    document.documentElement.setAttribute('data-store-display', 'icon');
   }
 
   // inject favicon if the page doesn't already have one

--- a/js/lib/topbar.js
+++ b/js/lib/topbar.js
@@ -58,11 +58,11 @@
       <circle cx="9.5" cy="11.5" r="1.2" fill="currentColor" stroke="none"/>
       <circle cx="14.5" cy="11.5" r="1.2" fill="currentColor" stroke="none"/>
     </symbol>
-    <!-- Round store glyphs for the "store badge: icon" preference. Filled
-         circle in the brand color with the brand glyph centered on top.
-         Glyph paths are the simpleicons.org SVG paths (24x24 viewBox)
-         scaled into a 16x16 area centered at (4,4) so they sit cleanly
-         inside the colored circle. -->
+    <!-- Store glyphs for the "store badge: icon" preference. Each retains
+         the brand's actual outline rather than being forced into a circle:
+         Steam is its own round mark on a blue circle; GOG is a white disc
+         with the purple "gog" wordmark; Epic is the shield-with-tab badge
+         in dark grey with the white "EPIC" wordmark. -->
     <symbol id="icon-store-steam" viewBox="0 0 24 24">
       <circle cx="12" cy="12" r="12" fill="#1689d0"/>
       <g transform="translate(4 4) scale(0.667)" fill="#fff">
@@ -70,16 +70,19 @@
       </g>
     </symbol>
     <symbol id="icon-store-gog" viewBox="0 0 24 24">
-      <circle cx="12" cy="12" r="12" fill="#7a3fcf"/>
-      <g transform="translate(4 4) scale(0.667)" fill="#fff">
-        <path d="M5.866 2.064C2.63 2.064 0 4.696 0 7.93v8.142c0 3.234 2.63 5.864 5.866 5.864h12.27c3.234 0 5.864-2.63 5.864-5.864V7.93c0-3.234-2.63-5.866-5.864-5.866H5.866zm-.16 2.97h2.756c1.07 0 1.937.867 1.937 1.935V13.4c0 1.07-.867 1.937-1.937 1.937h-.812V13.4h.812V7H5.706v6.4h1.94v3.42H5.706c-1.07 0-1.94-.866-1.94-1.937V6.969c0-1.068.87-1.935 1.94-1.935zm6.66 0h2.756c1.069 0 1.937.867 1.937 1.935V13.4c0 1.07-.868 1.937-1.937 1.937h-2.755c-1.071 0-1.94-.866-1.94-1.937V6.969c0-1.068.869-1.935 1.94-1.935zm.812 1.965v6.4h1.13V7h-1.13zm5.92 0h2.756v1.93H20.07v6.402h1.939V11.4h-1.124V9.467h3.063v5.87c0 1.071-.86 1.938-1.93 1.938H19.1c-1.071 0-1.94-.867-1.94-1.937V6.969c0-1.068.869-1.935 1.94-1.935z"/>
-      </g>
+      <!-- GOG's brand mark is a white disc with the purple 'gog' wordmark
+           inside a thin purple ring. Stylized as a clean text mark since
+           the real type face isn't web-available. -->
+      <circle cx="12" cy="12" r="11.5" fill="#fff" stroke="#7a3fcf" stroke-width="1.2"/>
+      <text x="12" y="16" text-anchor="middle" font-family="Inter, -apple-system, system-ui, sans-serif" font-weight="900" font-size="10" fill="#7a3fcf" letter-spacing="-0.5">gog</text>
     </symbol>
     <symbol id="icon-store-epic" viewBox="0 0 24 24">
-      <circle cx="12" cy="12" r="12" fill="#2a2a2a"/>
-      <g transform="translate(4 4) scale(0.667)" fill="#fff">
-        <path d="M3.537 0C2.165 0 1.66.506 1.66 1.879v15.732c0 .28 0 .43.018.604 0 .078 0 .15.05.224.07.36.279.434.836.633l4.853 1.92c.726.279 1.024.4 1.301.4.28 0 .555-.121 1.305-.4l4.846-1.92c.563-.198.78-.273.836-.633a.92.92 0 0 0 .05-.224 5.72 5.72 0 0 0 .022-.604V1.882c0-1.373-.512-1.879-1.881-1.879H3.537zm14.92 4.715h.961v8.519h-.961V4.715zM6.057 4.978h2.16c.781 0 1.198.42 1.198 1.205v3.9c0 .785-.417 1.205-1.198 1.205h-1.05v3.064h-1.11V4.978zm5.41 0h2.745v.985h-1.635v8.39h-1.11V4.978zm-4.3.985v3.34h.844c.26 0 .346-.103.346-.366V6.328c0-.262-.085-.365-.346-.365h-.844z"/>
-      </g>
+      <!-- Epic's brand mark is a shield-shaped badge (rounded rectangle
+           with a downward V-tab at the bottom) in dark slate, with the
+           white 'EPIC' wordmark above the tab. -->
+      <path d="M4 2 L20 2 Q22 2 22 4 L22 16 L12 22 L2 16 L2 4 Q2 2 4 2 Z" fill="#2a2a2a"/>
+      <text x="12" y="14" text-anchor="middle" font-family="Inter, -apple-system, system-ui, sans-serif" font-weight="900" font-size="6.5" fill="#fff" letter-spacing="0.3">EPIC</text>
+      <path d="M9 16 L15 16 L12 19 Z" fill="#fff"/>
     </symbol>
   </defs>
 </svg>`;

--- a/js/options/main.js
+++ b/js/options/main.js
@@ -168,6 +168,26 @@ if (cardLayoutGroup) {
   applyCardLayout(stored);
 }
 
+// Default layout: 'list' (horizontal cards) or 'grid' (Steam-style tile
+// grid). Each browse page also has its own quick toggle, but this radio
+// is the persistent baseline. Shared storage key with the browse pages.
+const GRID_LAYOUT_KEY = 'pp:grid-layout';
+const GRID_LAYOUT_VALUES = ['list', 'grid'];
+const gridLayoutGroup = document.getElementById('opt-grid-layout');
+if (gridLayoutGroup) {
+  let stored = localStorage.getItem(GRID_LAYOUT_KEY) || 'list';
+  if (!GRID_LAYOUT_VALUES.includes(stored)) stored = 'list';
+  gridLayoutGroup.querySelectorAll('input[type="radio"]').forEach(r => {
+    r.checked = r.value === stored;
+    r.addEventListener('change', () => {
+      if (r.checked) {
+        localStorage.setItem(GRID_LAYOUT_KEY, r.value);
+        console.log('[options] grid-layout:', r.value);
+      }
+    });
+  });
+}
+
 // Reports per page: how many cards app.html preloads per section before "Load
 // more". Stored as a string number; app.html reads it on load. Default 50.
 const LOAD_COUNT_KEY = 'pp:load-count';
@@ -191,7 +211,7 @@ if (loadCountGroup) {
 // defaults (OS reduced-motion, no card-layout attribute, etc).
 const resetBtn = document.getElementById('opt-reset');
 if (resetBtn) {
-  const RESET_KEYS = [MOTION_KEY, STORE_PILL_POS_KEY, STORE_DISPLAY_KEY, CARD_LAYOUT_KEY, LOAD_COUNT_KEY];
+  const RESET_KEYS = [MOTION_KEY, STORE_PILL_POS_KEY, STORE_DISPLAY_KEY, CARD_LAYOUT_KEY, GRID_LAYOUT_KEY, LOAD_COUNT_KEY];
   resetBtn.addEventListener('click', () => {
     if (!confirm('Reset all site preferences on this device to their defaults?')) return;
     RESET_KEYS.forEach(k => localStorage.removeItem(k));

--- a/js/options/main.js
+++ b/js/options/main.js
@@ -49,7 +49,11 @@ if (toggle) {
 //   'bar-segment' - last 1/4 of the bottom bar in store color (two-tone with tier)
 // bar-* values only have an effect when card-layout is 'strip'.
 const STORE_PILL_POS_KEY = 'pp:store-pill-pos';
-const STORE_PILL_POS_VALUES = ['right', 'art', 'bar-right', 'bar-segment'];
+const STORE_PILL_POS_VALUES = ['right', 'art', 'bar-segment'];
+// One-time migration from the dropped 'bar-right' chip variant to the split.
+if (localStorage.getItem(STORE_PILL_POS_KEY) === 'bar-right') {
+  localStorage.setItem(STORE_PILL_POS_KEY, 'bar-segment');
+}
 function applyStorePillPos(pos) {
   if (pos && pos !== 'right') {
     document.documentElement.setAttribute('data-store-pill-pos', pos);

--- a/js/options/main.js
+++ b/js/options/main.js
@@ -49,10 +49,14 @@ if (toggle) {
 //   'bar-segment' - last 1/4 of the bottom bar in store color (two-tone with tier)
 // bar-* values only have an effect when card-layout is 'strip'.
 const STORE_PILL_POS_KEY = 'pp:store-pill-pos';
-const STORE_PILL_POS_VALUES = ['right', 'art', 'art-corner', 'bar-icon', 'bar-segment'];
-// One-time migration from the dropped 'bar-right' chip variant to the split.
-if (localStorage.getItem(STORE_PILL_POS_KEY) === 'bar-right') {
-  localStorage.setItem(STORE_PILL_POS_KEY, 'bar-segment');
+const STORE_PILL_POS_VALUES = ['right', 'art', 'art-corner', 'bar-inline', 'bar-segment'];
+// Migrations: the old 'bar-right' chip variant collapsed into 'bar-segment';
+// 'bar-icon' was renamed to 'bar-inline' once it learned to honor the
+// store-display preference instead of always rendering the icon.
+{
+  const cur = localStorage.getItem(STORE_PILL_POS_KEY);
+  if (cur === 'bar-right') localStorage.setItem(STORE_PILL_POS_KEY, 'bar-segment');
+  else if (cur === 'bar-icon') localStorage.setItem(STORE_PILL_POS_KEY, 'bar-inline');
 }
 function applyStorePillPos(pos) {
   if (pos && pos !== 'right') {
@@ -173,5 +177,19 @@ if (loadCountGroup) {
         console.log('[options] load-count:', r.value);
       }
     });
+  });
+}
+
+// Reset to defaults: drop every browser-local preference key this page owns
+// then reload, so the controls and the page re-evaluate from system
+// defaults (OS reduced-motion, no card-layout attribute, etc).
+const resetBtn = document.getElementById('opt-reset');
+if (resetBtn) {
+  const RESET_KEYS = [MOTION_KEY, STORE_PILL_POS_KEY, STORE_DISPLAY_KEY, CARD_LAYOUT_KEY, LOAD_COUNT_KEY];
+  resetBtn.addEventListener('click', () => {
+    if (!confirm('Reset all site preferences on this device to their defaults?')) return;
+    RESET_KEYS.forEach(k => localStorage.removeItem(k));
+    console.log('[options] cleared preferences:', RESET_KEYS);
+    window.location.reload();
   });
 }

--- a/js/options/main.js
+++ b/js/options/main.js
@@ -49,7 +49,7 @@ if (toggle) {
 //   'bar-segment' - last 1/4 of the bottom bar in store color (two-tone with tier)
 // bar-* values only have an effect when card-layout is 'strip'.
 const STORE_PILL_POS_KEY = 'pp:store-pill-pos';
-const STORE_PILL_POS_VALUES = ['right', 'art', 'bar-segment'];
+const STORE_PILL_POS_VALUES = ['right', 'art', 'art-corner', 'bar-segment'];
 // One-time migration from the dropped 'bar-right' chip variant to the split.
 if (localStorage.getItem(STORE_PILL_POS_KEY) === 'bar-right') {
   localStorage.setItem(STORE_PILL_POS_KEY, 'bar-segment');

--- a/js/options/main.js
+++ b/js/options/main.js
@@ -65,10 +65,14 @@ function applyStorePillPos(pos) {
     document.documentElement.removeAttribute('data-store-pill-pos');
   }
 }
-// Defaults differ by viewport (matches topbar.js). Picked once at page load.
+// Store badge placement default is viewport-aware: desktop has room for a
+// card-corner tag, mobile would lose too much title width so the bar-inline
+// badge next to the rating reads better. Display defaults to text on both
+// (matches topbar.js) until the round brand glyphs read consistently
+// across stores.
 const _IS_DESKTOP = window.matchMedia('(min-width: 760px)').matches;
 const _DEFAULT_STORE_PILL_POS = _IS_DESKTOP ? 'art-corner' : 'bar-inline';
-const _DEFAULT_STORE_DISPLAY  = _IS_DESKTOP ? 'text' : 'icon';
+const _DEFAULT_STORE_DISPLAY  = 'text';
 
 const storePillGroup = document.getElementById('opt-store-pill-pos');
 if (storePillGroup) {

--- a/js/options/main.js
+++ b/js/options/main.js
@@ -118,9 +118,10 @@ if (storeDisplayGroup) {
 // beneath the title so long names get the full card width). Mirrors the
 // store-pill-pos pattern: a single attribute on <html> drives the CSS swap.
 const CARD_LAYOUT_KEY = 'pp:card-layout';
+const CARD_LAYOUTS_WITH_ATTR = new Set(['strip', 'combo']);
 function applyCardLayout(pos) {
-  if (pos === 'strip') {
-    document.documentElement.setAttribute('data-card-layout', 'strip');
+  if (CARD_LAYOUTS_WITH_ATTR.has(pos)) {
+    document.documentElement.setAttribute('data-card-layout', pos);
   } else {
     document.documentElement.removeAttribute('data-card-layout');
   }

--- a/js/options/main.js
+++ b/js/options/main.js
@@ -67,8 +67,8 @@ function applyStorePillPos(pos) {
 }
 const storePillGroup = document.getElementById('opt-store-pill-pos');
 if (storePillGroup) {
-  let stored = localStorage.getItem(STORE_PILL_POS_KEY) || 'right';
-  if (!STORE_PILL_POS_VALUES.includes(stored)) stored = 'right';
+  let stored = localStorage.getItem(STORE_PILL_POS_KEY) || 'bar-inline';
+  if (!STORE_PILL_POS_VALUES.includes(stored)) stored = 'bar-inline';
   storePillGroup.querySelectorAll('input[type="radio"]').forEach(r => {
     r.checked = r.value === stored;
     r.addEventListener('change', () => {
@@ -95,7 +95,7 @@ function applyStoreDisplay(mode) {
 }
 const storeDisplayGroup = document.getElementById('opt-store-display');
 if (storeDisplayGroup) {
-  const stored = localStorage.getItem(STORE_DISPLAY_KEY) || 'text';
+  const stored = localStorage.getItem(STORE_DISPLAY_KEY) || 'icon';
   storeDisplayGroup.querySelectorAll('input[type="radio"]').forEach(r => {
     r.checked = r.value === stored;
     r.addEventListener('change', () => {
@@ -148,7 +148,7 @@ function updateConditionalOptions() {
 }
 const cardLayoutGroup = document.getElementById('opt-card-layout');
 if (cardLayoutGroup) {
-  const stored = localStorage.getItem(CARD_LAYOUT_KEY) || 'right';
+  const stored = localStorage.getItem(CARD_LAYOUT_KEY) || 'strip';
   cardLayoutGroup.querySelectorAll('input[type="radio"]').forEach(r => {
     r.checked = r.value === stored;
     r.addEventListener('change', () => {

--- a/js/options/main.js
+++ b/js/options/main.js
@@ -49,7 +49,7 @@ if (toggle) {
 //   'bar-segment' - last 1/4 of the bottom bar in store color (two-tone with tier)
 // bar-* values only have an effect when card-layout is 'strip'.
 const STORE_PILL_POS_KEY = 'pp:store-pill-pos';
-const STORE_PILL_POS_VALUES = ['right', 'art', 'art-corner', 'bar-segment'];
+const STORE_PILL_POS_VALUES = ['right', 'art', 'art-corner', 'bar-icon', 'bar-segment'];
 // One-time migration from the dropped 'bar-right' chip variant to the split.
 if (localStorage.getItem(STORE_PILL_POS_KEY) === 'bar-right') {
   localStorage.setItem(STORE_PILL_POS_KEY, 'bar-segment');

--- a/js/options/main.js
+++ b/js/options/main.js
@@ -65,10 +65,15 @@ function applyStorePillPos(pos) {
     document.documentElement.removeAttribute('data-store-pill-pos');
   }
 }
+// Defaults differ by viewport (matches topbar.js). Picked once at page load.
+const _IS_DESKTOP = window.matchMedia('(min-width: 760px)').matches;
+const _DEFAULT_STORE_PILL_POS = _IS_DESKTOP ? 'art-corner' : 'bar-inline';
+const _DEFAULT_STORE_DISPLAY  = _IS_DESKTOP ? 'text' : 'icon';
+
 const storePillGroup = document.getElementById('opt-store-pill-pos');
 if (storePillGroup) {
-  let stored = localStorage.getItem(STORE_PILL_POS_KEY) || 'bar-inline';
-  if (!STORE_PILL_POS_VALUES.includes(stored)) stored = 'bar-inline';
+  let stored = localStorage.getItem(STORE_PILL_POS_KEY) || _DEFAULT_STORE_PILL_POS;
+  if (!STORE_PILL_POS_VALUES.includes(stored)) stored = _DEFAULT_STORE_PILL_POS;
   storePillGroup.querySelectorAll('input[type="radio"]').forEach(r => {
     r.checked = r.value === stored;
     r.addEventListener('change', () => {
@@ -95,7 +100,7 @@ function applyStoreDisplay(mode) {
 }
 const storeDisplayGroup = document.getElementById('opt-store-display');
 if (storeDisplayGroup) {
-  const stored = localStorage.getItem(STORE_DISPLAY_KEY) || 'icon';
+  const stored = localStorage.getItem(STORE_DISPLAY_KEY) || _DEFAULT_STORE_DISPLAY;
   storeDisplayGroup.querySelectorAll('input[type="radio"]').forEach(r => {
     r.checked = r.value === stored;
     r.addEventListener('change', () => {

--- a/js/options/main.js
+++ b/js/options/main.js
@@ -175,8 +175,8 @@ const GRID_LAYOUT_KEY = 'pp:grid-layout';
 const GRID_LAYOUT_VALUES = ['list', 'grid'];
 const gridLayoutGroup = document.getElementById('opt-grid-layout');
 if (gridLayoutGroup) {
-  let stored = localStorage.getItem(GRID_LAYOUT_KEY) || 'list';
-  if (!GRID_LAYOUT_VALUES.includes(stored)) stored = 'list';
+  let stored = localStorage.getItem(GRID_LAYOUT_KEY) || 'grid';
+  if (!GRID_LAYOUT_VALUES.includes(stored)) stored = 'grid';
   gridLayoutGroup.querySelectorAll('input[type="radio"]').forEach(r => {
     r.checked = r.value === stored;
     r.addEventListener('change', () => {

--- a/js/options/main.js
+++ b/js/options/main.js
@@ -42,18 +42,25 @@ if (toggle) {
   });
 }
 
-// Store pill position: 'right' (inline with rating) or 'art' (thumbnail overlay).
+// Store pill position. Values:
+//   'right'       - inline with the rating pill in the right column
+//   'art'         - overlaid on the thumbnail corner
+//   'bar-right'   - chip pinned to the trailing edge of the bottom-bar layout
+//   'bar-segment' - last 1/4 of the bottom bar in store color (two-tone with tier)
+// bar-* values only have an effect when card-layout is 'strip'.
 const STORE_PILL_POS_KEY = 'pp:store-pill-pos';
+const STORE_PILL_POS_VALUES = ['right', 'art', 'bar-right', 'bar-segment'];
 function applyStorePillPos(pos) {
-  if (pos === 'art') {
-    document.documentElement.setAttribute('data-store-pill-pos', 'art');
+  if (pos && pos !== 'right') {
+    document.documentElement.setAttribute('data-store-pill-pos', pos);
   } else {
     document.documentElement.removeAttribute('data-store-pill-pos');
   }
 }
 const storePillGroup = document.getElementById('opt-store-pill-pos');
 if (storePillGroup) {
-  const stored = localStorage.getItem(STORE_PILL_POS_KEY) || 'right';
+  let stored = localStorage.getItem(STORE_PILL_POS_KEY) || 'right';
+  if (!STORE_PILL_POS_VALUES.includes(stored)) stored = 'right';
   storePillGroup.querySelectorAll('input[type="radio"]').forEach(r => {
     r.checked = r.value === stored;
     r.addEventListener('change', () => {
@@ -67,6 +74,33 @@ if (storePillGroup) {
   applyStorePillPos(stored);
 }
 
+// Store display: 'text' shows the store name as a pill; 'icon' shows a small
+// round monogram icon instead. Either choice combines with store-pill-pos to
+// pick where the badge sits.
+const STORE_DISPLAY_KEY = 'pp:store-display';
+function applyStoreDisplay(mode) {
+  if (mode === 'icon') {
+    document.documentElement.setAttribute('data-store-display', 'icon');
+  } else {
+    document.documentElement.removeAttribute('data-store-display');
+  }
+}
+const storeDisplayGroup = document.getElementById('opt-store-display');
+if (storeDisplayGroup) {
+  const stored = localStorage.getItem(STORE_DISPLAY_KEY) || 'text';
+  storeDisplayGroup.querySelectorAll('input[type="radio"]').forEach(r => {
+    r.checked = r.value === stored;
+    r.addEventListener('change', () => {
+      if (r.checked) {
+        localStorage.setItem(STORE_DISPLAY_KEY, r.value);
+        applyStoreDisplay(r.value);
+        console.log('[options] store-display:', r.value);
+      }
+    });
+  });
+  applyStoreDisplay(stored);
+}
+
 // Card layout: 'right' (rating pill in right column) or 'strip' (rating row
 // beneath the title so long names get the full card width). Mirrors the
 // store-pill-pos pattern: a single attribute on <html> drives the CSS swap.
@@ -76,6 +110,32 @@ function applyCardLayout(pos) {
     document.documentElement.setAttribute('data-card-layout', 'strip');
   } else {
     document.documentElement.removeAttribute('data-card-layout');
+  }
+  updateConditionalOptions();
+}
+// Disable any option labeled data-requires="card-layout=strip" when the card
+// layout is not 'strip'. If the user had a bar-* store position chosen and
+// switches back to the right layout, fall back to 'right' so the rendered
+// card stays consistent.
+function updateConditionalOptions() {
+  const layout = document.documentElement.getAttribute('data-card-layout') || 'right';
+  document.querySelectorAll('.option-radio[data-requires]').forEach(label => {
+    const req = label.getAttribute('data-requires');
+    const [key, val] = req.split('=');
+    let active = false;
+    if (key === 'card-layout') active = layout === val;
+    label.classList.toggle('option-radio--disabled', !active);
+    const input = label.querySelector('input[type="radio"]');
+    if (input) input.disabled = !active;
+  });
+  if (layout !== 'strip') {
+    const cur = localStorage.getItem(STORE_PILL_POS_KEY);
+    if (cur && cur.startsWith('bar-')) {
+      localStorage.setItem(STORE_PILL_POS_KEY, 'right');
+      applyStorePillPos('right');
+      const right = document.querySelector('#opt-store-pill-pos input[value="right"]');
+      if (right) right.checked = true;
+    }
   }
 }
 const cardLayoutGroup = document.getElementById('opt-card-layout');

--- a/js/profile/components/edit-modals.js
+++ b/js/profile/components/edit-modals.js
@@ -4,7 +4,7 @@
 import {
   escapeHtml, formatSystemUpdated, enabledVarsToText, textToEnabledVars,
   parseUploadedSystem, isGenericSystemLabel, inferSystemLabel,
-} from '../utils.js?v=a77e8ddf';
+} from '../utils.js?v=38d77229';
 import {
   fetchCloudConfig, patchCloudConfig, fetchFullUserConfig,
   fetchReportHistory, patchUserConfig,

--- a/js/profile/components/my-hardware.js
+++ b/js/profile/components/my-hardware.js
@@ -8,7 +8,7 @@ import {
   parseSteamSystemInfo, inferGpuVendor,
   getMyHwSourceMeta, setMyHwSourceMeta, getMyHwFieldOrigins,
   setMyHwFieldOrigins, setMyHwFieldOrigin,
-} from '../utils.js?v=a77e8ddf';
+} from '../utils.js?v=38d77229';
 
 /**
  * Initialise the My Hardware pane. Call once after DOM is ready.

--- a/js/profile/components/my-reports.js
+++ b/js/profile/components/my-reports.js
@@ -5,7 +5,7 @@ import {
   getProtonPulseUserIdFromSession, escapeHtml, formatSystemUpdated,
   getWebClientIdProfile, getMyReportBadges, flaggedMessageHtml,
   mergeMyReportRows,
-} from '../utils.js?v=a77e8ddf';
+} from '../utils.js?v=38d77229';
 import {
   fetchMyUserConfigs, fetchMyCloudConfigs, deleteMyReportsEverywhere,
   unpublishReport,

--- a/js/profile/components/systems.js
+++ b/js/profile/components/systems.js
@@ -6,7 +6,7 @@ import {
   getProtonPulseUserIdFromSession, parseSteamSystemInfo, inferGpuVendor,
   parseUploadedSystem, isGenericSystemLabel, inferSystemLabel,
   summarizeSystem, escapeHtml, formatSystemUpdated,
-} from '../utils.js?v=a77e8ddf';
+} from '../utils.js?v=38d77229';
 import {
   listUserSystems, setDefaultSystem, clearDefaultSystem,
   updateSystemLabel, deleteSystem,

--- a/js/profile/main.js
+++ b/js/profile/main.js
@@ -9,7 +9,7 @@ import {
   getProtonPulseUserIdFromSession, getShowUsername, setShowUsername,
   escapeHtml, formatSystemUpdated, getWebClientIdProfile,
   getPluginLinkCodeFromLocation, getSteamIdFromSession,
-} from './utils.js?v=a77e8ddf';
+} from './utils.js?v=38d77229';
 import {
   deleteAllMyData, fetchAllMyData, checkMyDataExists,
 } from './api/configs.js?v=93128a98';

--- a/js/profile/system-edit.js
+++ b/js/profile/system-edit.js
@@ -2,7 +2,7 @@ import { SUPABASE_URL, SUPABASE_ANON_KEY, SupaAuth } from './config.js?v=87cd0f3
 import {
   getProtonPulseUserIdFromSession, parseSteamSystemInfo, inferGpuVendor, inferCpuVendor,
   parseUploadedSystem, isGenericSystemLabel, inferSystemLabel, escapeHtml,
-} from './utils.js?v=a77e8ddf';
+} from './utils.js?v=38d77229';
 import { supabaseHeaders } from './api/supabase.js?v=4889c5e6';
 import { supabaseUserSystemsUrl, listUserSystems, updateSystem } from './api/systems.js?v=770d14b7';
 

--- a/js/profile/utils.js
+++ b/js/profile/utils.js
@@ -538,9 +538,14 @@ export function mergeMyReportRows(publishedRows, cloudRows) {
   const merged = new Map();
 
   function ensureRow(appId) {
-    if (!merged.has(appId)) {
-      merged.set(appId, {
-        app_id: appId,
+    // Normalize the key to a string. user_configs.app_id is a text column (API
+    // returns "2358720") while user_proton_configs.app_id is bigint (returns
+    // 2358720), so keying on the raw value splits one game into two rows because
+    // the published report and the cloud config never collapse. See issue #131.
+    const key = String(appId);
+    if (!merged.has(key)) {
+      merged.set(key, {
+        app_id: key,
         title: '',
         rating: '',
         updated_at: '',
@@ -556,7 +561,7 @@ export function mergeMyReportRows(publishedRows, cloudRows) {
         flagged_reason: null,
       });
     }
-    return merged.get(appId);
+    return merged.get(key);
   }
 
   for (const row of publishedRows || []) {

--- a/options.html
+++ b/options.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=7b2b7e95">
+<link rel="stylesheet" href="css/shared/cards.css?v=9548e3dd">
 <link rel="stylesheet" href="css/options/options.css?v=25925fc2">
 </head>
 <body>

--- a/options.html
+++ b/options.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=d1db1355">
+<link rel="stylesheet" href="css/shared/cards.css?v=17c970a6">
 <link rel="stylesheet" href="css/options/options.css?v=25925fc2">
 </head>
 <body>
@@ -65,12 +65,8 @@
             <span>On artwork</span>
           </label>
           <label class="option-radio" data-requires="card-layout=strip">
-            <input type="radio" name="store-pill-pos" value="bar-right">
-            <span>On bar (right edge)</span>
-          </label>
-          <label class="option-radio" data-requires="card-layout=strip">
             <input type="radio" name="store-pill-pos" value="bar-segment">
-            <span>On bar (two-tone)</span>
+            <span>On bar (split)</span>
           </label>
         </div>
       </div>
@@ -159,8 +155,8 @@
   <a href="terms.html">Terms</a>
 </footer>
 
-<script src="js/lib/topbar.js?v=3585d26d"></script>
+<script src="js/lib/topbar.js?v=f444bec4"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/options/main.js?v=db9bca97"></script>
+<script type="module" src="js/options/main.js?v=6df74f22"></script>
 </body>
 </html>

--- a/options.html
+++ b/options.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=ac2f4490">
+<link rel="stylesheet" href="css/shared/cards.css?v=7906ae81">
 <link rel="stylesheet" href="css/options/options.css?v=25925fc2">
 </head>
 <body>

--- a/options.html
+++ b/options.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=9548e3dd">
+<link rel="stylesheet" href="css/shared/cards.css?v=d1db1355">
 <link rel="stylesheet" href="css/options/options.css?v=25925fc2">
 </head>
 <body>
@@ -159,7 +159,7 @@
   <a href="terms.html">Terms</a>
 </footer>
 
-<script src="js/lib/topbar.js?v=522f6c3d"></script>
+<script src="js/lib/topbar.js?v=3585d26d"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/options/main.js?v=db9bca97"></script>
 </body>

--- a/options.html
+++ b/options.html
@@ -159,6 +159,9 @@
   <a href="terms.html">Terms</a>
 </footer>
 
+<!-- supabase-client must load before topbar.js so the auth indicator can
+     reflect the signed-in state via SupaAuth.onStateChange. -->
+<script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=f444bec4"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/options/main.js?v=231eaaf5"></script>

--- a/options.html
+++ b/options.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
+<link rel="stylesheet" href="css/shared/cards.css?v=17142038">
 <link rel="stylesheet" href="css/options/options.css?v=bb5b3f8f">
 </head>
 <body>
@@ -120,6 +120,10 @@
             <input type="radio" name="card-layout" value="strip" checked>
             <span>Bottom bar <span class="option-default-tag">(default)</span></span>
           </label>
+          <label class="option-radio">
+            <input type="radio" name="card-layout" value="combo">
+            <span>Combined corner chip</span>
+          </label>
         </div>
       </div>
 
@@ -173,8 +177,8 @@
      reflect the signed-in state via SupaAuth.onStateChange. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=a47091a2"></script>
+<script src="js/lib/topbar.js?v=1d29a1b6"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/options/main.js?v=af9f49aa"></script>
+<script type="module" src="js/options/main.js?v=61c26e14"></script>
 </body>
 </html>

--- a/options.html
+++ b/options.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=7906ae81">
+<link rel="stylesheet" href="css/shared/cards.css?v=4b548983">
 <link rel="stylesheet" href="css/options/options.css?v=25925fc2">
 </head>
 <body>

--- a/options.html
+++ b/options.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=cb310e3b">
+<link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
 <link rel="stylesheet" href="css/options/options.css?v=8f15bf06">
 </head>
 <body>

--- a/options.html
+++ b/options.html
@@ -90,12 +90,12 @@
         </div>
         <div class="option-radio-group" id="opt-store-display">
           <label class="option-radio">
-            <input type="radio" name="store-display" value="text">
-            <span>Text <span class="option-default-tag option-default-tag--desktop">(desktop default)</span></span>
+            <input type="radio" name="store-display" value="text" checked>
+            <span>Text <span class="option-default-tag">(default)</span></span>
           </label>
           <label class="option-radio">
-            <input type="radio" name="store-display" value="icon" checked>
-            <span>Icon <span class="option-default-tag option-default-tag--mobile">(mobile default)</span></span>
+            <input type="radio" name="store-display" value="icon">
+            <span>Icon</span>
           </label>
         </div>
       </div>
@@ -200,8 +200,8 @@
      reflect the signed-in state via SupaAuth.onStateChange. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=1d29a1b6"></script>
+<script src="js/lib/topbar.js?v=a3dcfcd5"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/options/main.js?v=53e6fd39"></script>
+<script type="module" src="js/options/main.js?v=0b84807c"></script>
 </body>
 </html>

--- a/options.html
+++ b/options.html
@@ -12,8 +12,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=b48b5b18">
-<link rel="stylesheet" href="css/options/options.css?v=25925fc2">
+<link rel="stylesheet" href="css/shared/cards.css?v=cb310e3b">
+<link rel="stylesheet" href="css/options/options.css?v=8f15bf06">
 </head>
 <body>
 
@@ -45,6 +45,7 @@
           <input type="checkbox" id="opt-animations">
           <span class="option-switch-track"></span>
         </label>
+        <div class="option-default-note">Default: on (off when your system requests reduced motion).</div>
       </div>
       <div class="option-row option-row--block">
         <div class="option-text">
@@ -58,7 +59,7 @@
         <div class="option-radio-group" id="opt-store-pill-pos">
           <label class="option-radio">
             <input type="radio" name="store-pill-pos" value="right" checked>
-            <span>On right</span>
+            <span>On right <span class="option-default-tag">(default)</span></span>
           </label>
           <label class="option-radio">
             <input type="radio" name="store-pill-pos" value="art">
@@ -69,8 +70,8 @@
             <span>Card corner</span>
           </label>
           <label class="option-radio" data-requires="card-layout=strip">
-            <input type="radio" name="store-pill-pos" value="bar-icon">
-            <span>On bar (icon)</span>
+            <input type="radio" name="store-pill-pos" value="bar-inline">
+            <span>On bar (next to rating)</span>
           </label>
           <label class="option-radio" data-requires="card-layout=strip">
             <input type="radio" name="store-pill-pos" value="bar-segment">
@@ -90,7 +91,7 @@
         <div class="option-radio-group" id="opt-store-display">
           <label class="option-radio">
             <input type="radio" name="store-display" value="text" checked>
-            <span>Text</span>
+            <span>Text <span class="option-default-tag">(default)</span></span>
           </label>
           <label class="option-radio">
             <input type="radio" name="store-display" value="icon">
@@ -113,7 +114,7 @@
         <div class="option-radio-group" id="opt-card-layout">
           <label class="option-radio">
             <input type="radio" name="card-layout" value="right" checked>
-            <span>On right</span>
+            <span>On right <span class="option-default-tag">(default)</span></span>
           </label>
           <label class="option-radio">
             <input type="radio" name="card-layout" value="strip">
@@ -134,7 +135,7 @@
         <div class="option-radio-group" id="opt-load-count">
           <label class="option-radio">
             <input type="radio" name="load-count" value="50" checked>
-            <span>50</span>
+            <span>50 <span class="option-default-tag">(default)</span></span>
           </label>
           <label class="option-radio">
             <input type="radio" name="load-count" value="100">
@@ -149,6 +150,11 @@
             <span>200</span>
           </label>
         </div>
+      </div>
+
+      <div class="options-reset">
+        <button type="button" id="opt-reset" class="options-reset-btn">Reset to defaults</button>
+        <span class="options-reset-note">Clears all settings on this device and reloads the page.</span>
       </div>
     </div>
 
@@ -167,8 +173,8 @@
      reflect the signed-in state via SupaAuth.onStateChange. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=f444bec4"></script>
+<script src="js/lib/topbar.js?v=2f8197e0"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/options/main.js?v=48696e52"></script>
+<script type="module" src="js/options/main.js?v=95c96649"></script>
 </body>
 </html>

--- a/options.html
+++ b/options.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=4b548983">
+<link rel="stylesheet" href="css/shared/cards.css?v=5ec3c05a">
 <link rel="stylesheet" href="css/options/options.css?v=25925fc2">
 </head>
 <body>
@@ -67,6 +67,10 @@
           <label class="option-radio">
             <input type="radio" name="store-pill-pos" value="art-corner">
             <span>Card corner</span>
+          </label>
+          <label class="option-radio" data-requires="card-layout=strip">
+            <input type="radio" name="store-pill-pos" value="bar-icon">
+            <span>On bar (icon)</span>
           </label>
           <label class="option-radio" data-requires="card-layout=strip">
             <input type="radio" name="store-pill-pos" value="bar-segment">
@@ -164,6 +168,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=f444bec4"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/options/main.js?v=231eaaf5"></script>
+<script type="module" src="js/options/main.js?v=48696e52"></script>
 </body>
 </html>

--- a/options.html
+++ b/options.html
@@ -11,8 +11,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
-<link rel="stylesheet" href="css/shared/site.css?v=c581801e">
-<link rel="stylesheet" href="css/shared/cards.css?v=0092674d">
+<link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
+<link rel="stylesheet" href="css/shared/cards.css?v=ac2f4490">
 <link rel="stylesheet" href="css/options/options.css?v=25925fc2">
 </head>
 <body>

--- a/options.html
+++ b/options.html
@@ -11,8 +11,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
-<link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=17c970a6">
+<link rel="stylesheet" href="css/shared/site.css?v=c581801e">
+<link rel="stylesheet" href="css/shared/cards.css?v=0092674d">
 <link rel="stylesheet" href="css/options/options.css?v=25925fc2">
 </head>
 <body>
@@ -63,6 +63,10 @@
           <label class="option-radio">
             <input type="radio" name="store-pill-pos" value="art">
             <span>On artwork</span>
+          </label>
+          <label class="option-radio">
+            <input type="radio" name="store-pill-pos" value="art-corner">
+            <span>Artwork corner</span>
           </label>
           <label class="option-radio" data-requires="card-layout=strip">
             <input type="radio" name="store-pill-pos" value="bar-segment">
@@ -157,6 +161,6 @@
 
 <script src="js/lib/topbar.js?v=f444bec4"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/options/main.js?v=6df74f22"></script>
+<script type="module" src="js/options/main.js?v=231eaaf5"></script>
 </body>
 </html>

--- a/options.html
+++ b/options.html
@@ -10,7 +10,7 @@
 <meta name="description" content="Browser-local display preferences for Proton Pulse, including an animations on/off toggle.">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
-<link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
+<link rel="stylesheet" href="css/shared/topbar.css?v=256d07b6">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <link rel="stylesheet" href="css/options/options.css?v=bb5b3f8f">
@@ -200,7 +200,7 @@
      reflect the signed-in state via SupaAuth.onStateChange. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=a3dcfcd5"></script>
+<script src="js/lib/topbar.js?v=c2fe26da"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/options/main.js?v=0b84807c"></script>
 </body>

--- a/options.html
+++ b/options.html
@@ -10,7 +10,7 @@
 <meta name="description" content="Browser-local display preferences for Proton Pulse, including an animations on/off toggle.">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
-<link rel="stylesheet" href="css/shared/topbar.css?v=256d07b6">
+<link rel="stylesheet" href="css/shared/topbar.css?v=2d6b5e52">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <link rel="stylesheet" href="css/options/options.css?v=bb5b3f8f">
@@ -200,7 +200,7 @@
      reflect the signed-in state via SupaAuth.onStateChange. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=c2fe26da"></script>
+<script src="js/lib/topbar.js?v=449040e3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/options/main.js?v=0b84807c"></script>
 </body>

--- a/options.html
+++ b/options.html
@@ -58,8 +58,8 @@
         </div>
         <div class="option-radio-group" id="opt-store-pill-pos">
           <label class="option-radio">
-            <input type="radio" name="store-pill-pos" value="right" checked>
-            <span>On right <span class="option-default-tag">(default)</span></span>
+            <input type="radio" name="store-pill-pos" value="right">
+            <span>On right</span>
           </label>
           <label class="option-radio">
             <input type="radio" name="store-pill-pos" value="art">
@@ -70,8 +70,8 @@
             <span>Card corner</span>
           </label>
           <label class="option-radio" data-requires="card-layout=strip">
-            <input type="radio" name="store-pill-pos" value="bar-inline">
-            <span>On bar (next to rating)</span>
+            <input type="radio" name="store-pill-pos" value="bar-inline" checked>
+            <span>On bar (next to rating) <span class="option-default-tag">(default)</span></span>
           </label>
           <label class="option-radio" data-requires="card-layout=strip">
             <input type="radio" name="store-pill-pos" value="bar-segment">
@@ -90,12 +90,12 @@
         </div>
         <div class="option-radio-group" id="opt-store-display">
           <label class="option-radio">
-            <input type="radio" name="store-display" value="text" checked>
-            <span>Text <span class="option-default-tag">(default)</span></span>
+            <input type="radio" name="store-display" value="text">
+            <span>Text</span>
           </label>
           <label class="option-radio">
-            <input type="radio" name="store-display" value="icon">
-            <span>Icon</span>
+            <input type="radio" name="store-display" value="icon" checked>
+            <span>Icon <span class="option-default-tag">(default)</span></span>
           </label>
         </div>
       </div>
@@ -113,12 +113,12 @@
         </div>
         <div class="option-radio-group" id="opt-card-layout">
           <label class="option-radio">
-            <input type="radio" name="card-layout" value="right" checked>
-            <span>On right <span class="option-default-tag">(default)</span></span>
+            <input type="radio" name="card-layout" value="right">
+            <span>On right</span>
           </label>
           <label class="option-radio">
-            <input type="radio" name="card-layout" value="strip">
-            <span>Bottom bar</span>
+            <input type="radio" name="card-layout" value="strip" checked>
+            <span>Bottom bar <span class="option-default-tag">(default)</span></span>
           </label>
         </div>
       </div>
@@ -173,8 +173,8 @@
      reflect the signed-in state via SupaAuth.onStateChange. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=2f8197e0"></script>
+<script src="js/lib/topbar.js?v=8c2f9356"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/options/main.js?v=95c96649"></script>
+<script type="module" src="js/options/main.js?v=b544c702"></script>
 </body>
 </html>

--- a/options.html
+++ b/options.html
@@ -129,6 +129,29 @@
 
       <div class="option-row option-row--block">
         <div class="option-text">
+          <div class="option-title">Default layout</div>
+          <div class="option-desc">
+            How browse pages lay games out by default. "List" shows
+            horizontal cards stacked top to bottom. "Grid" shows a
+            Steam-style grid of header thumbnails. Each page also has a
+            List/Grid toggle that overrides this for the rest of the
+            session.
+          </div>
+        </div>
+        <div class="option-radio-group" id="opt-grid-layout">
+          <label class="option-radio">
+            <input type="radio" name="grid-layout" value="list" checked>
+            <span>List <span class="option-default-tag">(default)</span></span>
+          </label>
+          <label class="option-radio">
+            <input type="radio" name="grid-layout" value="grid">
+            <span>Grid (tiles)</span>
+          </label>
+        </div>
+      </div>
+
+      <div class="option-row option-row--block">
+        <div class="option-text">
           <div class="option-title">Reports per page</div>
           <div class="option-desc">
             How many game cards to preload in each section when browsing reports
@@ -179,6 +202,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=1d29a1b6"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/options/main.js?v=61c26e14"></script>
+<script type="module" src="js/options/main.js?v=4928dca1"></script>
 </body>
 </html>

--- a/options.html
+++ b/options.html
@@ -66,7 +66,7 @@
           </label>
           <label class="option-radio">
             <input type="radio" name="store-pill-pos" value="art-corner">
-            <span>Artwork corner</span>
+            <span>Card corner</span>
           </label>
           <label class="option-radio" data-requires="card-layout=strip">
             <input type="radio" name="store-pill-pos" value="bar-segment">

--- a/options.html
+++ b/options.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=5ec3c05a">
+<link rel="stylesheet" href="css/shared/cards.css?v=b48b5b18">
 <link rel="stylesheet" href="css/options/options.css?v=25925fc2">
 </head>
 <body>
@@ -165,6 +165,7 @@
 
 <!-- supabase-client must load before topbar.js so the auth indicator can
      reflect the signed-in state via SupaAuth.onStateChange. -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=f444bec4"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>

--- a/options.html
+++ b/options.html
@@ -12,8 +12,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=b75e75b2">
-<link rel="stylesheet" href="css/options/options.css?v=11d3971b">
+<link rel="stylesheet" href="css/shared/cards.css?v=7b2b7e95">
+<link rel="stylesheet" href="css/options/options.css?v=25925fc2">
 </head>
 <body>
 
@@ -63,6 +63,34 @@
           <label class="option-radio">
             <input type="radio" name="store-pill-pos" value="art">
             <span>On artwork</span>
+          </label>
+          <label class="option-radio" data-requires="card-layout=strip">
+            <input type="radio" name="store-pill-pos" value="bar-right">
+            <span>On bar (right edge)</span>
+          </label>
+          <label class="option-radio" data-requires="card-layout=strip">
+            <input type="radio" name="store-pill-pos" value="bar-segment">
+            <span>On bar (two-tone)</span>
+          </label>
+        </div>
+      </div>
+
+      <div class="option-row option-row--block">
+        <div class="option-text">
+          <div class="option-title">Store badge display</div>
+          <div class="option-desc">
+            Show the store as a text pill ("Steam", "GOG", "Epic") or a small
+            round icon. Icons take less space, which helps on narrow screens.
+          </div>
+        </div>
+        <div class="option-radio-group" id="opt-store-display">
+          <label class="option-radio">
+            <input type="radio" name="store-display" value="text" checked>
+            <span>Text</span>
+          </label>
+          <label class="option-radio">
+            <input type="radio" name="store-display" value="icon">
+            <span>Icon</span>
           </label>
         </div>
       </div>
@@ -131,8 +159,8 @@
   <a href="terms.html">Terms</a>
 </footer>
 
-<script src="js/lib/topbar.js?v=7e8205f8"></script>
+<script src="js/lib/topbar.js?v=522f6c3d"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/options/main.js?v=59780486"></script>
+<script type="module" src="js/options/main.js?v=db9bca97"></script>
 </body>
 </html>

--- a/options.html
+++ b/options.html
@@ -173,7 +173,7 @@
      reflect the signed-in state via SupaAuth.onStateChange. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=8c2f9356"></script>
+<script src="js/lib/topbar.js?v=8fe1c285"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/options/main.js?v=b544c702"></script>
 </body>

--- a/options.html
+++ b/options.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
-<link rel="stylesheet" href="css/options/options.css?v=8f15bf06">
+<link rel="stylesheet" href="css/options/options.css?v=bb5b3f8f">
 </head>
 <body>
 
@@ -67,11 +67,11 @@
           </label>
           <label class="option-radio">
             <input type="radio" name="store-pill-pos" value="art-corner">
-            <span>Card corner</span>
+            <span>Card corner <span class="option-default-tag option-default-tag--desktop">(desktop default)</span></span>
           </label>
           <label class="option-radio" data-requires="card-layout=strip">
             <input type="radio" name="store-pill-pos" value="bar-inline" checked>
-            <span>On bar (next to rating) <span class="option-default-tag">(default)</span></span>
+            <span>On bar (next to rating) <span class="option-default-tag option-default-tag--mobile">(mobile default)</span></span>
           </label>
           <label class="option-radio" data-requires="card-layout=strip">
             <input type="radio" name="store-pill-pos" value="bar-segment">
@@ -91,11 +91,11 @@
         <div class="option-radio-group" id="opt-store-display">
           <label class="option-radio">
             <input type="radio" name="store-display" value="text">
-            <span>Text</span>
+            <span>Text <span class="option-default-tag option-default-tag--desktop">(desktop default)</span></span>
           </label>
           <label class="option-radio">
             <input type="radio" name="store-display" value="icon" checked>
-            <span>Icon <span class="option-default-tag">(default)</span></span>
+            <span>Icon <span class="option-default-tag option-default-tag--mobile">(mobile default)</span></span>
           </label>
         </div>
       </div>
@@ -173,8 +173,8 @@
      reflect the signed-in state via SupaAuth.onStateChange. -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=8fe1c285"></script>
+<script src="js/lib/topbar.js?v=a47091a2"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/options/main.js?v=b544c702"></script>
+<script type="module" src="js/options/main.js?v=af9f49aa"></script>
 </body>
 </html>

--- a/options.html
+++ b/options.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=17142038">
+<link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <link rel="stylesheet" href="css/options/options.css?v=bb5b3f8f">
 </head>
 <body>

--- a/options.html
+++ b/options.html
@@ -140,12 +140,12 @@
         </div>
         <div class="option-radio-group" id="opt-grid-layout">
           <label class="option-radio">
-            <input type="radio" name="grid-layout" value="list" checked>
-            <span>List <span class="option-default-tag">(default)</span></span>
+            <input type="radio" name="grid-layout" value="list">
+            <span>List</span>
           </label>
           <label class="option-radio">
-            <input type="radio" name="grid-layout" value="grid">
-            <span>Grid (tiles)</span>
+            <input type="radio" name="grid-layout" value="grid" checked>
+            <span>Grid (tiles) <span class="option-default-tag">(default)</span></span>
           </label>
         </div>
       </div>
@@ -202,6 +202,6 @@
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=1d29a1b6"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/options/main.js?v=4928dca1"></script>
+<script type="module" src="js/options/main.js?v=53e6fd39"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.1",
+  "version": "1.5.0",
   "scripts": {
     "test": "jest",
     "dev": "vite --host --port 5173",

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -10,8 +10,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
-<link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=17c970a6">
+<link rel="stylesheet" href="css/shared/site.css?v=c581801e">
+<link rel="stylesheet" href="css/shared/cards.css?v=0092674d">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -9,7 +9,7 @@
 <title>Link Decky Plugin — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
-<link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
+<link rel="stylesheet" href="css/shared/topbar.css?v=256d07b6">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -10,8 +10,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
-<link rel="stylesheet" href="css/shared/site.css?v=c581801e">
-<link rel="stylesheet" href="css/shared/cards.css?v=0092674d">
+<link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
+<link rel="stylesheet" href="css/shared/cards.css?v=ac2f4490">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=cb310e3b">
+<link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -9,7 +9,7 @@
 <title>Link Decky Plugin — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
-<link rel="stylesheet" href="css/shared/topbar.css?v=256d07b6">
+<link rel="stylesheet" href="css/shared/topbar.css?v=2d6b5e52">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=ac2f4490">
+<link rel="stylesheet" href="css/shared/cards.css?v=7906ae81">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=7906ae81">
+<link rel="stylesheet" href="css/shared/cards.css?v=4b548983">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=4b548983">
+<link rel="stylesheet" href="css/shared/cards.css?v=5ec3c05a">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
+<link rel="stylesheet" href="css/shared/cards.css?v=17142038">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=7b2b7e95">
+<link rel="stylesheet" href="css/shared/cards.css?v=9548e3dd">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=d1db1355">
+<link rel="stylesheet" href="css/shared/cards.css?v=17c970a6">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=b48b5b18">
+<link rel="stylesheet" href="css/shared/cards.css?v=cb310e3b">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=9548e3dd">
+<link rel="stylesheet" href="css/shared/cards.css?v=d1db1355">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=b75e75b2">
+<link rel="stylesheet" href="css/shared/cards.css?v=7b2b7e95">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=5ec3c05a">
+<link rel="stylesheet" href="css/shared/cards.css?v=b48b5b18">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=17142038">
+<link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/privacy.html
+++ b/privacy.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=9548e3dd">
-<link rel="stylesheet" href="css/index/index.css?v=b3faf0dd">
+<link rel="stylesheet" href="css/shared/cards.css?v=d1db1355">
+<link rel="stylesheet" href="css/index/index.css?v=ad77490b">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }
@@ -87,7 +87,7 @@
 </div>
 </div>
 
-<script src="js/lib/topbar.js?v=522f6c3d"></script>
+<script src="js/lib/topbar.js?v=3585d26d"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -9,7 +9,7 @@
 <title>Privacy Policy - Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
-<link rel="stylesheet" href="css/shared/topbar.css?v=256d07b6">
+<link rel="stylesheet" href="css/shared/topbar.css?v=2d6b5e52">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <link rel="stylesheet" href="css/index/index.css?v=624d05bc">
@@ -89,7 +89,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=c2fe26da"></script>
+<script src="js/lib/topbar.js?v=449040e3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=cb310e3b">
-<link rel="stylesheet" href="css/index/index.css?v=977253e5">
+<link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
+<link rel="stylesheet" href="css/index/index.css?v=edf9e702">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/privacy.html
+++ b/privacy.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=b48b5b18">
-<link rel="stylesheet" href="css/index/index.css?v=501c588c">
+<link rel="stylesheet" href="css/shared/cards.css?v=cb310e3b">
+<link rel="stylesheet" href="css/index/index.css?v=977253e5">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }
@@ -89,7 +89,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=f444bec4"></script>
+<script src="js/lib/topbar.js?v=2f8197e0"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -89,7 +89,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=2f8197e0"></script>
+<script src="js/lib/topbar.js?v=8c2f9356"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
-<link rel="stylesheet" href="css/index/index.css?v=f047d582">
+<link rel="stylesheet" href="css/shared/cards.css?v=17142038">
+<link rel="stylesheet" href="css/index/index.css?v=cef6764d">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }
@@ -89,7 +89,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=a47091a2"></script>
+<script src="js/lib/topbar.js?v=1d29a1b6"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -87,6 +87,7 @@
 </div>
 </div>
 
+<script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=f444bec4"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>

--- a/privacy.html
+++ b/privacy.html
@@ -10,9 +10,9 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
-<link rel="stylesheet" href="css/shared/site.css?v=c581801e">
-<link rel="stylesheet" href="css/shared/cards.css?v=0092674d">
-<link rel="stylesheet" href="css/index/index.css?v=5ef799ac">
+<link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
+<link rel="stylesheet" href="css/shared/cards.css?v=ac2f4490">
+<link rel="stylesheet" href="css/index/index.css?v=a2de5ad7">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/privacy.html
+++ b/privacy.html
@@ -89,7 +89,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=1d29a1b6"></script>
+<script src="js/lib/topbar.js?v=a3dcfcd5"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=7b2b7e95">
-<link rel="stylesheet" href="css/index/index.css?v=e7a3bfb0">
+<link rel="stylesheet" href="css/shared/cards.css?v=9548e3dd">
+<link rel="stylesheet" href="css/index/index.css?v=b3faf0dd">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/privacy.html
+++ b/privacy.html
@@ -10,8 +10,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
-<link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=17c970a6">
+<link rel="stylesheet" href="css/shared/site.css?v=c581801e">
+<link rel="stylesheet" href="css/shared/cards.css?v=0092674d">
 <link rel="stylesheet" href="css/index/index.css?v=5ef799ac">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }

--- a/privacy.html
+++ b/privacy.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=7906ae81">
+<link rel="stylesheet" href="css/shared/cards.css?v=4b548983">
 <link rel="stylesheet" href="css/index/index.css?v=39339c49">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }

--- a/privacy.html
+++ b/privacy.html
@@ -9,7 +9,7 @@
 <title>Privacy Policy - Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
-<link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
+<link rel="stylesheet" href="css/shared/topbar.css?v=256d07b6">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <link rel="stylesheet" href="css/index/index.css?v=624d05bc">
@@ -89,7 +89,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=a3dcfcd5"></script>
+<script src="js/lib/topbar.js?v=c2fe26da"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=ac2f4490">
-<link rel="stylesheet" href="css/index/index.css?v=a2de5ad7">
+<link rel="stylesheet" href="css/shared/cards.css?v=7906ae81">
+<link rel="stylesheet" href="css/index/index.css?v=39339c49">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/privacy.html
+++ b/privacy.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=17142038">
-<link rel="stylesheet" href="css/index/index.css?v=cef6764d">
+<link rel="stylesheet" href="css/index/index.css?v=6b16bc5f">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/privacy.html
+++ b/privacy.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=4b548983">
-<link rel="stylesheet" href="css/index/index.css?v=39339c49">
+<link rel="stylesheet" href="css/shared/cards.css?v=5ec3c05a">
+<link rel="stylesheet" href="css/index/index.css?v=82445769">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/privacy.html
+++ b/privacy.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=d1db1355">
-<link rel="stylesheet" href="css/index/index.css?v=ad77490b">
+<link rel="stylesheet" href="css/shared/cards.css?v=17c970a6">
+<link rel="stylesheet" href="css/index/index.css?v=5ef799ac">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }
@@ -87,7 +87,7 @@
 </div>
 </div>
 
-<script src="js/lib/topbar.js?v=3585d26d"></script>
+<script src="js/lib/topbar.js?v=f444bec4"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=17142038">
-<link rel="stylesheet" href="css/index/index.css?v=6b16bc5f">
+<link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
+<link rel="stylesheet" href="css/index/index.css?v=624d05bc">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/privacy.html
+++ b/privacy.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
-<link rel="stylesheet" href="css/index/index.css?v=edf9e702">
+<link rel="stylesheet" href="css/index/index.css?v=f047d582">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }
@@ -89,7 +89,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=8fe1c285"></script>
+<script src="js/lib/topbar.js?v=a47091a2"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -89,7 +89,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=8c2f9356"></script>
+<script src="js/lib/topbar.js?v=8fe1c285"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=b75e75b2">
-<link rel="stylesheet" href="css/index/index.css?v=2d161a7e">
+<link rel="stylesheet" href="css/shared/cards.css?v=7b2b7e95">
+<link rel="stylesheet" href="css/index/index.css?v=e7a3bfb0">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }
@@ -87,7 +87,7 @@
 </div>
 </div>
 
-<script src="js/lib/topbar.js?v=7e8205f8"></script>
+<script src="js/lib/topbar.js?v=522f6c3d"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=5ec3c05a">
-<link rel="stylesheet" href="css/index/index.css?v=82445769">
+<link rel="stylesheet" href="css/shared/cards.css?v=b48b5b18">
+<link rel="stylesheet" href="css/index/index.css?v=501c588c">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }
@@ -87,6 +87,7 @@
 </div>
 </div>
 
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=f444bec4"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>

--- a/profile.html
+++ b/profile.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=b48b5b18">
+<link rel="stylesheet" href="css/shared/cards.css?v=cb310e3b">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>
@@ -289,7 +289,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=f444bec4"></script>
+<script src="js/lib/topbar.js?v=2f8197e0"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/profile/main.js?v=7207779a"></script>
 </body>

--- a/profile.html
+++ b/profile.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=7b2b7e95">
+<link rel="stylesheet" href="css/shared/cards.css?v=9548e3dd">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/profile.html
+++ b/profile.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=cb310e3b">
+<link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/profile.html
+++ b/profile.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=4b548983">
+<link rel="stylesheet" href="css/shared/cards.css?v=5ec3c05a">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/profile.html
+++ b/profile.html
@@ -9,7 +9,7 @@
 <title>My Account — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
-<link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
+<link rel="stylesheet" href="css/shared/topbar.css?v=256d07b6">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
@@ -289,7 +289,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=a3dcfcd5"></script>
+<script src="js/lib/topbar.js?v=c2fe26da"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/profile/main.js?v=7207779a"></script>
 </body>

--- a/profile.html
+++ b/profile.html
@@ -10,8 +10,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
-<link rel="stylesheet" href="css/shared/site.css?v=c581801e">
-<link rel="stylesheet" href="css/shared/cards.css?v=0092674d">
+<link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
+<link rel="stylesheet" href="css/shared/cards.css?v=ac2f4490">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/profile.html
+++ b/profile.html
@@ -9,7 +9,7 @@
 <title>My Account — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
-<link rel="stylesheet" href="css/shared/topbar.css?v=256d07b6">
+<link rel="stylesheet" href="css/shared/topbar.css?v=2d6b5e52">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
@@ -289,7 +289,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=c2fe26da"></script>
+<script src="js/lib/topbar.js?v=449040e3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/profile/main.js?v=7207779a"></script>
 </body>

--- a/profile.html
+++ b/profile.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=ac2f4490">
+<link rel="stylesheet" href="css/shared/cards.css?v=7906ae81">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/profile.html
+++ b/profile.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=9548e3dd">
+<link rel="stylesheet" href="css/shared/cards.css?v=d1db1355">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>
@@ -289,7 +289,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=522f6c3d"></script>
+<script src="js/lib/topbar.js?v=3585d26d"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/profile/main.js?v=7207779a"></script>
 </body>

--- a/profile.html
+++ b/profile.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
+<link rel="stylesheet" href="css/shared/cards.css?v=17142038">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>
@@ -289,7 +289,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=a47091a2"></script>
+<script src="js/lib/topbar.js?v=1d29a1b6"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/profile/main.js?v=7207779a"></script>
 </body>

--- a/profile.html
+++ b/profile.html
@@ -10,8 +10,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
-<link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=17c970a6">
+<link rel="stylesheet" href="css/shared/site.css?v=c581801e">
+<link rel="stylesheet" href="css/shared/cards.css?v=0092674d">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/profile.html
+++ b/profile.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=7906ae81">
+<link rel="stylesheet" href="css/shared/cards.css?v=4b548983">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/profile.html
+++ b/profile.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=d1db1355">
+<link rel="stylesheet" href="css/shared/cards.css?v=17c970a6">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>
@@ -289,7 +289,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=3585d26d"></script>
+<script src="js/lib/topbar.js?v=f444bec4"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/profile/main.js?v=7207779a"></script>
 </body>

--- a/profile.html
+++ b/profile.html
@@ -289,7 +289,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=2f8197e0"></script>
+<script src="js/lib/topbar.js?v=8c2f9356"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/profile/main.js?v=7207779a"></script>
 </body>

--- a/profile.html
+++ b/profile.html
@@ -289,7 +289,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=1d29a1b6"></script>
+<script src="js/lib/topbar.js?v=a3dcfcd5"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/profile/main.js?v=7207779a"></script>
 </body>

--- a/profile.html
+++ b/profile.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=17142038">
+<link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/profile.html
+++ b/profile.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=b75e75b2">
+<link rel="stylesheet" href="css/shared/cards.css?v=7b2b7e95">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>
@@ -289,7 +289,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=7e8205f8"></script>
+<script src="js/lib/topbar.js?v=522f6c3d"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/profile/main.js?v=7207779a"></script>
 </body>

--- a/profile.html
+++ b/profile.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=5ec3c05a">
+<link rel="stylesheet" href="css/shared/cards.css?v=b48b5b18">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/profile.html
+++ b/profile.html
@@ -289,7 +289,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=8fe1c285"></script>
+<script src="js/lib/topbar.js?v=a47091a2"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/profile/main.js?v=7207779a"></script>
 </body>

--- a/profile.html
+++ b/profile.html
@@ -289,7 +289,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=8c2f9356"></script>
+<script src="js/lib/topbar.js?v=8fe1c285"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/profile/main.js?v=7207779a"></script>
 </body>

--- a/scoring.html
+++ b/scoring.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=9548e3dd">
+<link rel="stylesheet" href="css/shared/cards.css?v=d1db1355">
 <style>
 h1 {
   font-family: var(--font-display);
@@ -490,7 +490,7 @@ h2 small {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=522f6c3d"></script>
+<script src="js/lib/topbar.js?v=3585d26d"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/scoring.html
+++ b/scoring.html
@@ -492,7 +492,7 @@ h2 small {
 <body>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=2f8197e0"></script>
+<script src="js/lib/topbar.js?v=8c2f9356"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/scoring.html
+++ b/scoring.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
+<link rel="stylesheet" href="css/shared/cards.css?v=17142038">
 <style>
 h1 {
   font-family: var(--font-display);
@@ -492,7 +492,7 @@ h2 small {
 <body>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=a47091a2"></script>
+<script src="js/lib/topbar.js?v=1d29a1b6"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/scoring.html
+++ b/scoring.html
@@ -11,8 +11,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
-<link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=17c970a6">
+<link rel="stylesheet" href="css/shared/site.css?v=c581801e">
+<link rel="stylesheet" href="css/shared/cards.css?v=0092674d">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/scoring.html
+++ b/scoring.html
@@ -10,7 +10,7 @@
 <meta name="description" content="Transparent explanation of how Proton Pulse scores compatibility reports against your hardware. Identical algorithm to the Decky Loader plugin - one canonical source of truth, no hidden magic.">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
-<link rel="stylesheet" href="css/shared/topbar.css?v=256d07b6">
+<link rel="stylesheet" href="css/shared/topbar.css?v=2d6b5e52">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <style>
@@ -492,7 +492,7 @@ h2 small {
 <body>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=c2fe26da"></script>
+<script src="js/lib/topbar.js?v=449040e3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/scoring.html
+++ b/scoring.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=ac2f4490">
+<link rel="stylesheet" href="css/shared/cards.css?v=7906ae81">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/scoring.html
+++ b/scoring.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=cb310e3b">
+<link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/scoring.html
+++ b/scoring.html
@@ -492,7 +492,7 @@ h2 small {
 <body>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=1d29a1b6"></script>
+<script src="js/lib/topbar.js?v=a3dcfcd5"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/scoring.html
+++ b/scoring.html
@@ -11,8 +11,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
-<link rel="stylesheet" href="css/shared/site.css?v=c581801e">
-<link rel="stylesheet" href="css/shared/cards.css?v=0092674d">
+<link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
+<link rel="stylesheet" href="css/shared/cards.css?v=ac2f4490">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/scoring.html
+++ b/scoring.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=d1db1355">
+<link rel="stylesheet" href="css/shared/cards.css?v=17c970a6">
 <style>
 h1 {
   font-family: var(--font-display);
@@ -490,7 +490,7 @@ h2 small {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=3585d26d"></script>
+<script src="js/lib/topbar.js?v=f444bec4"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/scoring.html
+++ b/scoring.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=4b548983">
+<link rel="stylesheet" href="css/shared/cards.css?v=5ec3c05a">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/scoring.html
+++ b/scoring.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=7906ae81">
+<link rel="stylesheet" href="css/shared/cards.css?v=4b548983">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/scoring.html
+++ b/scoring.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=b48b5b18">
+<link rel="stylesheet" href="css/shared/cards.css?v=cb310e3b">
 <style>
 h1 {
   font-family: var(--font-display);
@@ -492,7 +492,7 @@ h2 small {
 <body>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=f444bec4"></script>
+<script src="js/lib/topbar.js?v=2f8197e0"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/scoring.html
+++ b/scoring.html
@@ -490,6 +490,7 @@ h2 small {
 </style>
 </head>
 <body>
+<script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=f444bec4"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 

--- a/scoring.html
+++ b/scoring.html
@@ -10,7 +10,7 @@
 <meta name="description" content="Transparent explanation of how Proton Pulse scores compatibility reports against your hardware. Identical algorithm to the Decky Loader plugin - one canonical source of truth, no hidden magic.">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
-<link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
+<link rel="stylesheet" href="css/shared/topbar.css?v=256d07b6">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <style>
@@ -492,7 +492,7 @@ h2 small {
 <body>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=a3dcfcd5"></script>
+<script src="js/lib/topbar.js?v=c2fe26da"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/scoring.html
+++ b/scoring.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=7b2b7e95">
+<link rel="stylesheet" href="css/shared/cards.css?v=9548e3dd">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/scoring.html
+++ b/scoring.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=b75e75b2">
+<link rel="stylesheet" href="css/shared/cards.css?v=7b2b7e95">
 <style>
 h1 {
   font-family: var(--font-display);
@@ -490,7 +490,7 @@ h2 small {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=7e8205f8"></script>
+<script src="js/lib/topbar.js?v=522f6c3d"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/scoring.html
+++ b/scoring.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=17142038">
+<link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/scoring.html
+++ b/scoring.html
@@ -492,7 +492,7 @@ h2 small {
 <body>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=8c2f9356"></script>
+<script src="js/lib/topbar.js?v=8fe1c285"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/scoring.html
+++ b/scoring.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=5ec3c05a">
+<link rel="stylesheet" href="css/shared/cards.css?v=b48b5b18">
 <style>
 h1 {
   font-family: var(--font-display);
@@ -490,6 +490,7 @@ h2 small {
 </style>
 </head>
 <body>
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=f444bec4"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>

--- a/scoring.html
+++ b/scoring.html
@@ -492,7 +492,7 @@ h2 small {
 <body>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=8fe1c285"></script>
+<script src="js/lib/topbar.js?v=a47091a2"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/stats.html
+++ b/stats.html
@@ -10,7 +10,7 @@
 <meta name="description" content="Aggregate compatibility stats for Steam on Linux: ratings, GPU and CPU breakdowns, OS distribution, Proton version share, and top-reported games. Filter by hardware to drill in.">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
-<link rel="stylesheet" href="css/shared/topbar.css?v=256d07b6">
+<link rel="stylesheet" href="css/shared/topbar.css?v=2d6b5e52">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
@@ -663,7 +663,7 @@ h2 {
 <body>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=c2fe26da"></script>
+<script src="js/lib/topbar.js?v=449040e3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/stats.html
+++ b/stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=7906ae81">
+<link rel="stylesheet" href="css/shared/cards.css?v=4b548983">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/stats.html
+++ b/stats.html
@@ -663,7 +663,7 @@ h2 {
 <body>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=2f8197e0"></script>
+<script src="js/lib/topbar.js?v=8c2f9356"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/stats.html
+++ b/stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=7b2b7e95">
+<link rel="stylesheet" href="css/shared/cards.css?v=9548e3dd">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/stats.html
+++ b/stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
+<link rel="stylesheet" href="css/shared/cards.css?v=17142038">
 <style>
 h1 {
   font-family: var(--font-display);
@@ -663,7 +663,7 @@ h2 {
 <body>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=a47091a2"></script>
+<script src="js/lib/topbar.js?v=1d29a1b6"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/stats.html
+++ b/stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=cb310e3b">
+<link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/stats.html
+++ b/stats.html
@@ -11,9 +11,9 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
-<link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
+<link rel="stylesheet" href="css/shared/site.css?v=c581801e">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=17c970a6">
+<link rel="stylesheet" href="css/shared/cards.css?v=0092674d">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/stats.html
+++ b/stats.html
@@ -661,6 +661,7 @@ h2 {
 </style>
 </head>
 <body>
+<script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=f444bec4"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 

--- a/stats.html
+++ b/stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=b48b5b18">
+<link rel="stylesheet" href="css/shared/cards.css?v=cb310e3b">
 <style>
 h1 {
   font-family: var(--font-display);
@@ -663,7 +663,7 @@ h2 {
 <body>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=f444bec4"></script>
+<script src="js/lib/topbar.js?v=2f8197e0"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/stats.html
+++ b/stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=ac2f4490">
+<link rel="stylesheet" href="css/shared/cards.css?v=7906ae81">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/stats.html
+++ b/stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=d1db1355">
+<link rel="stylesheet" href="css/shared/cards.css?v=17c970a6">
 <style>
 h1 {
   font-family: var(--font-display);
@@ -661,7 +661,7 @@ h2 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=3585d26d"></script>
+<script src="js/lib/topbar.js?v=f444bec4"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/stats.html
+++ b/stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=9548e3dd">
+<link rel="stylesheet" href="css/shared/cards.css?v=d1db1355">
 <style>
 h1 {
   font-family: var(--font-display);
@@ -661,7 +661,7 @@ h2 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=522f6c3d"></script>
+<script src="js/lib/topbar.js?v=3585d26d"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/stats.html
+++ b/stats.html
@@ -663,7 +663,7 @@ h2 {
 <body>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=1d29a1b6"></script>
+<script src="js/lib/topbar.js?v=a3dcfcd5"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/stats.html
+++ b/stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=4b548983">
+<link rel="stylesheet" href="css/shared/cards.css?v=5ec3c05a">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/stats.html
+++ b/stats.html
@@ -11,9 +11,9 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
-<link rel="stylesheet" href="css/shared/site.css?v=c581801e">
+<link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=0092674d">
+<link rel="stylesheet" href="css/shared/cards.css?v=ac2f4490">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/stats.html
+++ b/stats.html
@@ -10,7 +10,7 @@
 <meta name="description" content="Aggregate compatibility stats for Steam on Linux: ratings, GPU and CPU breakdowns, OS distribution, Proton version share, and top-reported games. Filter by hardware to drill in.">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
-<link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
+<link rel="stylesheet" href="css/shared/topbar.css?v=256d07b6">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
@@ -663,7 +663,7 @@ h2 {
 <body>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=a3dcfcd5"></script>
+<script src="js/lib/topbar.js?v=c2fe26da"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/stats.html
+++ b/stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=b75e75b2">
+<link rel="stylesheet" href="css/shared/cards.css?v=7b2b7e95">
 <style>
 h1 {
   font-family: var(--font-display);
@@ -661,7 +661,7 @@ h2 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=7e8205f8"></script>
+<script src="js/lib/topbar.js?v=522f6c3d"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/stats.html
+++ b/stats.html
@@ -663,7 +663,7 @@ h2 {
 <body>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=8c2f9356"></script>
+<script src="js/lib/topbar.js?v=8fe1c285"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/stats.html
+++ b/stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=5ec3c05a">
+<link rel="stylesheet" href="css/shared/cards.css?v=b48b5b18">
 <style>
 h1 {
   font-family: var(--font-display);
@@ -661,6 +661,7 @@ h2 {
 </style>
 </head>
 <body>
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=f444bec4"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>

--- a/stats.html
+++ b/stats.html
@@ -663,7 +663,7 @@ h2 {
 <body>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=8fe1c285"></script>
+<script src="js/lib/topbar.js?v=a47091a2"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/stats.html
+++ b/stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
-<link rel="stylesheet" href="css/shared/cards.css?v=17142038">
+<link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <style>
 h1 {
   font-family: var(--font-display);

--- a/submit.html
+++ b/submit.html
@@ -10,8 +10,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
-<link rel="stylesheet" href="css/shared/site.css?v=c581801e">
-<link rel="stylesheet" href="css/shared/cards.css?v=0092674d">
+<link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
+<link rel="stylesheet" href="css/shared/cards.css?v=ac2f4490">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/submit.html
+++ b/submit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=7b2b7e95">
+<link rel="stylesheet" href="css/shared/cards.css?v=9548e3dd">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/submit.html
+++ b/submit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=9548e3dd">
+<link rel="stylesheet" href="css/shared/cards.css?v=d1db1355">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
@@ -22,7 +22,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=522f6c3d"></script>
+<script src="js/lib/topbar.js?v=3585d26d"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/submit.html
+++ b/submit.html
@@ -9,7 +9,7 @@
 <title>Submit Report — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
-<link rel="stylesheet" href="css/shared/topbar.css?v=256d07b6">
+<link rel="stylesheet" href="css/shared/topbar.css?v=2d6b5e52">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <link rel="stylesheet" href="css/app/game-header.css?v=669186d7">
@@ -22,7 +22,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=c2fe26da"></script>
+<script src="js/lib/topbar.js?v=449040e3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/submit.html
+++ b/submit.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
-<link rel="stylesheet" href="css/app/home.css?v=4ea20844">
+<link rel="stylesheet" href="css/app/home.css?v=d983b41a">
 </head>
 <body>
 

--- a/submit.html
+++ b/submit.html
@@ -22,7 +22,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=1d29a1b6"></script>
+<script src="js/lib/topbar.js?v=a3dcfcd5"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/submit.html
+++ b/submit.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
-<link rel="stylesheet" href="css/app/game-header.css?v=eae4ea27">
+<link rel="stylesheet" href="css/app/game-header.css?v=669186d7">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">

--- a/submit.html
+++ b/submit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=cb310e3b">
+<link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/submit.html
+++ b/submit.html
@@ -11,18 +11,18 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
+<link rel="stylesheet" href="css/shared/cards.css?v=17142038">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
-<link rel="stylesheet" href="css/app/home.css?v=b62dd0ac">
+<link rel="stylesheet" href="css/app/home.css?v=4ea20844">
 </head>
 <body>
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=a47091a2"></script>
+<script src="js/lib/topbar.js?v=1d29a1b6"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/submit.html
+++ b/submit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=4b548983">
+<link rel="stylesheet" href="css/shared/cards.css?v=5ec3c05a">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/submit.html
+++ b/submit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=b48b5b18">
+<link rel="stylesheet" href="css/shared/cards.css?v=cb310e3b">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
@@ -22,7 +22,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=f444bec4"></script>
+<script src="js/lib/topbar.js?v=2f8197e0"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/submit.html
+++ b/submit.html
@@ -10,8 +10,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
-<link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=17c970a6">
+<link rel="stylesheet" href="css/shared/site.css?v=c581801e">
+<link rel="stylesheet" href="css/shared/cards.css?v=0092674d">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/submit.html
+++ b/submit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=ac2f4490">
+<link rel="stylesheet" href="css/shared/cards.css?v=7906ae81">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/submit.html
+++ b/submit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=d1db1355">
+<link rel="stylesheet" href="css/shared/cards.css?v=17c970a6">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
@@ -22,7 +22,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=3585d26d"></script>
+<script src="js/lib/topbar.js?v=f444bec4"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/submit.html
+++ b/submit.html
@@ -9,7 +9,7 @@
 <title>Submit Report — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
-<link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
+<link rel="stylesheet" href="css/shared/topbar.css?v=256d07b6">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <link rel="stylesheet" href="css/app/game-header.css?v=669186d7">
@@ -22,7 +22,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=a3dcfcd5"></script>
+<script src="js/lib/topbar.js?v=c2fe26da"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/submit.html
+++ b/submit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=7906ae81">
+<link rel="stylesheet" href="css/shared/cards.css?v=4b548983">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/submit.html
+++ b/submit.html
@@ -22,7 +22,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=2f8197e0"></script>
+<script src="js/lib/topbar.js?v=8c2f9356"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/submit.html
+++ b/submit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=b75e75b2">
+<link rel="stylesheet" href="css/shared/cards.css?v=7b2b7e95">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
@@ -22,7 +22,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=7e8205f8"></script>
+<script src="js/lib/topbar.js?v=522f6c3d"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/submit.html
+++ b/submit.html
@@ -16,13 +16,13 @@
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">
-<link rel="stylesheet" href="css/app/home.css?v=4bf8008f">
+<link rel="stylesheet" href="css/app/home.css?v=b62dd0ac">
 </head>
 <body>
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=8fe1c285"></script>
+<script src="js/lib/topbar.js?v=a47091a2"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/submit.html
+++ b/submit.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=17142038">
-<link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
+<link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
+<link rel="stylesheet" href="css/app/game-header.css?v=eae4ea27">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">
 <link rel="stylesheet" href="css/app/modals.css?v=2172da2e">

--- a/submit.html
+++ b/submit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=5ec3c05a">
+<link rel="stylesheet" href="css/shared/cards.css?v=b48b5b18">
 <link rel="stylesheet" href="css/app/game-header.css?v=9e753353">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=80a67287">

--- a/submit.html
+++ b/submit.html
@@ -22,7 +22,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=8c2f9356"></script>
+<script src="js/lib/topbar.js?v=8fe1c285"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/system-edit.html
+++ b/system-edit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=7b2b7e95">
+<link rel="stylesheet" href="css/shared/cards.css?v=9548e3dd">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/system-edit.html
+++ b/system-edit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=cb310e3b">
+<link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/system-edit.html
+++ b/system-edit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=4b548983">
+<link rel="stylesheet" href="css/shared/cards.css?v=5ec3c05a">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/system-edit.html
+++ b/system-edit.html
@@ -11,14 +11,14 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=9548e3dd">
+<link rel="stylesheet" href="css/shared/cards.css?v=d1db1355">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=522f6c3d"></script>
+<script src="js/lib/topbar.js?v=3585d26d"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/system-edit.html
+++ b/system-edit.html
@@ -18,7 +18,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=1d29a1b6"></script>
+<script src="js/lib/topbar.js?v=a3dcfcd5"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/system-edit.html
+++ b/system-edit.html
@@ -11,14 +11,14 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=d1db1355">
+<link rel="stylesheet" href="css/shared/cards.css?v=17c970a6">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=3585d26d"></script>
+<script src="js/lib/topbar.js?v=f444bec4"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/system-edit.html
+++ b/system-edit.html
@@ -10,8 +10,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
-<link rel="stylesheet" href="css/shared/site.css?v=c581801e">
-<link rel="stylesheet" href="css/shared/cards.css?v=0092674d">
+<link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
+<link rel="stylesheet" href="css/shared/cards.css?v=ac2f4490">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/system-edit.html
+++ b/system-edit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=ac2f4490">
+<link rel="stylesheet" href="css/shared/cards.css?v=7906ae81">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/system-edit.html
+++ b/system-edit.html
@@ -9,7 +9,7 @@
 <title>Edit System — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
-<link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
+<link rel="stylesheet" href="css/shared/topbar.css?v=256d07b6">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
@@ -18,7 +18,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=a3dcfcd5"></script>
+<script src="js/lib/topbar.js?v=c2fe26da"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/system-edit.html
+++ b/system-edit.html
@@ -9,7 +9,7 @@
 <title>Edit System — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
-<link rel="stylesheet" href="css/shared/topbar.css?v=256d07b6">
+<link rel="stylesheet" href="css/shared/topbar.css?v=2d6b5e52">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
@@ -18,7 +18,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=c2fe26da"></script>
+<script src="js/lib/topbar.js?v=449040e3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/system-edit.html
+++ b/system-edit.html
@@ -10,8 +10,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
-<link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=17c970a6">
+<link rel="stylesheet" href="css/shared/site.css?v=c581801e">
+<link rel="stylesheet" href="css/shared/cards.css?v=0092674d">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/system-edit.html
+++ b/system-edit.html
@@ -11,14 +11,14 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=b48b5b18">
+<link rel="stylesheet" href="css/shared/cards.css?v=cb310e3b">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=f444bec4"></script>
+<script src="js/lib/topbar.js?v=2f8197e0"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/system-edit.html
+++ b/system-edit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=7906ae81">
+<link rel="stylesheet" href="css/shared/cards.css?v=4b548983">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/system-edit.html
+++ b/system-edit.html
@@ -18,7 +18,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=2f8197e0"></script>
+<script src="js/lib/topbar.js?v=8c2f9356"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/system-edit.html
+++ b/system-edit.html
@@ -11,14 +11,14 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
+<link rel="stylesheet" href="css/shared/cards.css?v=17142038">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=a47091a2"></script>
+<script src="js/lib/topbar.js?v=1d29a1b6"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/system-edit.html
+++ b/system-edit.html
@@ -11,14 +11,14 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=b75e75b2">
+<link rel="stylesheet" href="css/shared/cards.css?v=7b2b7e95">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=7e8205f8"></script>
+<script src="js/lib/topbar.js?v=522f6c3d"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/system-edit.html
+++ b/system-edit.html
@@ -18,7 +18,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=8c2f9356"></script>
+<script src="js/lib/topbar.js?v=8fe1c285"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/system-edit.html
+++ b/system-edit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=17142038">
+<link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/system-edit.html
+++ b/system-edit.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=5ec3c05a">
+<link rel="stylesheet" href="css/shared/cards.css?v=b48b5b18">
 <link rel="stylesheet" href="css/profile/profile.css?v=3b36d4de">
 </head>
 <body>

--- a/system-edit.html
+++ b/system-edit.html
@@ -18,7 +18,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=8fe1c285"></script>
+<script src="js/lib/topbar.js?v=a47091a2"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/terms.html
+++ b/terms.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=cb310e3b">
-<link rel="stylesheet" href="css/index/index.css?v=977253e5">
+<link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
+<link rel="stylesheet" href="css/index/index.css?v=edf9e702">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/terms.html
+++ b/terms.html
@@ -89,6 +89,7 @@
 </div>
 </div>
 
+<script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=f444bec4"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>

--- a/terms.html
+++ b/terms.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=9548e3dd">
-<link rel="stylesheet" href="css/index/index.css?v=b3faf0dd">
+<link rel="stylesheet" href="css/shared/cards.css?v=d1db1355">
+<link rel="stylesheet" href="css/index/index.css?v=ad77490b">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }
@@ -89,7 +89,7 @@
 </div>
 </div>
 
-<script src="js/lib/topbar.js?v=522f6c3d"></script>
+<script src="js/lib/topbar.js?v=3585d26d"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -91,7 +91,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=1d29a1b6"></script>
+<script src="js/lib/topbar.js?v=a3dcfcd5"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
-<link rel="stylesheet" href="css/index/index.css?v=f047d582">
+<link rel="stylesheet" href="css/shared/cards.css?v=17142038">
+<link rel="stylesheet" href="css/index/index.css?v=cef6764d">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }
@@ -91,7 +91,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=a47091a2"></script>
+<script src="js/lib/topbar.js?v=1d29a1b6"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -10,9 +10,9 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
-<link rel="stylesheet" href="css/shared/site.css?v=c581801e">
-<link rel="stylesheet" href="css/shared/cards.css?v=0092674d">
-<link rel="stylesheet" href="css/index/index.css?v=5ef799ac">
+<link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
+<link rel="stylesheet" href="css/shared/cards.css?v=ac2f4490">
+<link rel="stylesheet" href="css/index/index.css?v=a2de5ad7">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/terms.html
+++ b/terms.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=7b2b7e95">
-<link rel="stylesheet" href="css/index/index.css?v=e7a3bfb0">
+<link rel="stylesheet" href="css/shared/cards.css?v=9548e3dd">
+<link rel="stylesheet" href="css/index/index.css?v=b3faf0dd">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/terms.html
+++ b/terms.html
@@ -10,8 +10,8 @@
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
-<link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=17c970a6">
+<link rel="stylesheet" href="css/shared/site.css?v=c581801e">
+<link rel="stylesheet" href="css/shared/cards.css?v=0092674d">
 <link rel="stylesheet" href="css/index/index.css?v=5ef799ac">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }

--- a/terms.html
+++ b/terms.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=7906ae81">
+<link rel="stylesheet" href="css/shared/cards.css?v=4b548983">
 <link rel="stylesheet" href="css/index/index.css?v=39339c49">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }

--- a/terms.html
+++ b/terms.html
@@ -91,7 +91,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=2f8197e0"></script>
+<script src="js/lib/topbar.js?v=8c2f9356"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=ac2f4490">
-<link rel="stylesheet" href="css/index/index.css?v=a2de5ad7">
+<link rel="stylesheet" href="css/shared/cards.css?v=7906ae81">
+<link rel="stylesheet" href="css/index/index.css?v=39339c49">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/terms.html
+++ b/terms.html
@@ -9,7 +9,7 @@
 <title>Terms of Service - Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
-<link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
+<link rel="stylesheet" href="css/shared/topbar.css?v=256d07b6">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <link rel="stylesheet" href="css/index/index.css?v=624d05bc">
@@ -91,7 +91,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=a3dcfcd5"></script>
+<script src="js/lib/topbar.js?v=c2fe26da"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=17142038">
-<link rel="stylesheet" href="css/index/index.css?v=cef6764d">
+<link rel="stylesheet" href="css/index/index.css?v=6b16bc5f">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/terms.html
+++ b/terms.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=d1db1355">
-<link rel="stylesheet" href="css/index/index.css?v=ad77490b">
+<link rel="stylesheet" href="css/shared/cards.css?v=17c970a6">
+<link rel="stylesheet" href="css/index/index.css?v=5ef799ac">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }
@@ -89,7 +89,7 @@
 </div>
 </div>
 
-<script src="js/lib/topbar.js?v=3585d26d"></script>
+<script src="js/lib/topbar.js?v=f444bec4"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -9,7 +9,7 @@
 <title>Terms of Service - Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
-<link rel="stylesheet" href="css/shared/topbar.css?v=256d07b6">
+<link rel="stylesheet" href="css/shared/topbar.css?v=2d6b5e52">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
 <link rel="stylesheet" href="css/index/index.css?v=624d05bc">
@@ -91,7 +91,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=c2fe26da"></script>
+<script src="js/lib/topbar.js?v=449040e3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=4b548983">
-<link rel="stylesheet" href="css/index/index.css?v=39339c49">
+<link rel="stylesheet" href="css/shared/cards.css?v=5ec3c05a">
+<link rel="stylesheet" href="css/index/index.css?v=82445769">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/terms.html
+++ b/terms.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=b48b5b18">
-<link rel="stylesheet" href="css/index/index.css?v=501c588c">
+<link rel="stylesheet" href="css/shared/cards.css?v=cb310e3b">
+<link rel="stylesheet" href="css/index/index.css?v=977253e5">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }
@@ -91,7 +91,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=f444bec4"></script>
+<script src="js/lib/topbar.js?v=2f8197e0"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -91,7 +91,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=8c2f9356"></script>
+<script src="js/lib/topbar.js?v=8fe1c285"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=17142038">
-<link rel="stylesheet" href="css/index/index.css?v=6b16bc5f">
+<link rel="stylesheet" href="css/shared/cards.css?v=564a6733">
+<link rel="stylesheet" href="css/index/index.css?v=624d05bc">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }

--- a/terms.html
+++ b/terms.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
-<link rel="stylesheet" href="css/shared/cards.css?v=5ec3c05a">
-<link rel="stylesheet" href="css/index/index.css?v=82445769">
+<link rel="stylesheet" href="css/shared/cards.css?v=b48b5b18">
+<link rel="stylesheet" href="css/index/index.css?v=501c588c">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }
@@ -89,6 +89,7 @@
 </div>
 </div>
 
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
 <script src="js/lib/topbar.js?v=f444bec4"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>

--- a/terms.html
+++ b/terms.html
@@ -11,8 +11,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=45c7e06d">
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=4d518a51">
-<link rel="stylesheet" href="css/shared/cards.css?v=b75e75b2">
-<link rel="stylesheet" href="css/index/index.css?v=2d161a7e">
+<link rel="stylesheet" href="css/shared/cards.css?v=7b2b7e95">
+<link rel="stylesheet" href="css/index/index.css?v=e7a3bfb0">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }
@@ -89,7 +89,7 @@
 </div>
 </div>
 
-<script src="js/lib/topbar.js?v=7e8205f8"></script>
+<script src="js/lib/topbar.js?v=522f6c3d"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/terms.html
+++ b/terms.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=f4f0510d">
 <link rel="stylesheet" href="css/shared/site.css?v=5fac0fae">
 <link rel="stylesheet" href="css/shared/cards.css?v=e3d2c5cb">
-<link rel="stylesheet" href="css/index/index.css?v=edf9e702">
+<link rel="stylesheet" href="css/index/index.css?v=f047d582">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
   .prose h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }
@@ -91,7 +91,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=04813aa1"></script>
-<script src="js/lib/topbar.js?v=8fe1c285"></script>
+<script src="js/lib/topbar.js?v=a47091a2"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/tests/adminAllReports.test.js
+++ b/tests/adminAllReports.test.js
@@ -4,12 +4,21 @@ function makeSession() {
   return { access_token: 'tok', user: { id: 'uid' } };
 }
 
-function loadApi(fetchImpl) {
+// Default approval mock: empty list (every row reads as pending). Tests that
+// care about approval state override `approvalsImpl`.
+function loadApi(fetchImpl, { approvalsImpl } = {}) {
   const calls = [];
   const ctx = {
     SUPABASE_URL: 'https://sb.example',
     supabaseHeaders: (s, extra = {}) => ({ Authorization: 'Bearer tok', apikey: 'anon', ...extra }),
-    fetch: (url, opts) => { calls.push({ url, opts }); return fetchImpl(url, opts); },
+    fetch: (url, opts) => {
+      calls.push({ url, opts });
+      if (url.includes('/report_approvals')) {
+        const impl = approvalsImpl || (() => Promise.resolve({ ok: true, json: () => Promise.resolve([]) }));
+        return impl(url, opts);
+      }
+      return fetchImpl(url, opts);
+    },
   };
   loadEsm(['js/admin/api/allReports.js'], ctx);
   return { ctx, calls };
@@ -18,15 +27,53 @@ function loadApi(fetchImpl) {
 describe('fetchAllReports', () => {
   test('fetches user_configs ordered by created_at desc, defaults to clean', async () => {
     const rows = [{ id: 1, app_id: '730', title: 'Counter-Strike 2', rating: 'platinum', source: 'pulse', created_at: '2025-01-01T00:00:00Z' }];
-    const { ctx, calls } = loadApi(() => Promise.resolve({ ok: true, json: () => Promise.resolve(rows) }));
+    const { ctx, calls } = loadApi(
+      () => Promise.resolve({ ok: true, json: () => Promise.resolve(rows) }),
+      { approvalsImpl: () => Promise.resolve({ ok: true, json: () => Promise.resolve([{ report_id: 1 }]) }) },
+    );
 
     const result = await ctx.fetchAllReports(makeSession());
 
-    expect(result).toEqual(rows);
-    expect(calls).toHaveLength(1);
-    expect(calls[0].url).toContain('/user_configs');
-    expect(calls[0].url).toContain('order=created_at.desc');
-    expect(calls[0].url).toContain('is_flagged=eq.false');
+    expect(result).toEqual([{ ...rows[0], is_pending: false }]);
+    const userCfgCall = calls.find(c => c.url.includes('/user_configs'));
+    expect(userCfgCall).toBeTruthy();
+    expect(userCfgCall.url).toContain('order=created_at.desc');
+    expect(userCfgCall.url).toContain('is_flagged=eq.false');
+    expect(calls.some(c => c.url.includes('/report_approvals'))).toBe(true);
+  });
+
+  test('clean status filters out reports without an approval row', async () => {
+    const rows = [
+      { id: 1, app_id: '730', title: 'Approved game', created_at: '2025-01-01' },
+      { id: 2, app_id: '731', title: 'Pending game',  created_at: '2025-01-02' },
+    ];
+    const { ctx } = loadApi(
+      () => Promise.resolve({ ok: true, json: () => Promise.resolve(rows) }),
+      { approvalsImpl: () => Promise.resolve({ ok: true, json: () => Promise.resolve([{ report_id: 1 }]) }) },
+    );
+
+    const result = await ctx.fetchAllReports(makeSession(), { status: 'clean' });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(1);
+    expect(result[0].is_pending).toBe(false);
+  });
+
+  test('pending status keeps only reports without an approval row', async () => {
+    const rows = [
+      { id: 1, app_id: '730', created_at: '2025-01-01' },
+      { id: 2, app_id: '731', created_at: '2025-01-02' },
+    ];
+    const { ctx } = loadApi(
+      () => Promise.resolve({ ok: true, json: () => Promise.resolve(rows) }),
+      { approvalsImpl: () => Promise.resolve({ ok: true, json: () => Promise.resolve([{ report_id: 1 }]) }) },
+    );
+
+    const result = await ctx.fetchAllReports(makeSession(), { status: 'pending' });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(2);
+    expect(result[0].is_pending).toBe(true);
   });
 
   test('applies date range filter when provided', async () => {
@@ -82,13 +129,29 @@ describe('fetchAllReports', () => {
 describe('fetchReportById', () => {
   test('fetches a single report by id from user_configs', async () => {
     const report = { id: 42, app_id: '730', title: 'Counter-Strike 2', is_flagged: false, is_hidden: false };
-    const { ctx, calls } = loadApi(() => Promise.resolve({ ok: true, json: () => Promise.resolve([report]) }));
+    const { ctx, calls } = loadApi(
+      () => Promise.resolve({ ok: true, json: () => Promise.resolve([report]) }),
+      { approvalsImpl: () => Promise.resolve({ ok: true, json: () => Promise.resolve([{ report_id: 42 }]) }) },
+    );
 
     const result = await ctx.fetchReportById(makeSession(), '42');
 
-    expect(result).toEqual(report);
-    expect(calls[0].url).toContain('user_configs');
-    expect(calls[0].url).toContain('id=eq.42');
+    expect(result).toEqual({ ...report, is_pending: false });
+    const userCfgCall = calls.find(c => c.url.includes('/user_configs'));
+    expect(userCfgCall.url).toContain('id=eq.42');
+    expect(calls.some(c => c.url.includes('/report_approvals') && c.url.includes('report_id=eq.42'))).toBe(true);
+  });
+
+  test('marks report as pending when no approval row exists', async () => {
+    const report = { id: 42, app_id: '730', title: 'Counter-Strike 2', is_flagged: false, is_hidden: false };
+    const { ctx } = loadApi(
+      () => Promise.resolve({ ok: true, json: () => Promise.resolve([report]) }),
+      { approvalsImpl: () => Promise.resolve({ ok: true, json: () => Promise.resolve([]) }) },
+    );
+
+    const result = await ctx.fetchReportById(makeSession(), '42');
+
+    expect(result.is_pending).toBe(true);
   });
 
   test('throws when report is not found', async () => {

--- a/tests/gridSize.test.js
+++ b/tests/gridSize.test.js
@@ -38,25 +38,29 @@ describe('configurable card size (S/M/L)', () => {
     expect(cssSrc).toContain('.cards--lg .game-card-thumb');
   });
 
-  test('S/M/L are disabled in list mode', () => {
+  test('S/M/L/XL stay enabled in both layouts (tile mode uses size as column width)', () => {
     expect(homeSrc).toContain('function _setSizeEnabled(enabled)');
     expect(homeSrc).toContain('b.disabled = !enabled');
-    expect(homeSrc).toContain('_setSizeEnabled(!isList)');
+    expect(homeSrc).toContain('_setSizeEnabled(true)');
     expect(cssSrc).toContain('.home-size-btn:disabled');
   });
 
-  test('list view applies to both Recent and Popular sections', () => {
-    expect(homeSrc).toContain("document.getElementById('cards-popular')?.classList.toggle('home-cards-list', isList)");
-    // popular renders a slim list row in list mode, a sized card otherwise
+  test('tile-mode (grid) applies to both Recent and Popular sections', () => {
+    expect(homeSrc).toContain("document.getElementById('cards-popular')?.classList.toggle('home-cards-tile-mode', isTile)");
+    // both layouts use the same card renderer; CSS does the visual swap
     expect(homeSrc).toContain('function _popularItemHtml(g)');
-    expect(homeSrc).toContain("if (currentLayout === 'list') return _listRowHtml(g)");
+    expect(homeSrc).not.toContain('_listRowHtml');
   });
 
   test('load more keeps the current view in both sections', () => {
-    // recent appends with the layout-aware renderFn, popular with _popularItemHtml
     expect(homeSrc).toContain('batch.map(renderFn).join(\'\')');
     expect(homeSrc).toContain('batch.map(_popularItemHtml).join(\'\')');
-    // the old layout-blind _appendCards helper is gone
     expect(homeSrc).not.toContain('function _appendCards');
+  });
+
+  test('CSS reshapes the card container into a Steam-style tile grid', () => {
+    expect(cssSrc).toContain('.home-cards-tile-mode');
+    expect(cssSrc).toContain('grid-template-columns: repeat(auto-fill, minmax');
+    expect(cssSrc).toContain('aspect-ratio: 460 / 215');
   });
 });

--- a/tests/gridSize.test.js
+++ b/tests/gridSize.test.js
@@ -13,10 +13,11 @@ describe('configurable card size (S/M/L)', () => {
     expect(homeSrc).toContain('data-size="lg"');
   });
 
-  test('size is a saved user preference defaulting to medium', () => {
+  test('size is a saved user preference; default picks lg on desktop, md on mobile', () => {
     expect(homeSrc).toContain("const SIZE_KEY = 'pp:grid-size'");
     expect(homeSrc).toContain('localStorage.setItem(SIZE_KEY, size)');
-    expect(homeSrc).toContain("return SIZES.includes(s) ? s : 'md'");
+    expect(homeSrc).toContain("window.matchMedia('(min-width: 760px)').matches ? 'lg' : 'md'");
+    expect(homeSrc).toContain('SIZES.includes(s) ? s : _DEFAULT_SIZE');
     expect(homeSrc).toContain('applyGridSize(_savedSize())');
   });
 

--- a/tests/profileSystems.test.js
+++ b/tests/profileSystems.test.js
@@ -775,7 +775,7 @@ describe('mergeMyReportRows', () => {
 
     expect(rows).toEqual([
       expect.objectContaining({
-        app_id: 570,
+        app_id: '570',
         published: true,
         cloud: false,
         unpublished: false,
@@ -797,7 +797,7 @@ describe('mergeMyReportRows', () => {
 
     expect(rows).toEqual([
       expect.objectContaining({
-        app_id: 730,
+        app_id: '730',
         published: false,
         cloud: true,
         unpublished: true,
@@ -823,7 +823,7 @@ describe('mergeMyReportRows', () => {
     // published. unpublished=true only applies to cloud-only rows with no report.
     expect(rows).toEqual([
       expect.objectContaining({
-        app_id: 1091500,
+        app_id: '1091500',
         published: true,
         cloud: true,
         unpublished: false,
@@ -846,12 +846,39 @@ describe('mergeMyReportRows', () => {
 
     expect(rows).toEqual([
       expect.objectContaining({
-        app_id: 620,
+        app_id: '620',
         cloud: true,
         published: true,
         unpublished: false,
       }),
     ]);
+    expect(ctx.__getMyReportBadges(rows[0])).toEqual([
+      { label: 'Cloud', tone: 'cloud' },
+      { label: 'Published', tone: 'published' },
+    ]);
+  });
+
+  test('collapses one game into a single row when published app_id is a string and cloud app_id is a number (issue #131)', async () => {
+    const { ctx } = makeCtx(null);
+    await flush();
+
+    // user_configs.app_id is a text column (string from the API);
+    // user_proton_configs.app_id is bigint (number). The merge must treat them
+    // as the same game instead of emitting two rows.
+    const rows = ctx.__mergeMyReportRows([
+      { app_id: '2358720', title: 'Black Myth: Wukong', rating: 'platinum', id: 22, created_at: '2026-06-28T23:42:56Z' },
+    ], [
+      { app_id: 2358720, app_name: 'Black Myth: Wukong', updated_at: '2026-06-28T23:41:43Z', is_published: false },
+    ]);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual(expect.objectContaining({
+      app_id: '2358720',
+      cloud: true,
+      published: true,
+      unpublished: false,
+      rating: 'platinum',
+    }));
     expect(ctx.__getMyReportBadges(rows[0])).toEqual([
       { label: 'Cloud', tone: 'cloud' },
       { label: 'Published', tone: 'published' },

--- a/tests/storeBrowsing.test.js
+++ b/tests/storeBrowsing.test.js
@@ -81,9 +81,8 @@ describe('store pill rendering', () => {
       expect(cardsCss).toContain(`.game-card-store-pill--${s}`);
     });
   });
-  test('home cards and list rows pass a storePill', () => {
+  test('home cards pass a storePill to the renderer (both layouts use the same card)', () => {
     expect(homeSrc).toContain('storePill: storeLabel(appType)');
-    expect(homeSrc).toContain('game-card-store-pill game-card-store-pill--${store.toLowerCase()}');
   });
   test('search results and dropdown show the store pill', () => {
     expect(searchSrc).toContain('storePill: storeLabelFromAppId(row.appId)');


### PR DESCRIPTION
## Summary

v1.5.0 promotion bundling the bottom-bar card layout work (#130), the admin Reports pending filter (#132), the My Reports duplicate fix (#131), the Steam-style tile grid, the combined corner chip, and the matching topbar-search dropdown chip.

## Highlights

### Card layout & defaults
- **Bottom-bar tier strip** is the default rating layout. Five placement options for the store badge: right column, artwork overlay, card corner, on bar next to rating, on bar split.
- **Default badge placement is viewport-aware**: mobile uses `bar-inline` (next to the rating in the bottom bar), desktop uses `art-corner` (card top-right tag). Both default to the text label until the round brand glyphs read consistently.
- **Combined corner chip** card layout: tier color on the left, store color on the right, in a single corner pill. Hides the strip / right column / other store placements automatically.

### Card sizes & layouts
- **Desktop S/M/L/XL bumped roomier** (LG: 290x135 thumb, XL: 400x187). Mobile sizes unchanged.
- **Default size on desktop is `lg`**; mobile keeps `md`.
- **Steam-style tile grid**: new \"Grid\" view turns the browse pages into a CSS grid of header-aspect thumbnails (vertical tile per game, title below thumb). \"List\" view is the renamed horizontal-card layout; the super-condensed list mode is gone. Grid is the default while verifying; Options page has a `Default layout` radio.

### Polish
- **GOG and Epic store glyphs** redrawn so they keep their brand shape.
- **Permalink** anchor wraps the whole report block so #report-r<id> lands on top of the report; topbar-offset scroll so the header isn't tucked behind the toolbar.
- **Framegen icon** is green when not required, red when required.
- **Submit Report button** swaps the neon-green pill for the Steam-blue accent.
- **Confidence pill** widened (flex 7 -> 9) and locked to nowrap so \"Confidence: 95%\" no longer wraps to two lines.
- **Tile/sm peak text**: \" peak players\" suffix drops on small list rows and all tile-mode tiles; nowrap + ellipsis as a backstop.
- **Topbar search dropdown** rows use a split combo chip (tier color | store color) on the trailing edge, matching the .game-card-combo-tag look. App id moves to the row-two subline (the old report-count line is gone) so the thumbnail flows straight into the title.

### Options page
- `(default)` markers (with mobile / desktop variants where relevant) and a Reset to defaults button.
- `pp:grid-layout` added to the Reset list.
- Supabase header auth fixed on options / privacy / scoring / stats / terms (the supabase library wasn't being loaded on those pages).

### Admin
- Admin Reports tab adds a `Pending approval` filter with approval-aware status badges. Rows in user_configs without a matching `report_approvals` row now show as pending instead of mixing into Clean.
- App link goes to the report permalink for approved-and-visible rows; pending / flagged / hidden rows keep the game-level link.
- New `approved` (green) and `pending` (blue) badges in the legend.

### Profile
- My Reports dedupes rows when `app_id` is stored as string in one row and number in another (#131).

## Test plan

- [ ] /options.html: defaults marked correctly per viewport; Reset clears all preferences
- [ ] Fresh visit on mobile lands on bar-inline + text; on desktop lands on art-corner + text
- [ ] Card layout permutations (right, artwork, card corner, bar inline, bar split, combo) render cleanly on home and app pages
- [ ] Tile (Grid) view loads correctly on both home and app pages; S/M/L/XL adjusts tile column width
- [ ] List view still works
- [ ] Confidence pill stays on one line at narrow widths
- [ ] Topbar search dropdown rows: thumb -> title -> app id -> split chip; thumbnail flows straight into the title
- [ ] /admin.html Reports tab: pending filter, badges, permalink-style App link
- [ ] Permalink lands on top of the report
- [ ] Framegen icon colored correctly
- [ ] Signed-in avatar visible on options / privacy / scoring / stats / terms
- [ ] /profile.html My Reports: no duplicates

31 commits ahead of main. About page should read **v1.5.0 - 645e1aa** (or later staging head) after deploy.