### PR TITLE
Coverage groundwork: 16% -> 95% + two real bug fixes

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -22,13 +22,10 @@ module.exports = {
     'js/admin/api/allReports.js',
     'js/admin/api/analytics.js',
     'js/admin/api/pending.js',
+    'js/profile/utils.js',
     'js/lib/analytics.js',
     'js/lib/app-id.js',
     'js/lib/gpu-arch-detector.js',
-    // js/profile/utils.js is a large legacy module without direct
-    // require-based coverage yet; add when behavioral tests land
-    // (existing profileSystems.test.js uses vm/loadEsm which Istanbul
-    // does not instrument).
   ],
   coverageThreshold: {
     global: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,9 +4,31 @@ module.exports = {
   transform: {
     '^.+\\.m?js$': 'babel-jest',
   },
+  // The site's import paths carry a ?v=<content-hash> cache-busting
+  // suffix that Node cannot resolve. Strip it at module-resolution time
+  // so babel-jest can transform + instrument these files for coverage.
+  moduleNameMapper: {
+    '^(.*?)\\?v=[a-f0-9]+$': '$1',
+  },
+  // Coverage scope: pure-ish modules with real branching logic. Page-init
+  // IIFEs (js/admin/main.js, js/profile/main.js, etc.) and DOM-heavy
+  // components stay out -- those need jsdom rather than a vm context to
+  // measure cleanly, and the source-shape tests catch their regressions
+  // already. As behavioral tests come in for component files, add them
+  // here so the threshold below keeps applying.
   collectCoverageFrom: [
     'js/app/utils.js',
     'js/admin/permissions.js',
+    'js/admin/api/allReports.js',
+    'js/admin/api/analytics.js',
+    'js/admin/api/pending.js',
+    'js/lib/analytics.js',
+    'js/lib/app-id.js',
+    'js/lib/gpu-arch-detector.js',
+    // js/profile/utils.js is a large legacy module without direct
+    // require-based coverage yet; add when behavioral tests land
+    // (existing profileSystems.test.js uses vm/loadEsm which Istanbul
+    // does not instrument).
   ],
   coverageThreshold: {
     global: {

--- a/js/app/api/votes.js
+++ b/js/app/api/votes.js
@@ -1,6 +1,6 @@
 // votes (api) for the app page. Relocated from app.js.
 
-import { getWebClientId } from '../../shared/submit.js?v=113ce5ad';
+import { getWebClientId } from '../../shared/submit.js?v=bfb1bfdc';
 import { SB_KEY, SB_URL } from '../config.js?v=df5b5024';
 
 export async function fetchVotes(appId) {

--- a/js/app/components/config-cards.js
+++ b/js/app/components/config-cards.js
@@ -1,6 +1,6 @@
 // config-cards (components) for the app page. Relocated from app.js.
 
-import { getWebClientId } from '../../shared/submit.js?v=113ce5ad';
+import { getWebClientId } from '../../shared/submit.js?v=bfb1bfdc';
 import { isNonSteamAppId } from '../config.js?v=df5b5024';
 import { cfgNa, configKey, esc, utcStamp } from '../utils.js?v=9a30ef3e';
 

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -1,6 +1,6 @@
 // game-page (components) for the app page. Relocated from app.js.
 
-import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
+import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=b4fbb7ef';
 import { populateScoringTooltip, pulseTierFromReports, tierFromReports } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=113ce5ad';
 import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.js?v=21903124';

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -2,7 +2,7 @@
 
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=b4fbb7ef';
 import { populateScoringTooltip, pulseTierFromReports, tierFromReports } from '../../shared/scoring.js?v=0dae1257';
-import { getWebClientId } from '../../shared/submit.js?v=113ce5ad';
+import { getWebClientId } from '../../shared/submit.js?v=bfb1bfdc';
 import { fetchDeckStatusForApp, fetchMinRequirements } from '../api/deck-status.js?v=21903124';
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=083594fa';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=0594677b';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { getWebClientId } from '../../shared/submit.js?v=113ce5ad';
-import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=1f02f4a6';
+import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=b4fbb7ef';
 import { renderAuthorBlock } from './author.js?v=2316d334';
 import { buildFormRows } from './config-cards.js?v=c67740f8';
 import { renderSignalStrip } from './signals.js?v=a23da3df';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -1,7 +1,7 @@
 // report-card (components) for the app page. Relocated from app.js.
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
-import { getWebClientId } from '../../shared/submit.js?v=113ce5ad';
+import { getWebClientId } from '../../shared/submit.js?v=bfb1bfdc';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=b4fbb7ef';
 import { renderAuthorBlock } from './author.js?v=2316d334';
 import { buildFormRows } from './config-cards.js?v=c67740f8';

--- a/js/lib/gpu-arch-detector.js
+++ b/js/lib/gpu-arch-detector.js
@@ -31,14 +31,36 @@ export function detectGpuArch(gpu) {
   // Polaris — RX 4xx/5xx (discrete, not RDNA RX 5xxx already matched above)
   if (/\brx\s*[45][0-9]{2}\b/.test(s)) return 'Polaris';
 
-  // GCN3 — Fiji/Hawaii: R9 Fury, R9 Nano, R9 390, R9 285, R9 380
-  if (/r9\s*(fury|nano)|r9\s*3[89]0|r9\s*28[05]|r9\s*380/.test(s)) return 'GCN3';
+  // GCN3 — Tonga/Fiji: R9 Fury, R9 Nano, R9 285, R9 380/390
+  // #151: dropped "R9 280" from the GCN3 set -- it's GCN2 (Tahiti). Only
+  // R9 285 (Tonga) belongs here.
+  if (/r9\s*(fury|nano)|r9\s*3[89]0|r9\s*285/.test(s)) return 'GCN3';
 
   // GCN2 — Sea Islands: R9 270/280, R7 260/265
   if (/r[79]\s*2[678]\d/.test(s)) return 'GCN2';
 
   // GCN1 — Southern Islands: HD 7xxx
   if (/hd\s*7[0-9]{3}/.test(s)) return 'GCN1';
+
+  // ---- Intel --------------------------------------------------------------
+  // #151: Intel block runs BEFORE NVIDIA so the Arc A-series doesn't get
+  // swallowed by NVIDIA Ampere's `\ba\d{3,4}\b` workstation fallback.
+  // Architectures are distinct across vendors so reorder is safe.
+
+  // Arc Battlemage — Arc B-series (B580, B770)
+  if (/arc\s*b\d{3}/.test(s)) return 'Battlemage';
+
+  // Arc Alchemist — Arc A-series (A380, A750, A770)
+  if (/arc\s*a\d{3}/.test(s) || /\balchemist\b/.test(s)) return 'Alchemist';
+
+  // Xe / Gen12 — Iris Xe, UHD 7xx (Tiger Lake / Alder Lake). Allow an
+  // optional "graphics" word between UHD and the model number so e.g.
+  // "Intel UHD Graphics 770" matches.
+  if (/iris\s*xe|uhd(?:\s+graphics)?\s*7[0-9]{2}/.test(s)) return 'Xe';
+
+  // Gen9 — HD 5xx/6xx, UHD 6xx (Skylake/Kaby Lake/Coffee Lake). Same
+  // optional "graphics" affordance as Xe.
+  if (/(?:^|\W)hd(?:\s+graphics)?\s*[56]\d{2}|uhd(?:\s+graphics)?\s*6[0-9]{2}/.test(s)) return 'Gen9';
 
   // ---- NVIDIA -------------------------------------------------------------
 
@@ -54,28 +76,15 @@ export function detectGpuArch(gpu) {
   // Turing — RTX 2xxx, GTX 1650/1660
   if (/rtx\s*2\d{3}/.test(s) || /gtx\s*16[56]\d/.test(s)) return 'Turing';
 
-  // Pascal — GTX 10xx (e.g. GTX 1080 Ti, GTX 1060)
-  if (/gtx\s*10[567]\d/.test(s)) return 'Pascal';
+  // Pascal — GTX 1050/1060/1070/1080 (range widened from 10[567] to 10[5-8]
+  // so the GTX 1080 flagship matches; #151).
+  if (/gtx\s*10[5-8]\d/.test(s)) return 'Pascal';
 
   // Maxwell — GTX 9xx, GTX 750 (not GTX 760+ which are Kepler)
   if (/gtx\s*9[0-9]{2}/.test(s) || /gtx\s*750/.test(s)) return 'Maxwell';
 
   // Kepler — GTX 6xx, GTX 7xx (excepting 750 already matched)
   if (/gtx\s*[67]\d{2}/.test(s)) return 'Kepler';
-
-  // ---- Intel --------------------------------------------------------------
-
-  // Arc Battlemage — Arc B-series (B580, B770)
-  if (/arc\s*b\d{3}/.test(s)) return 'Battlemage';
-
-  // Arc Alchemist — Arc A-series (A380, A750, A770)
-  if (/arc\s*a\d{3}/.test(s) || /\balchemist\b/.test(s)) return 'Alchemist';
-
-  // Xe / Gen12 — Iris Xe, UHD 7xx (Tiger Lake / Alder Lake)
-  if (/iris\s*xe|uhd\s*7[0-9]{2}/.test(s)) return 'Xe';
-
-  // Gen9 — HD 5xx/6xx, UHD 6xx (Skylake/Kaby Lake/Coffee Lake)
-  if (/hd\s*[56]\d{2}|uhd\s*6[0-9]{2}/.test(s)) return 'Gen9';
 
   return '';
 }

--- a/js/profile/components/edit-modals.js
+++ b/js/profile/components/edit-modals.js
@@ -4,13 +4,13 @@
 import {
   escapeHtml, formatSystemUpdated, enabledVarsToText, textToEnabledVars,
   parseUploadedSystem, isGenericSystemLabel, inferSystemLabel,
-} from '../utils.js?v=9a539c02';
+} from '../utils.js?v=94e4c20f';
 import {
   fetchCloudConfig, patchCloudConfig, fetchFullUserConfig,
   fetchReportHistory, patchUserConfig,
 } from '../api/configs.js?v=0c5650ed';
 import { updateSystem } from '../api/systems.js?v=770d14b7';
-import { notesFormattingHelpHtml } from '../../shared/submit.js?v=113ce5ad';
+import { notesFormattingHelpHtml } from '../../shared/submit.js?v=bfb1bfdc';
 
 export let _cloudEditModal = null;
 export function getCloudEditModal() {

--- a/js/profile/components/my-hardware.js
+++ b/js/profile/components/my-hardware.js
@@ -8,7 +8,7 @@ import {
   parseSteamSystemInfo, inferGpuVendor,
   getMyHwSourceMeta, setMyHwSourceMeta, getMyHwFieldOrigins,
   setMyHwFieldOrigins, setMyHwFieldOrigin,
-} from '../utils.js?v=9a539c02';
+} from '../utils.js?v=94e4c20f';
 
 /**
  * Initialise the My Hardware pane. Call once after DOM is ready.

--- a/js/profile/components/my-reports.js
+++ b/js/profile/components/my-reports.js
@@ -5,7 +5,7 @@ import {
   getProtonPulseUserIdFromSession, escapeHtml, formatSystemUpdated,
   getWebClientIdProfile, getMyReportBadges, flaggedMessageHtml,
   mergeMyReportRows,
-} from '../utils.js?v=9a539c02';
+} from '../utils.js?v=94e4c20f';
 import {
   fetchMyUserConfigs, fetchMyCloudConfigs, deleteMyReportsEverywhere,
   unpublishReport,

--- a/js/profile/components/systems.js
+++ b/js/profile/components/systems.js
@@ -6,7 +6,7 @@ import {
   getProtonPulseUserIdFromSession, parseSteamSystemInfo, inferGpuVendor,
   parseUploadedSystem, isGenericSystemLabel, inferSystemLabel,
   summarizeSystem, escapeHtml, formatSystemUpdated,
-} from '../utils.js?v=9a539c02';
+} from '../utils.js?v=94e4c20f';
 import {
   listUserSystems, setDefaultSystem, clearDefaultSystem,
   updateSystemLabel, deleteSystem,

--- a/js/profile/main.js
+++ b/js/profile/main.js
@@ -9,7 +9,7 @@ import {
   getProtonPulseUserIdFromSession, getShowUsername, setShowUsername,
   escapeHtml, formatSystemUpdated, getWebClientIdProfile,
   getPluginLinkCodeFromLocation, getSteamIdFromSession,
-} from './utils.js?v=9a539c02';
+} from './utils.js?v=94e4c20f';
 import {
   deleteAllMyData, fetchAllMyData, checkMyDataExists,
 } from './api/configs.js?v=0c5650ed';

--- a/js/profile/system-edit.js
+++ b/js/profile/system-edit.js
@@ -2,7 +2,7 @@ import { SUPABASE_URL, SUPABASE_ANON_KEY, SupaAuth } from './config.js?v=87cd0f3
 import {
   getProtonPulseUserIdFromSession, parseSteamSystemInfo, inferGpuVendor, inferCpuVendor,
   parseUploadedSystem, isGenericSystemLabel, inferSystemLabel, escapeHtml,
-} from './utils.js?v=9a539c02';
+} from './utils.js?v=94e4c20f';
 import { supabaseHeaders } from './api/supabase.js?v=4889c5e6';
 import { supabaseUserSystemsUrl, listUserSystems, updateSystem } from './api/systems.js?v=770d14b7';
 

--- a/js/profile/utils.js
+++ b/js/profile/utils.js
@@ -187,8 +187,10 @@ export function parseSteamSystemInfo(text) {
   const vram = text.match(/VRAM:\s*(\d+)\s*Mb/i);
   if (vram) out.vramMb = Number(vram[1]);
 
-  // RAM shows in megs, e.g. "RAM: 32677 Mb". Convert to whole GB for the form
-  const ram = text.match(/RAM:\s*(\d+)\s*Mb/i);
+  // RAM shows in megs, e.g. "RAM: 32677 Mb". Convert to whole GB for the form.
+  // #152: anchor on start-of-line so a "VRAM:" prefix earlier in the buffer
+  // does not steal the match (no word boundary anchor in plain text).
+  const ram = text.match(/^\s*RAM:\s*(\d+)\s*Mb/im);
   if (ram) {
     const gb = Math.round(Number(ram[1]) / 1024);
     if (gb > 0) out.ram = `${gb} GB`;

--- a/js/shared/submit.js
+++ b/js/shared/submit.js
@@ -2,7 +2,7 @@
 
 import { SupaAuth } from './config.js?v=f6f2c00a';
 import { FAULT_KEYS_WEB, deriveRatingFromState, inferProtonType } from './scoring.js?v=0dae1257';
-import { detectGpuArch } from '../lib/gpu-arch-detector.js?v=1f02f4a6';
+import { detectGpuArch } from '../lib/gpu-arch-detector.js?v=b4fbb7ef';
 
 // Form submission + populate-submit-form -- factored out of app.js.
 // Loaded as a classic script BEFORE app.js so its globals

--- a/js/shared/submit.js
+++ b/js/shared/submit.js
@@ -48,7 +48,9 @@ export function parseSteamSystemInfo(text) {
   if (gpu && !/^unknown$/i.test(gpu)) out.gpu = gpu.replace(/^(NVIDIA Corporation|Advanced Micro Devices.*?Inc\.\s*\[AMD\/ATI\]|AMD|Intel Corporation)\s*/i, '').replace(/^NVIDIA\s+/i, '').trim();
   const drv = m(/Driver Version:\s*(.+)/i);
   if (drv && !/^unknown$/i.test(drv)) out.gpuDriver = drv;
-  const ram = text.match(/RAM:\s*(\d+)\s*Mb/i);
+  // #152: anchor on start-of-line so "VRAM:" earlier in the buffer cannot
+  // steal the match.
+  const ram = text.match(/^\s*RAM:\s*(\d+)\s*Mb/im);
   if (ram) { const gb = Math.round(Number(ram[1]) / 1024); if (gb > 0) out.ram = `${gb} GB`; }
   const vram = text.match(/VRAM:\s*(\d+)\s*Mb/i);
   if (vram) out.vramMb = Number(vram[1]);

--- a/js/submit/main.js
+++ b/js/submit/main.js
@@ -1,6 +1,6 @@
 // Entry module for submit.html. Migrated from the page's inline script.
 import { FAULT_KEYS_WEB } from '../shared/scoring.js?v=0dae1257';
-import { populateSubmitForm, prefillSubmitFormFromMyHardware, submitReport } from '../shared/submit.js?v=113ce5ad';
+import { populateSubmitForm, prefillSubmitFormFromMyHardware, submitReport } from '../shared/submit.js?v=bfb1bfdc';
 import { SupaAuth } from '../shared/config.js?v=f6f2c00a';
 import { appIdToDir } from '../lib/app-id.js?v=18a73fb7';
 

--- a/tests/adminApiAllReports.test.js
+++ b/tests/adminApiAllReports.test.js
@@ -1,0 +1,243 @@
+/**
+ * Behavioral tests for js/admin/api/allReports.js loaded via require()
+ * so Istanbul instruments the source for real coverage credit.
+ *
+ * admin/config.js bridges classic-script globals (window.SUPABASE_URL +
+ * SUPABASE_ANON_KEY) into ES module scope. We seed those on globalThis +
+ * window before requiring so the import chain resolves.
+ */
+
+global.window = global;
+global.window.SUPABASE_URL = 'https://test.supabase.co';
+global.window.SUPABASE_ANON_KEY = 'test-anon-key';
+// jest.config moduleNameMapper strips ?v=<hash> so this require chain
+// resolves cleanly.
+const {
+  fetchReportById,
+  fetchAllReports,
+  patchReportFlags,
+} = require('../js/admin/api/allReports.js');
+
+function makeFetchStub(routes) {
+  // routes: { '<url-prefix>': rowsOrPayload }, falls through to []
+  return jest.fn(async (url) => {
+    const entry = Object.entries(routes).find(([prefix]) => url.startsWith(prefix));
+    const payload = entry ? entry[1] : [];
+    return { ok: true, json: async () => payload };
+  });
+}
+
+const makeSession = () => ({ access_token: 'tok_xyz', user: { id: 'admin-1' } });
+
+describe('fetchAllReports query building', () => {
+  beforeEach(() => { delete global.location; global.location = { hostname: 'localhost' }; });
+
+  test('select column list includes flagged_reason for the row tooltip', async () => {
+    const fetchSpy = makeFetchStub({});
+    global.fetch = fetchSpy;
+    await fetchAllReports(makeSession(), { status: '' });
+    const callUrl = fetchSpy.mock.calls[0][0];
+    expect(callUrl).toMatch(/select=[^&]*flagged_reason/);
+  });
+
+  test('search term builds an or= filter on app_id + title.ilike', async () => {
+    const fetchSpy = makeFetchStub({});
+    global.fetch = fetchSpy;
+    await fetchAllReports(makeSession(), { status: '', search: 'half life' });
+    const callUrl = fetchSpy.mock.calls[0][0];
+    expect(callUrl).toContain('or=(app_id.eq.half%20life,title.ilike.*half%20life*)');
+  });
+
+  test('status=flagged adds is_flagged=eq.true to the query', async () => {
+    const fetchSpy = makeFetchStub({});
+    global.fetch = fetchSpy;
+    await fetchAllReports(makeSession(), { status: 'flagged' });
+    expect(fetchSpy.mock.calls[0][0]).toContain('is_flagged=eq.true');
+  });
+
+  test('status=hidden adds is_hidden=eq.true', async () => {
+    const fetchSpy = makeFetchStub({});
+    global.fetch = fetchSpy;
+    await fetchAllReports(makeSession(), { status: 'hidden' });
+    expect(fetchSpy.mock.calls[0][0]).toContain('is_hidden=eq.true');
+  });
+
+  test('status=clean and pending both exclude flagged + hidden at the DB level', async () => {
+    const fetchSpy = makeFetchStub({});
+    global.fetch = fetchSpy;
+    await fetchAllReports(makeSession(), { status: 'clean' });
+    expect(fetchSpy.mock.calls[0][0]).toContain('is_flagged=eq.false&is_hidden=eq.false');
+    fetchSpy.mockClear();
+    await fetchAllReports(makeSession(), { status: 'pending' });
+    expect(fetchSpy.mock.calls[0][0]).toContain('is_flagged=eq.false&is_hidden=eq.false');
+  });
+
+  test('appType filter is forwarded to app_type=eq.<value>', async () => {
+    const fetchSpy = makeFetchStub({});
+    global.fetch = fetchSpy;
+    await fetchAllReports(makeSession(), { status: '', appType: 'gog' });
+    expect(fetchSpy.mock.calls[0][0]).toContain('app_type=eq.gog');
+  });
+
+  test('date range builds created_at>=from + <=to+T23:59:59', async () => {
+    const fetchSpy = makeFetchStub({});
+    global.fetch = fetchSpy;
+    await fetchAllReports(makeSession(), { status: '', dateFrom: '2026-01-01', dateTo: '2026-06-30' });
+    const url = fetchSpy.mock.calls[0][0];
+    expect(url).toContain('created_at=gte.2026-01-01');
+    expect(url).toContain('created_at=lte.2026-06-30T23%3A59%3A59');
+  });
+});
+
+describe('fetchAllReports pending/clean partition', () => {
+  beforeEach(() => { delete global.location; global.location = { hostname: 'localhost' }; });
+
+  test('status=pending keeps rows without an approval row', async () => {
+    const rows = [
+      { id: 1, app_id: '730', title: 'A', is_flagged: false, is_hidden: false },
+      { id: 2, app_id: '731', title: 'B', is_flagged: false, is_hidden: false },
+    ];
+    global.fetch = makeFetchStub({
+      'https://test.supabase.co/rest/v1/user_configs': rows,
+      'https://test.supabase.co/rest/v1/report_approvals': [{ report_id: 1 }],
+    });
+    const result = await fetchAllReports(makeSession(), { status: 'pending' });
+    expect(result.map((r) => r.id)).toEqual([2]);
+    expect(result[0].is_pending).toBe(true);
+  });
+
+  test('status=clean keeps rows that DO have an approval row', async () => {
+    const rows = [
+      { id: 1, app_id: '730', title: 'A', is_flagged: false, is_hidden: false },
+      { id: 2, app_id: '731', title: 'B', is_flagged: false, is_hidden: false },
+    ];
+    global.fetch = makeFetchStub({
+      'https://test.supabase.co/rest/v1/user_configs': rows,
+      'https://test.supabase.co/rest/v1/report_approvals': [{ report_id: 1 }],
+    });
+    const result = await fetchAllReports(makeSession(), { status: 'clean' });
+    expect(result.map((r) => r.id)).toEqual([1]);
+    expect(result[0].is_pending).toBe(false);
+  });
+});
+
+describe('fetchAllReports fallback title repair (#147)', () => {
+  beforeEach(() => {
+    delete global.location;
+    global.location = { hostname: 'localhost' };
+    // Reset the module-level search-index cache so each test gets a clean fetch.
+    jest.resetModules();
+  });
+
+  test('"App <id>" titles get rewritten from search-index.json', async () => {
+    const { fetchAllReports: fresh } = require('../js/admin/api/allReports.js');
+    global.fetch = makeFetchStub({
+      'https://test.supabase.co/rest/v1/user_configs': [
+        { id: 23, app_id: '2881370', title: 'App 2881370', is_flagged: false, is_hidden: false },
+      ],
+      'https://test.supabase.co/rest/v1/report_approvals': [],
+      'https://www.proton-pulse.com/search-index.json': [
+        ['2881370', 'Thank You For Your Application', '', 0, 0, 'steam'],
+      ],
+    });
+    const result = await fresh(makeSession(), { status: '' });
+    expect(result[0].title).toBe('Thank You For Your Application');
+  });
+
+  test('real titles pass through unchanged', async () => {
+    const { fetchAllReports: fresh } = require('../js/admin/api/allReports.js');
+    global.fetch = makeFetchStub({
+      'https://test.supabase.co/rest/v1/user_configs': [
+        { id: 1, app_id: '570', title: 'Dota 2', is_flagged: false, is_hidden: false },
+      ],
+      'https://test.supabase.co/rest/v1/report_approvals': [],
+      'https://www.proton-pulse.com/search-index.json': [['570', 'Dota: Other Name']],
+    });
+    const result = await fresh(makeSession(), { status: '' });
+    expect(result[0].title).toBe('Dota 2');
+  });
+
+  test('all-real-titles skips the search-index fetch entirely', async () => {
+    const { fetchAllReports: fresh } = require('../js/admin/api/allReports.js');
+    const fetchSpy = jest.fn(async (url) => {
+      if (url.startsWith('https://test.supabase.co/rest/v1/user_configs')) {
+        return { ok: true, json: async () => [
+          { id: 1, app_id: '570', title: 'Dota 2', is_flagged: false, is_hidden: false },
+        ]};
+      }
+      return { ok: true, json: async () => [] };
+    });
+    global.fetch = fetchSpy;
+    await fresh(makeSession(), { status: '' });
+    const sawIndex = fetchSpy.mock.calls.some(
+      ([url]) => url === 'https://www.proton-pulse.com/search-index.json'
+    );
+    expect(sawIndex).toBe(false);
+  });
+
+  test('rows with no matching index entry keep the fallback title', async () => {
+    const { fetchAllReports: fresh } = require('../js/admin/api/allReports.js');
+    global.fetch = makeFetchStub({
+      'https://test.supabase.co/rest/v1/user_configs': [
+        { id: 1, app_id: '99999', title: 'App 99999', is_flagged: false, is_hidden: false },
+      ],
+      'https://test.supabase.co/rest/v1/report_approvals': [],
+      'https://www.proton-pulse.com/search-index.json': [['570', 'Dota 2']],
+    });
+    const result = await fresh(makeSession(), { status: '' });
+    expect(result[0].title).toBe('App 99999');
+  });
+});
+
+describe('fetchReportById', () => {
+  beforeEach(() => { delete global.location; global.location = { hostname: 'localhost' }; });
+
+  test('returns the single row with is_pending=true when no approval row exists', async () => {
+    global.fetch = makeFetchStub({
+      'https://test.supabase.co/rest/v1/user_configs': [
+        { id: 42, app_id: '730', title: 'Hl2', flagged_reason: null, flagged_at: null },
+      ],
+      'https://test.supabase.co/rest/v1/report_approvals': [],
+    });
+    const r = await fetchReportById(makeSession(), 42);
+    expect(r.id).toBe(42);
+    expect(r.is_pending).toBe(true);
+  });
+
+  test('flips is_pending=false when an approval row exists', async () => {
+    global.fetch = makeFetchStub({
+      'https://test.supabase.co/rest/v1/user_configs': [
+        { id: 42, app_id: '730', title: 'Hl2' },
+      ],
+      'https://test.supabase.co/rest/v1/report_approvals': [{ report_id: 42 }],
+    });
+    const r = await fetchReportById(makeSession(), 42);
+    expect(r.is_pending).toBe(false);
+  });
+
+  test('throws when the row does not exist', async () => {
+    global.fetch = makeFetchStub({
+      'https://test.supabase.co/rest/v1/user_configs': [],
+      'https://test.supabase.co/rest/v1/report_approvals': [],
+    });
+    await expect(fetchReportById(makeSession(), 999)).rejects.toThrow(/Report not found/);
+  });
+});
+
+describe('patchReportFlags', () => {
+  test('PATCHes the row with the supplied body and Prefer:return=minimal', async () => {
+    const fetchSpy = jest.fn(async () => ({ ok: true, json: async () => [] }));
+    global.fetch = fetchSpy;
+    await patchReportFlags(makeSession(), '7', { is_flagged: true });
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('https://test.supabase.co/rest/v1/user_configs?id=eq.7');
+    expect(init.method).toBe('PATCH');
+    expect(init.headers.Prefer).toBe('return=minimal');
+    expect(JSON.parse(init.body)).toEqual({ is_flagged: true });
+  });
+
+  test('throws on non-ok response', async () => {
+    global.fetch = jest.fn(async () => ({ ok: false, status: 403, text: async () => '' }));
+    await expect(patchReportFlags(makeSession(), '7', { is_flagged: true })).rejects.toThrow(/403/);
+  });
+});

--- a/tests/adminApiAnalytics.test.js
+++ b/tests/adminApiAnalytics.test.js
@@ -1,0 +1,191 @@
+/**
+ * Behavioral tests for js/admin/api/analytics.js loaded via require()
+ * so the coverage report sees the lines hit.
+ */
+
+global.window = global;
+global.window.SUPABASE_URL = 'https://test.supabase.co';
+global.window.SUPABASE_ANON_KEY = 'test-anon-key';
+const { fetchAnalytics } = require('../js/admin/api/analytics.js');
+
+const makeSession = () => ({ access_token: 'tok_a' });
+
+function routedFetch(routes) {
+  return jest.fn(async (url) => {
+    const entry = Object.entries(routes).find(([prefix]) => url.startsWith(prefix));
+    if (!entry) return { ok: true, json: async () => [] };
+    const payload = entry[1];
+    if (payload && typeof payload === 'object' && payload.__http) {
+      // sentinel for non-ok response: { __http: { ok, status, text } }
+      return payload.__http;
+    }
+    return { ok: true, json: async () => payload };
+  });
+}
+
+describe('fetchAnalytics top-level RPC + side fetches', () => {
+  test('POSTs to admin_analytics with days_back and merges side fetches', async () => {
+    const rpcPayload = {
+      totals: { authed_users: 7 },
+      daily: [],
+      top_pages: [],
+      top_games: [],
+      event_types: [],
+    };
+    const fetchSpy = routedFetch({
+      'https://test.supabase.co/rest/v1/rpc/admin_analytics': rpcPayload,
+      'https://test.supabase.co/rest/v1/user_configs': [
+        { created_at: '2026-06-29T10:00:00Z', source: 'web-linux' },
+        { created_at: '2026-06-30T09:00:00Z', source: 'plugin-linux' },
+      ],
+      'https://test.supabase.co/rest/v1/site_events': [
+        { metadata: { hits: 5, misses: 1 }, created_at: '2026-06-30T01:00:00Z' },
+      ],
+    });
+    global.fetch = fetchSpy;
+    const result = await fetchAnalytics(makeSession(), { daysBack: 7 });
+
+    const rpcCall = fetchSpy.mock.calls.find(([url]) =>
+      url === 'https://test.supabase.co/rest/v1/rpc/admin_analytics'
+    );
+    expect(rpcCall).toBeTruthy();
+    expect(rpcCall[1].method).toBe('POST');
+    expect(JSON.parse(rpcCall[1].body)).toEqual({ days_back: 7 });
+
+    expect(result.totals.authed_users).toBe(7);
+    expect(result.reports_by_day).toEqual([
+      { day: '2026-06-29', count: 1, web: 1, plugin: 0, other: 0 },
+      { day: '2026-06-30', count: 1, web: 0, plugin: 1, other: 0 },
+    ]);
+    expect(result.sw_cache.hits).toBe(5);
+    expect(result.sw_cache.misses).toBe(1);
+    expect(result.sw_cache.hit_rate).toBe(83);
+  });
+
+  test('throws when the RPC returns non-ok', async () => {
+    global.fetch = routedFetch({
+      'https://test.supabase.co/rest/v1/rpc/admin_analytics': {
+        __http: { ok: false, status: 500, text: async () => 'boom' },
+      },
+    });
+    await expect(fetchAnalytics(makeSession())).rejects.toThrow(/fetchAnalytics failed \(500\)/);
+  });
+
+  test('side fetches that throw or 4xx degrade to safe defaults', async () => {
+    // RPC ok, user_configs throws, site_events 4xx -> reports_by_day=[]
+    // and sw_cache=null instead of bubbling the failure.
+    const fetchSpy = jest.fn(async (url) => {
+      if (url.startsWith('https://test.supabase.co/rest/v1/rpc/admin_analytics')) {
+        return { ok: true, json: async () => ({ totals: {} }) };
+      }
+      if (url.startsWith('https://test.supabase.co/rest/v1/user_configs')) {
+        throw new Error('network');
+      }
+      if (url.startsWith('https://test.supabase.co/rest/v1/site_events')) {
+        return { ok: false, status: 401, text: async () => '' };
+      }
+      return { ok: true, json: async () => [] };
+    });
+    global.fetch = fetchSpy;
+    const result = await fetchAnalytics(makeSession());
+    expect(result.reports_by_day).toEqual([]);
+    expect(result.sw_cache).toBeNull();
+  });
+});
+
+describe('fetchReportsByDay source bucketing (via fetchAnalytics)', () => {
+  test('rows with unknown source bucket into "other"', async () => {
+    global.fetch = routedFetch({
+      'https://test.supabase.co/rest/v1/rpc/admin_analytics': { totals: {} },
+      'https://test.supabase.co/rest/v1/user_configs': [
+        { created_at: '2026-06-30T01:00:00Z', source: 'protondb' },
+        { created_at: '2026-06-30T02:00:00Z', source: '' },
+        { created_at: '2026-06-30T03:00:00Z', source: null },
+      ],
+    });
+    const result = await fetchAnalytics(makeSession());
+    expect(result.reports_by_day).toEqual([
+      { day: '2026-06-30', count: 3, web: 0, plugin: 0, other: 3 },
+    ]);
+  });
+
+  test('source classification is case-insensitive on the prefix', async () => {
+    global.fetch = routedFetch({
+      'https://test.supabase.co/rest/v1/rpc/admin_analytics': { totals: {} },
+      'https://test.supabase.co/rest/v1/user_configs': [
+        { created_at: '2026-06-30T01:00:00Z', source: 'WEB-LINUX' },
+        { created_at: '2026-06-30T02:00:00Z', source: 'Plugin-Steamdeck' },
+      ],
+    });
+    const result = await fetchAnalytics(makeSession());
+    expect(result.reports_by_day[0]).toEqual({ day: '2026-06-30', count: 2, web: 1, plugin: 1, other: 0 });
+  });
+
+  test('days are returned in ascending order', async () => {
+    global.fetch = routedFetch({
+      'https://test.supabase.co/rest/v1/rpc/admin_analytics': { totals: {} },
+      'https://test.supabase.co/rest/v1/user_configs': [
+        { created_at: '2026-07-01T01:00:00Z', source: 'web' },
+        { created_at: '2026-06-28T01:00:00Z', source: 'web' },
+        { created_at: '2026-06-30T01:00:00Z', source: 'web' },
+      ],
+    });
+    const result = await fetchAnalytics(makeSession());
+    expect(result.reports_by_day.map((r) => r.day)).toEqual(['2026-06-28', '2026-06-30', '2026-07-01']);
+  });
+
+  test('rows missing created_at are skipped silently', async () => {
+    global.fetch = routedFetch({
+      'https://test.supabase.co/rest/v1/rpc/admin_analytics': { totals: {} },
+      'https://test.supabase.co/rest/v1/user_configs': [
+        { source: 'web' },
+        { created_at: '2026-06-30T01:00:00Z', source: 'web' },
+      ],
+    });
+    const result = await fetchAnalytics(makeSession());
+    expect(result.reports_by_day).toEqual([
+      { day: '2026-06-30', count: 1, web: 1, plugin: 0, other: 0 },
+    ]);
+  });
+});
+
+describe('sw_cache aggregation', () => {
+  test('rows without metadata default hits/misses to 0', async () => {
+    global.fetch = routedFetch({
+      'https://test.supabase.co/rest/v1/rpc/admin_analytics': { totals: {} },
+      'https://test.supabase.co/rest/v1/site_events': [
+        { metadata: null, created_at: '2026-06-30T01:00:00Z' },
+        { metadata: { hits: 4, misses: 0 }, created_at: '2026-06-30T02:00:00Z' },
+      ],
+    });
+    const result = await fetchAnalytics(makeSession());
+    expect(result.sw_cache.hits).toBe(4);
+    expect(result.sw_cache.misses).toBe(0);
+    expect(result.sw_cache.hit_rate).toBe(100);
+  });
+
+  test('zero traffic returns hit_rate 0 without dividing by zero', async () => {
+    global.fetch = routedFetch({
+      'https://test.supabase.co/rest/v1/rpc/admin_analytics': { totals: {} },
+      'https://test.supabase.co/rest/v1/site_events': [],
+    });
+    const result = await fetchAnalytics(makeSession());
+    expect(result.sw_cache).toEqual({
+      sessions: 0, hits: 0, misses: 0, served: 0, hit_rate: 0, by_day: [],
+    });
+  });
+
+  test('per-day hit_rate rounds correctly', async () => {
+    global.fetch = routedFetch({
+      'https://test.supabase.co/rest/v1/rpc/admin_analytics': { totals: {} },
+      'https://test.supabase.co/rest/v1/site_events': [
+        { metadata: { hits: 3, misses: 1 }, created_at: '2026-06-29T01:00:00Z' },
+        { metadata: { hits: 2, misses: 8 }, created_at: '2026-06-30T01:00:00Z' },
+      ],
+    });
+    const result = await fetchAnalytics(makeSession());
+    const byDay = Object.fromEntries(result.sw_cache.by_day.map((d) => [d.day, d.hit_rate]));
+    expect(byDay['2026-06-29']).toBe(75);
+    expect(byDay['2026-06-30']).toBe(20);
+  });
+});

--- a/tests/adminApiPending.test.js
+++ b/tests/adminApiPending.test.js
@@ -1,0 +1,183 @@
+/**
+ * Behavioral tests for js/admin/api/pending.js loaded via require().
+ *
+ * Covers fetchPendingReports (filter by missing/mismatched approval
+ * hash), approveReport (POST + hash payload), and the internal md5
+ * implementation by way of round-trip equality.
+ */
+
+global.window = global;
+global.window.SUPABASE_URL = 'https://test.supabase.co';
+global.window.SUPABASE_ANON_KEY = 'test-anon-key';
+const { fetchPendingReports, approveReport } = require('../js/admin/api/pending.js');
+
+const session = { access_token: 'tok' };
+
+function routedFetch(routes) {
+  return jest.fn(async (url, init) => {
+    const entry = Object.entries(routes).find(([prefix]) => url.startsWith(prefix));
+    if (!entry) return { ok: true, json: async () => [] };
+    const v = typeof entry[1] === 'function' ? entry[1](url, init) : entry[1];
+    if (v && typeof v === 'object' && v.__http) return v.__http;
+    return { ok: true, json: async () => v };
+  });
+}
+
+// Mirror the file's own md5 input layout so we can predict the hash
+// without re-importing computeHash (it's not exported). compute it via
+// approveReport's POST body for the assertions.
+function reportRow(overrides = {}) {
+  return {
+    id: 42,
+    app_id: '730',
+    client_id: 'client-7',
+    rating: 'gold',
+    notes: 'runs ok',
+    os: 'SteamOS',
+    gpu: 'AMD',
+    created_at: '2026-06-29T22:57:07.752066+00:00',
+    proton_version: 'Proton 9.0',
+    cpu: 'AMD Ryzen',
+    gpu_driver: '',
+    gpu_vendor: 'amd',
+    gpu_architecture: 'gfx10',
+    ram: '16G',
+    vram_mb: 8192,
+    kernel: '6.1',
+    duration: 'longGame',
+    duration_minutes: 240,
+    form_responses: {},
+    config_key: '',
+    game_owned: true,
+    source: 'web-linux',
+    updated_at: '2026-06-29T22:57:07.752066+00:00',
+    title: 'Hl2',
+    ...overrides,
+  };
+}
+
+describe('fetchPendingReports', () => {
+  test('keeps a report that has no approval row', async () => {
+    const row = reportRow({ id: 99 });
+    global.fetch = routedFetch({
+      'https://test.supabase.co/rest/v1/user_configs': [row],
+      'https://test.supabase.co/rest/v1/report_approvals': [],
+    });
+    const result = await fetchPendingReports(session);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(99);
+    expect(typeof result[0]._approval_hash).toBe('string');
+    expect(result[0]._approval_hash).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  test('keeps a report whose stored hash does not match the live content', async () => {
+    const row = reportRow({ id: 5 });
+    global.fetch = routedFetch({
+      'https://test.supabase.co/rest/v1/user_configs': [row],
+      'https://test.supabase.co/rest/v1/report_approvals': [
+        { report_id: 5, approval_hash: 'deadbeef' },
+      ],
+    });
+    const result = await fetchPendingReports(session);
+    expect(result.map((r) => r.id)).toEqual([5]);
+  });
+
+  test('drops a report whose stored hash matches the live content', async () => {
+    // Compute the expected hash via approveReport first, then feed it
+    // back as the stored hash so the row is "already approved".
+    const row = reportRow({ id: 11 });
+    let postedHash = null;
+    global.fetch = routedFetch({
+      'https://test.supabase.co/rest/v1/report_approvals?on_conflict=report_id': (_url, init) => {
+        postedHash = JSON.parse(init.body).approval_hash;
+        return { __http: { ok: true, json: async () => [] } };
+      },
+    });
+    await approveReport(session, row);
+    expect(postedHash).toMatch(/^[0-9a-f]{32}$/);
+
+    global.fetch = routedFetch({
+      'https://test.supabase.co/rest/v1/user_configs': [row],
+      'https://test.supabase.co/rest/v1/report_approvals': [
+        { report_id: 11, approval_hash: postedHash },
+      ],
+    });
+    const result = await fetchPendingReports(session);
+    expect(result).toHaveLength(0);
+  });
+
+  test('throws on a non-ok report fetch', async () => {
+    global.fetch = routedFetch({
+      'https://test.supabase.co/rest/v1/user_configs': { __http: { ok: false, status: 503 } },
+    });
+    await expect(fetchPendingReports(session)).rejects.toThrow(/Failed to fetch reports: 503/);
+  });
+
+  test('treats a non-ok approvals fetch as "no approvals" rather than throwing', async () => {
+    const row = reportRow({ id: 1 });
+    global.fetch = routedFetch({
+      'https://test.supabase.co/rest/v1/user_configs': [row],
+      'https://test.supabase.co/rest/v1/report_approvals': { __http: { ok: false, status: 500 } },
+    });
+    const result = await fetchPendingReports(session);
+    expect(result).toHaveLength(1);
+  });
+});
+
+describe('approveReport', () => {
+  test('POSTs to report_approvals with hash + approved_at=now + admin author', async () => {
+    let captured = null;
+    global.fetch = routedFetch({
+      'https://test.supabase.co/rest/v1/report_approvals?on_conflict=report_id': (_url, init) => {
+        captured = init;
+        return { __http: { ok: true, json: async () => [] } };
+      },
+    });
+    await approveReport(session, reportRow({ id: 5 }));
+    expect(captured.method).toBe('POST');
+    expect(captured.headers.Prefer).toBe('resolution=merge-duplicates,return=minimal');
+    const body = JSON.parse(captured.body);
+    expect(body).toEqual({
+      report_id: 5,
+      approval_hash: expect.stringMatching(/^[0-9a-f]{32}$/),
+      approved_at: expect.any(String),
+      approved_by: 'admin',
+    });
+    expect(Array.isArray(body)).toBe(false);
+    // approved_at should be a valid ISO timestamp.
+    expect(new Date(body.approved_at).toString()).not.toBe('Invalid Date');
+  });
+
+  test('throws on non-ok response', async () => {
+    global.fetch = routedFetch({
+      'https://test.supabase.co/rest/v1/report_approvals': { __http: { ok: false, status: 403 } },
+    });
+    await expect(approveReport(session, reportRow())).rejects.toThrow(/Approve failed: 403/);
+  });
+
+  test('two edits to the same row yield different hashes', async () => {
+    const hashes = [];
+    global.fetch = routedFetch({
+      'https://test.supabase.co/rest/v1/report_approvals?on_conflict=report_id': (_url, init) => {
+        hashes.push(JSON.parse(init.body).approval_hash);
+        return { __http: { ok: true, json: async () => [] } };
+      },
+    });
+    await approveReport(session, reportRow({ id: 1, notes: 'first' }));
+    await approveReport(session, reportRow({ id: 1, notes: 'second' }));
+    expect(hashes[0]).not.toBe(hashes[1]);
+  });
+
+  test('equal content yields equal hashes (md5 determinism)', async () => {
+    const hashes = [];
+    global.fetch = routedFetch({
+      'https://test.supabase.co/rest/v1/report_approvals?on_conflict=report_id': (_url, init) => {
+        hashes.push(JSON.parse(init.body).approval_hash);
+        return { __http: { ok: true, json: async () => [] } };
+      },
+    });
+    await approveReport(session, reportRow({ id: 1, notes: 'same' }));
+    await approveReport(session, reportRow({ id: 1, notes: 'same' }));
+    expect(hashes[0]).toBe(hashes[1]);
+  });
+});

--- a/tests/adminApiPending.test.js
+++ b/tests/adminApiPending.test.js
@@ -168,6 +168,28 @@ describe('approveReport', () => {
     expect(hashes[0]).not.toBe(hashes[1]);
   });
 
+  test('row with all-falsy hashable fields still computes a deterministic hash', () => {
+    // computeHash applies `String(row.field || '')` to each contributing
+    // column. The OR-coalesce branches were uncovered until we exercised
+    // a row where every column was absent or null.
+    const hashes = [];
+    global.fetch = routedFetch({
+      'https://test.supabase.co/rest/v1/report_approvals?on_conflict=report_id': (_url, init) => {
+        hashes.push(JSON.parse(init.body).approval_hash);
+        return { __http: { ok: true, json: async () => [] } };
+      },
+    });
+    const empty = {
+      id: 99,
+      app_id: null, client_id: null, rating: null, notes: null,
+      os: null, gpu: null, created_at: null,
+    };
+    return approveReport(session, empty).then(() => approveReport(session, empty)).then(() => {
+      expect(hashes[0]).toMatch(/^[0-9a-f]{32}$/);
+      expect(hashes[0]).toBe(hashes[1]);
+    });
+  });
+
   test('equal content yields equal hashes (md5 determinism)', async () => {
     const hashes = [];
     global.fetch = routedFetch({

--- a/tests/libModulesCoverage.test.js
+++ b/tests/libModulesCoverage.test.js
@@ -53,9 +53,9 @@ describe('detectGpuArch', () => {
     expect(detectGpuArch('Radeon VII')).toBe('Vega');
     expect(detectGpuArch('Radeon RX 580')).toBe('Polaris');
     expect(detectGpuArch('Radeon R9 Fury X')).toBe('GCN3');
-    // Source regex matches R9 280 as GCN3 (r9\s*28[05]). The classification
-    // table comment says it should be GCN2; tracked as a small follow-up.
-    expect(detectGpuArch('Radeon R9 280X')).toBe('GCN3');
+    expect(detectGpuArch('Radeon R9 285')).toBe('GCN3');
+    // #151: R9 280 is Tahiti -> GCN2, not GCN3.
+    expect(detectGpuArch('Radeon R9 280X')).toBe('GCN2');
     expect(detectGpuArch('Radeon R9 270X')).toBe('GCN2');
     expect(detectGpuArch('Radeon HD 7970')).toBe('GCN1');
   });
@@ -70,28 +70,34 @@ describe('detectGpuArch', () => {
   });
 
   test('NVIDIA GTX generations classify correctly', () => {
-    // Source regex `gtx\s*10[567]\d` covers 1050/1060/1070, not 1080.
-    // GTX 1080 is a real gap; tracked separately.
+    expect(detectGpuArch('GeForce GTX 1080 Ti')).toBe('Pascal');
     expect(detectGpuArch('GeForce GTX 1070')).toBe('Pascal');
     expect(detectGpuArch('GeForce GTX 1060')).toBe('Pascal');
+    expect(detectGpuArch('GeForce GTX 1050')).toBe('Pascal');
     expect(detectGpuArch('GeForce GTX 960')).toBe('Maxwell');
     expect(detectGpuArch('GeForce GTX 750')).toBe('Maxwell');
     expect(detectGpuArch('GeForce GTX 770')).toBe('Kepler');
     expect(detectGpuArch('GeForce GTX 660')).toBe('Kepler');
   });
 
-  test('Intel Arc / Xe / Gen9 classify', () => {
+  test('Intel Arc / Xe / Gen9 classify (#151: Intel block precedes NVIDIA)', () => {
     expect(detectGpuArch('Intel Arc B580')).toBe('Battlemage');
-    // Intel Arc A-series collides with NVIDIA's Ampere fallback
-    // (\ba\d{3,4}\b) and currently misclassifies as Ampere. Tracked as
-    // a follow-up; test pins current behaviour.
-    expect(detectGpuArch('Intel Arc A770')).toBe('Ampere');
+    // Intel Arc A-series no longer falls through to NVIDIA Ampere.
+    expect(detectGpuArch('Intel Arc A770')).toBe('Alchemist');
+    expect(detectGpuArch('Intel Arc A380')).toBe('Alchemist');
     expect(detectGpuArch('Intel Iris Xe Graphics')).toBe('Xe');
-    // Source regex `uhd\s*7[0-9]{2}` requires UHD<ws>7xx with no intervening
-    // word, so "Intel UHD Graphics 770" misses. Test with a tighter form.
+    // The optional "graphics" word now matches.
+    expect(detectGpuArch('Intel UHD Graphics 770')).toBe('Xe');
     expect(detectGpuArch('Intel UHD 770')).toBe('Xe');
-    expect(detectGpuArch('Intel HD 530')).toBe('Gen9');
-    expect(detectGpuArch('Intel UHD 630')).toBe('Gen9');
+    expect(detectGpuArch('Intel HD Graphics 530')).toBe('Gen9');
+    expect(detectGpuArch('Intel UHD Graphics 630')).toBe('Gen9');
+  });
+
+  test('NVIDIA Ampere workstation A-series still classifies after the Intel reorder', () => {
+    // Regression guard: moving Intel above NVIDIA must not break the
+    // `\ba\d{3,4}\b` Ampere fallback for actual NVIDIA cards.
+    expect(detectGpuArch('NVIDIA A100')).toBe('Ampere');
+    expect(detectGpuArch('NVIDIA A4000')).toBe('Ampere');
   });
 
   test('unrecognised GPU strings return empty', () => {

--- a/tests/libModulesCoverage.test.js
+++ b/tests/libModulesCoverage.test.js
@@ -1,0 +1,237 @@
+/**
+ * Require-loaded behavioral tests for pure-ish lib modules so Istanbul
+ * sees the lines hit. Existing vm-based suites (loadEsm in _esm-vm.js)
+ * keep working as integration covers but do not contribute to the
+ * coverage report.
+ */
+
+// ── js/lib/app-id.js ────────────────────────────────────────────────────────
+
+describe('appIdToDir', () => {
+  const { appIdToDir } = require('../js/lib/app-id.js');
+
+  test('Steam numeric ids pass through unchanged', () => {
+    expect(appIdToDir('730')).toBe('730');
+    expect(appIdToDir(730)).toBe('730');
+  });
+
+  test('GOG canonical ids collapse the colon to underscore', () => {
+    expect(appIdToDir('gog:123')).toBe('gog_123');
+    expect(appIdToDir('gog:1971477531')).toBe('gog_1971477531');
+  });
+
+  test('Epic canonical ids collapse the colon too', () => {
+    expect(appIdToDir('epic:fortnite')).toBe('epic_fortnite');
+  });
+
+  test('only the first colon is replaced (canonical ids only carry one)', () => {
+    expect(appIdToDir('gog:abc:def')).toBe('gog_abc:def');
+  });
+});
+
+// ── js/lib/gpu-arch-detector.js ─────────────────────────────────────────────
+
+describe('detectGpuArch', () => {
+  const { detectGpuArch } = require('../js/lib/gpu-arch-detector.js');
+
+  test('empty / falsy input returns empty string', () => {
+    expect(detectGpuArch('')).toBe('');
+    expect(detectGpuArch(null)).toBe('');
+    expect(detectGpuArch(undefined)).toBe('');
+  });
+
+  test('AMD RDNA generations classify correctly', () => {
+    expect(detectGpuArch('AMD Radeon RX 9070')).toBe('RDNA4');
+    expect(detectGpuArch('Radeon RX 7900 XTX')).toBe('RDNA3');
+    expect(detectGpuArch('Radeon RX 6800')).toBe('RDNA2');
+    expect(detectGpuArch('Steam Deck Van Gogh APU')).toBe('RDNA2');
+    expect(detectGpuArch('Radeon RX 5700 XT')).toBe('RDNA');
+  });
+
+  test('older AMD architectures Vega / Polaris / GCN classify', () => {
+    expect(detectGpuArch('Radeon RX Vega 64')).toBe('Vega');
+    expect(detectGpuArch('Radeon VII')).toBe('Vega');
+    expect(detectGpuArch('Radeon RX 580')).toBe('Polaris');
+    expect(detectGpuArch('Radeon R9 Fury X')).toBe('GCN3');
+    // Source regex matches R9 280 as GCN3 (r9\s*28[05]). The classification
+    // table comment says it should be GCN2; tracked as a small follow-up.
+    expect(detectGpuArch('Radeon R9 280X')).toBe('GCN3');
+    expect(detectGpuArch('Radeon R9 270X')).toBe('GCN2');
+    expect(detectGpuArch('Radeon HD 7970')).toBe('GCN1');
+  });
+
+  test('NVIDIA RTX generations classify correctly', () => {
+    expect(detectGpuArch('NVIDIA GeForce RTX 5090')).toBe('Blackwell');
+    expect(detectGpuArch('GeForce RTX 4060 Ti')).toBe('Ada');
+    expect(detectGpuArch('GeForce RTX 3080')).toBe('Ampere');
+    expect(detectGpuArch('NVIDIA A100')).toBe('Ampere');
+    expect(detectGpuArch('GeForce RTX 2070')).toBe('Turing');
+    expect(detectGpuArch('GeForce GTX 1660 Ti')).toBe('Turing');
+  });
+
+  test('NVIDIA GTX generations classify correctly', () => {
+    // Source regex `gtx\s*10[567]\d` covers 1050/1060/1070, not 1080.
+    // GTX 1080 is a real gap; tracked separately.
+    expect(detectGpuArch('GeForce GTX 1070')).toBe('Pascal');
+    expect(detectGpuArch('GeForce GTX 1060')).toBe('Pascal');
+    expect(detectGpuArch('GeForce GTX 960')).toBe('Maxwell');
+    expect(detectGpuArch('GeForce GTX 750')).toBe('Maxwell');
+    expect(detectGpuArch('GeForce GTX 770')).toBe('Kepler');
+    expect(detectGpuArch('GeForce GTX 660')).toBe('Kepler');
+  });
+
+  test('Intel Arc / Xe / Gen9 classify', () => {
+    expect(detectGpuArch('Intel Arc B580')).toBe('Battlemage');
+    // Intel Arc A-series collides with NVIDIA's Ampere fallback
+    // (\ba\d{3,4}\b) and currently misclassifies as Ampere. Tracked as
+    // a follow-up; test pins current behaviour.
+    expect(detectGpuArch('Intel Arc A770')).toBe('Ampere');
+    expect(detectGpuArch('Intel Iris Xe Graphics')).toBe('Xe');
+    // Source regex `uhd\s*7[0-9]{2}` requires UHD<ws>7xx with no intervening
+    // word, so "Intel UHD Graphics 770" misses. Test with a tighter form.
+    expect(detectGpuArch('Intel UHD 770')).toBe('Xe');
+    expect(detectGpuArch('Intel HD 530')).toBe('Gen9');
+    expect(detectGpuArch('Intel UHD 630')).toBe('Gen9');
+  });
+
+  test('unrecognised GPU strings return empty', () => {
+    expect(detectGpuArch('llvmpipe')).toBe('');
+    expect(detectGpuArch('Microsoft Basic Render Driver')).toBe('');
+  });
+
+  test('mixed case + extra whitespace still match', () => {
+    expect(detectGpuArch('RX 7900')).toBe('RDNA3');
+    expect(detectGpuArch('rtx  4070')).toBe('Ada');
+  });
+});
+
+// ── js/lib/analytics.js ─────────────────────────────────────────────────────
+//
+// analytics.js is an IIFE that wires window.ppTrack at load time. To get
+// require-credit we set up the minimal browser-like globals it touches
+// and then require the module so the IIFE runs once.
+
+describe('analytics.js track() core behavior', () => {
+  let origFetch;
+  let origLocation;
+  let fetchSpy;
+  let track;
+
+  beforeEach(() => {
+    jest.resetModules();
+    origFetch = global.fetch;
+    origLocation = global.location;
+    global.window = global;
+    global.window.SUPABASE_URL = 'https://test.supabase.co';
+    global.window.SUPABASE_ANON_KEY = 'anon-key';
+    global.window.SupaAuth = { getSession: jest.fn().mockResolvedValue(null) };
+    global.navigator = { userAgent: 'Mozilla/5.0 (X11; Linux x86_64)' };
+    global.location = { pathname: '/app.html' };
+    global.sessionStorage = {
+      _store: {},
+      getItem(k) { return this._store[k] ?? null; },
+      setItem(k, v) { this._store[k] = String(v); },
+    };
+    global.document = { addEventListener: jest.fn(), querySelectorAll: () => [] };
+    // window.addEventListener is needed for the error/unhandledrejection hooks.
+    global.window.addEventListener = jest.fn();
+    fetchSpy = jest.fn().mockResolvedValue({ ok: true });
+    global.fetch = fetchSpy;
+    // Reload the module each test so the IIFE re-runs with fresh stubs.
+    require('../js/lib/analytics.js');
+    track = global.window.ppTrack;
+  });
+
+  afterEach(() => {
+    global.fetch = origFetch;
+    global.location = origLocation;
+    delete global.window.ppTrack;
+    delete global.window.SupaAuth;
+  });
+
+  test('exports ppTrack on window', () => {
+    expect(typeof track).toBe('function');
+  });
+
+  test('anonymous track posts with proton_pulse_user_id=null and anon-key auth', async () => {
+    await track('page_view', {});
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [, init] = fetchSpy.mock.calls[0];
+    const body = JSON.parse(init.body);
+    expect(body.event_type).toBe('page_view');
+    expect(body.proton_pulse_user_id).toBeNull();
+    expect(body.metadata.device).toBe('desktop');
+    expect(init.headers.Authorization).toBe('Bearer anon-key');
+  });
+
+  test('signed-in track attaches user id + bearer access_token', async () => {
+    global.window.SupaAuth.getSession.mockResolvedValue({
+      access_token: 'tok_xyz',
+      user: { id: 'pp-user-1' },
+    });
+    await track('game_view', { app_id: '730' });
+    const [, init] = fetchSpy.mock.calls[0];
+    const body = JSON.parse(init.body);
+    expect(body.proton_pulse_user_id).toBe('pp-user-1');
+    expect(body.metadata).toEqual({ device: 'desktop', app_id: '730' });
+    expect(init.headers.Authorization).toBe('Bearer tok_xyz');
+  });
+
+  test('Steam Deck UA classifies as deck', async () => {
+    jest.resetModules();
+    global.navigator = { userAgent: 'Mozilla/5.0 (X11; Linux x86_64; SteamDeck)' };
+    require('../js/lib/analytics.js');
+    await global.window.ppTrack('page_view', {});
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(JSON.parse(init.body).metadata.device).toBe('deck');
+  });
+
+  test('Android UA classifies as mobile', async () => {
+    jest.resetModules();
+    global.navigator = { userAgent: 'Mozilla/5.0 (Linux; Android 14)' };
+    require('../js/lib/analytics.js');
+    await global.window.ppTrack('page_view', {});
+    expect(JSON.parse(fetchSpy.mock.calls[0][1].body).metadata.device).toBe('mobile');
+  });
+
+  test('curl-like UA classifies as other', async () => {
+    jest.resetModules();
+    global.navigator = { userAgent: 'curl/8.5.0' };
+    require('../js/lib/analytics.js');
+    await global.window.ppTrack('page_view', {});
+    expect(JSON.parse(fetchSpy.mock.calls[0][1].body).metadata.device).toBe('other');
+  });
+
+  test('window error listener fires error_event with rate-limit', async () => {
+    // Re-init so we can capture the listener registration.
+    jest.resetModules();
+    const listeners = {};
+    global.window.addEventListener = jest.fn((event, fn) => { listeners[event] = fn; });
+    require('../js/lib/analytics.js');
+    expect(listeners.error).toBeDefined();
+    expect(listeners.unhandledrejection).toBeDefined();
+
+    fetchSpy.mockClear();
+    listeners.error({ message: 'boom', filename: 'a.js', lineno: 1, colno: 1, error: { stack: 'Error: boom\n  at x' } });
+    listeners.error({ message: 'boom', filename: 'a.js', lineno: 1, colno: 1, error: { stack: 'Error: boom\n  at x' } });
+    await new Promise((r) => setImmediate(r));
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+    expect(body.event_type).toBe('error_event');
+    expect(body.metadata.message).toBe('boom');
+  });
+
+  test('unhandledrejection listener extracts reason.message', async () => {
+    jest.resetModules();
+    const listeners = {};
+    global.window.addEventListener = jest.fn((event, fn) => { listeners[event] = fn; });
+    require('../js/lib/analytics.js');
+    fetchSpy.mockClear();
+    listeners.unhandledrejection({ reason: { message: 'p-rej', stack: 'Error: p-rej\n  at p' } });
+    await new Promise((r) => setImmediate(r));
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+    expect(body.metadata.message).toBe('p-rej');
+    expect(body.metadata.source).toBe('unhandledrejection');
+  });
+});

--- a/tests/libModulesCoverage.test.js
+++ b/tests/libModulesCoverage.test.js
@@ -240,4 +240,48 @@ describe('analytics.js track() core behavior', () => {
     expect(body.metadata.message).toBe('p-rej');
     expect(body.metadata.source).toBe('unhandledrejection');
   });
+
+  test('SupaAuth.getSession throwing synchronously falls back to anonymous', async () => {
+    // The catch branch in getCurrentSession (returning null) is hit only
+    // when SupaAuth.getSession throws synchronously instead of returning
+    // a rejected promise. Cover that line explicitly.
+    jest.resetModules();
+    global.window.SupaAuth = {
+      getSession: () => { throw new Error('SupaAuth not ready'); },
+    };
+    require('../js/lib/analytics.js');
+    fetchSpy.mockClear();
+    await global.window.ppTrack('page_view', {});
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+    expect(body.proton_pulse_user_id).toBeNull();
+  });
+
+  test('DOMContentLoaded handler fires a page_view and wires auth_attempt links', async () => {
+    jest.resetModules();
+    let domReady;
+    const linkClickHandlers = [];
+    global.document = {
+      addEventListener: (event, fn) => { if (event === 'DOMContentLoaded') domReady = fn; },
+      querySelectorAll: () => [
+        { href: '/steam-callback?next=/', addEventListener: (_e, fn) => linkClickHandlers.push(fn) },
+        { href: '/something-else', addEventListener: jest.fn() }, // not a steam-callback link
+      ],
+    };
+    require('../js/lib/analytics.js');
+    expect(typeof domReady).toBe('function');
+    fetchSpy.mockClear();
+    domReady();
+    await new Promise((r) => setImmediate(r));
+    // page_view fires immediately
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(fetchSpy.mock.calls[0][1].body).event_type).toBe('page_view');
+    // The steam-callback link got a click handler; the other link did not.
+    expect(linkClickHandlers).toHaveLength(1);
+    fetchSpy.mockClear();
+    await linkClickHandlers[0]();
+    await new Promise((r) => setImmediate(r));
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(fetchSpy.mock.calls[0][1].body).event_type).toBe('auth_attempt');
+  });
 });

--- a/tests/profileUtilsCoverage.test.js
+++ b/tests/profileUtilsCoverage.test.js
@@ -1,0 +1,351 @@
+/**
+ * Require-loaded coverage tests for js/profile/utils.js. The file is large
+ * and was previously only exercised via the vm-based profileSystems suite,
+ * which Istanbul does not instrument. These tests load the module through
+ * babel-jest + the ?v= moduleNameMapper so coverage credit lands on the
+ * source lines directly.
+ *
+ * profile/config.js reads window.SUPABASE_URL and friends at module-load
+ * time, so we seed those before the first require. localStorage is also
+ * touched by several helpers; a minimal in-memory shim keeps tests
+ * deterministic.
+ */
+
+// Seed the window globals profile/config.js reads at module-load time.
+// MUST happen before the require() below so the import chain resolves.
+global.window = global;
+global.window.SUPABASE_URL = 'https://test.supabase.co';
+global.window.SUPABASE_ANON_KEY = 'test-anon';
+global.window.SupaAuth = {};
+global.window.location = { host: 'localhost' };
+
+const _store = {};
+beforeEach(() => {
+  for (const k of Object.keys(_store)) delete _store[k];
+  global.localStorage = {
+    getItem: (k) => (k in _store ? _store[k] : null),
+    setItem: (k, v) => { _store[k] = String(v); },
+    removeItem: (k) => { delete _store[k]; },
+  };
+  global.crypto = {
+    randomUUID: () => 'test-uuid-' + Math.random().toString(16).slice(2, 10),
+  };
+});
+
+const utils = require('../js/profile/utils.js');
+
+describe('session readers', () => {
+  test('getSteamIdFromSession prefers user_metadata.steam_id', () => {
+    expect(utils.getSteamIdFromSession({
+      user: { user_metadata: { steam_id: 'A', provider_id: 'B', sub: 'C' } },
+    })).toBe('A');
+  });
+  test('getSteamIdFromSession falls back to provider_id then sub', () => {
+    expect(utils.getSteamIdFromSession({ user: { user_metadata: { provider_id: 'B', sub: 'C' } } })).toBe('B');
+    expect(utils.getSteamIdFromSession({ user: { user_metadata: { sub: 'C' } } })).toBe('C');
+  });
+  test('getSteamIdFromSession returns null when nothing matches', () => {
+    expect(utils.getSteamIdFromSession(null)).toBeNull();
+    expect(utils.getSteamIdFromSession({})).toBeNull();
+    expect(utils.getSteamIdFromSession({ user: { user_metadata: {} } })).toBeNull();
+  });
+  test('getProtonPulseUserIdFromSession reads session.user.id', () => {
+    expect(utils.getProtonPulseUserIdFromSession({ user: { id: 'pp-1' } })).toBe('pp-1');
+    expect(utils.getProtonPulseUserIdFromSession(null)).toBeNull();
+    expect(utils.getProtonPulseUserIdFromSession({})).toBeNull();
+  });
+});
+
+describe('show-username preference', () => {
+  test('defaults to true when nothing stored', () => {
+    expect(utils.getShowUsername()).toBe(true);
+  });
+  test('returns true when "true" stored', () => {
+    utils.setShowUsername(true);
+    expect(utils.getShowUsername()).toBe(true);
+  });
+  test('returns false when "false" stored', () => {
+    utils.setShowUsername(false);
+    expect(utils.getShowUsername()).toBe(false);
+  });
+});
+
+describe('cleanUnknown', () => {
+  test('strips literal "unknown" (case-insensitive)', () => {
+    expect(utils.cleanUnknown('Unknown')).toBe('');
+    expect(utils.cleanUnknown('UNKNOWN')).toBe('');
+    expect(utils.cleanUnknown('unknown')).toBe('');
+  });
+  test('returns trimmed value otherwise', () => {
+    expect(utils.cleanUnknown('  Arch Linux  ')).toBe('Arch Linux');
+  });
+  test('non-string input returns empty', () => {
+    expect(utils.cleanUnknown(null)).toBe('');
+    expect(utils.cleanUnknown(undefined)).toBe('');
+    expect(utils.cleanUnknown(42)).toBe('');
+  });
+});
+
+describe('inferGpuVendor', () => {
+  test('nvidia patterns', () => {
+    expect(utils.inferGpuVendor('GeForce RTX 4070')).toBe('nvidia');
+    expect(utils.inferGpuVendor('NVIDIA Quadro P2000')).toBe('nvidia');
+  });
+  test('amd patterns', () => {
+    expect(utils.inferGpuVendor('Radeon RX 7800 XT')).toBe('amd');
+    expect(utils.inferGpuVendor('AMD Vega 56')).toBe('amd');
+  });
+  test('intel patterns', () => {
+    expect(utils.inferGpuVendor('Intel Arc A770')).toBe('intel');
+    expect(utils.inferGpuVendor('Iris Xe Graphics')).toBe('intel');
+  });
+  test('unknown returns empty string', () => {
+    expect(utils.inferGpuVendor('llvmpipe')).toBe('');
+    expect(utils.inferGpuVendor('')).toBe('');
+    expect(utils.inferGpuVendor(null)).toBe('');
+  });
+});
+
+describe('inferCpuVendor', () => {
+  test('amd patterns', () => {
+    expect(utils.inferCpuVendor('AMD Ryzen 9 7950X')).toBe('amd');
+    expect(utils.inferCpuVendor('Threadripper 7970X')).toBe('amd');
+  });
+  test('intel patterns', () => {
+    expect(utils.inferCpuVendor('Intel Core i9-13900K')).toBe('intel');
+    expect(utils.inferCpuVendor('Core Ultra 7 155H')).toBe('intel');
+  });
+  test('unknown -> other', () => {
+    expect(utils.inferCpuVendor('SiFive HiFive Unmatched')).toBe('other');
+  });
+  test('empty input -> empty string', () => {
+    expect(utils.inferCpuVendor('')).toBe('');
+    expect(utils.inferCpuVendor(null)).toBe('');
+  });
+});
+
+describe('isGenericSystemLabel', () => {
+  test('placeholders return true', () => {
+    expect(utils.isGenericSystemLabel('')).toBe(true);
+    expect(utils.isGenericSystemLabel(' ')).toBe(true);
+    expect(utils.isGenericSystemLabel(null)).toBe(true);
+    expect(utils.isGenericSystemLabel('Unknown')).toBe(true);
+    expect(utils.isGenericSystemLabel('unknown system')).toBe(true);
+    expect(utils.isGenericSystemLabel('Unnamed')).toBe(true);
+    expect(utils.isGenericSystemLabel('System')).toBe(true);
+    expect(utils.isGenericSystemLabel('Uploaded system')).toBe(true);
+  });
+  test('real labels return false', () => {
+    expect(utils.isGenericSystemLabel('My Steam Deck')).toBe(false);
+    expect(utils.isGenericSystemLabel('Desktop')).toBe(false);
+  });
+});
+
+describe('inferSystemLabel', () => {
+  test('Steam Deck OLED via Valve/Galileo board match', () => {
+    const sysinfo = 'Manufacturer: Valve\nModel: Galileo\nCPU Brand: AMD Custom APU 0932\n';
+    expect(utils.inferSystemLabel({ sysinfo_text: sysinfo })).toBe('Steam Deck OLED');
+  });
+  test('Steam Deck LCD via Valve/Jupiter board match', () => {
+    const sysinfo = 'Manufacturer: Valve\nModel: Jupiter\nCPU Brand: AMD Custom APU 0405\n';
+    expect(utils.inferSystemLabel({ sysinfo_text: sysinfo })).toBe('Steam Deck LCD');
+  });
+  test('Steam Deck via VanGogh chipset hint (generic, no LCD/OLED)', () => {
+    // Chipset hint alone cannot disambiguate LCD vs OLED -- only the
+    // Jupiter/Galileo board model can. So chipset-only -> "Steam Deck".
+    const sysinfo = 'CPU Brand: AMD Custom APU 0405\nVideo Card: VanGogh\n';
+    expect(utils.inferSystemLabel({ sysinfo_text: sysinfo })).toBe('Steam Deck');
+  });
+  test('OS-VENDOR-GPU fallback when no Deck hints', () => {
+    const parsed = { os: 'Arch', gpu: 'GeForce RTX 4070', gpuVendor: 'nvidia' };
+    expect(utils.inferSystemLabel(parsed)).toBe('Arch-NVIDIA-GeForce RTX 4070');
+  });
+  test('Uploaded system when nothing parseable', () => {
+    expect(utils.inferSystemLabel({})).toBe('Uploaded system');
+  });
+});
+
+describe('summarizeSystem', () => {
+  test('joins os + cpu + ram with bullet separators', () => {
+    expect(utils.summarizeSystem({ os: 'Arch', cpu: 'Ryzen 9', ram: '32 GB' })).toBe('Arch \u2022 Ryzen 9 \u2022 32 GB');
+  });
+  test('falls back to gpu when cpu absent', () => {
+    expect(utils.summarizeSystem({ os: 'Arch', gpu: 'RTX 4070', ram: '32 GB' })).toBe('Arch \u2022 RTX 4070 \u2022 32 GB');
+  });
+  test('placeholder when nothing present', () => {
+    expect(utils.summarizeSystem({})).toBe('No parsed hardware summary available yet.');
+  });
+});
+
+describe('hardware metadata localStorage helpers', () => {
+  test('getMyHwSourceMeta returns null when unset', () => {
+    expect(utils.getMyHwSourceMeta()).toBeNull();
+  });
+  test('setMyHwSourceMeta then read returns the object', () => {
+    utils.setMyHwSourceMeta({ source: 'steam-paste', when: 1 });
+    expect(utils.getMyHwSourceMeta()).toEqual({ source: 'steam-paste', when: 1 });
+  });
+  test('setMyHwSourceMeta(null) removes the key', () => {
+    utils.setMyHwSourceMeta({ source: 'x' });
+    utils.setMyHwSourceMeta(null);
+    expect(utils.getMyHwSourceMeta()).toBeNull();
+  });
+  test('getMyHwSourceMeta tolerates corrupt JSON', () => {
+    _store['proton-pulse:myhw:source-meta'] = '{not valid';
+    expect(utils.getMyHwSourceMeta()).toBeNull();
+  });
+  test('field origins round-trip + per-field set', () => {
+    expect(utils.getMyHwFieldOrigins()).toEqual({});
+    utils.setMyHwFieldOrigins({ cpu: 'steam-paste' });
+    expect(utils.getMyHwFieldOrigins()).toEqual({ cpu: 'steam-paste' });
+    utils.setMyHwFieldOrigin('gpu', 'manual');
+    expect(utils.getMyHwFieldOrigins()).toEqual({ cpu: 'steam-paste', gpu: 'manual' });
+  });
+});
+
+describe('escapeHtml', () => {
+  test('escapes the five HTML-unsafe chars', () => {
+    expect(utils.escapeHtml(`<a href="x">'&y</a>`)).toBe('&lt;a href=&quot;x&quot;&gt;&#39;&amp;y&lt;/a&gt;');
+  });
+  test('coerces non-string and handles falsy', () => {
+    expect(utils.escapeHtml(null)).toBe('');
+    expect(utils.escapeHtml(undefined)).toBe('');
+    expect(utils.escapeHtml(42)).toBe('42');
+  });
+});
+
+describe('formatSystemUpdated', () => {
+  test('returns "-" for falsy input', () => {
+    expect(utils.formatSystemUpdated('')).toBe('-');
+    expect(utils.formatSystemUpdated(null)).toBe('-');
+    expect(utils.formatSystemUpdated(undefined)).toBe('-');
+  });
+  test('valid ISO timestamp parses (any non-empty string)', () => {
+    const out = utils.formatSystemUpdated('2026-06-30T12:00:00Z');
+    expect(typeof out).toBe('string');
+    expect(out.length).toBeGreaterThan(0);
+    expect(out).not.toBe('-');
+  });
+  test('unparseable strings return the raw input', () => {
+    expect(utils.formatSystemUpdated('not a date')).toBe('not a date');
+  });
+});
+
+describe('getWebClientIdProfile', () => {
+  test('generates a UUID on first call and persists it', () => {
+    const first = utils.getWebClientIdProfile();
+    expect(first).toMatch(/^test-uuid-/);
+    const second = utils.getWebClientIdProfile();
+    expect(second).toBe(first);
+  });
+});
+
+describe('enabled vars text round-trip', () => {
+  test('enabledVarsToText joins KEY=VALUE per line', () => {
+    expect(utils.enabledVarsToText({ DXVK: '1', PROTON: 'experimental' })).toBe('DXVK=1\nPROTON=experimental');
+  });
+  test('null or non-object returns empty string', () => {
+    expect(utils.enabledVarsToText(null)).toBe('');
+    expect(utils.enabledVarsToText('not an object')).toBe('');
+  });
+  test('textToEnabledVars parses lines back, skipping malformed', () => {
+    expect(utils.textToEnabledVars('A=1\nB=two\n\n=skipme\nbad-no-equals\nC=three')).toEqual({
+      A: '1', B: 'two', C: 'three',
+    });
+  });
+});
+
+describe('getMyReportBadges', () => {
+  test('cloud-only emits Synced badge with restore tooltip', () => {
+    const out = utils.getMyReportBadges({ cloud: true, unpublished: true });
+    expect(out[0].label).toBe('Synced');
+    expect(out[0].tone).toBe('cloud');
+    expect(out[0].title).toMatch(/cloud sync/i);
+    expect(out[1].label).toBe('Unpublished');
+  });
+  test('published+cloud emits Synced + Published', () => {
+    const out = utils.getMyReportBadges({ cloud: true, published: true });
+    expect(out.map((b) => b.label)).toEqual(['Synced', 'Published']);
+  });
+  test('pending emits Synced + Pending in that order', () => {
+    const out = utils.getMyReportBadges({ pending: true });
+    expect(out.map((b) => b.label)).toEqual(['Synced', 'Pending']);
+  });
+  test('flagged badge always last', () => {
+    const out = utils.getMyReportBadges({ published: true, flagged: true });
+    expect(out[out.length - 1].label).toBe('Flagged');
+  });
+});
+
+describe('flaggedMessageHtml', () => {
+  test('null reason returns the generic message (no Discord link)', () => {
+    const out = utils.flaggedMessageHtml(null);
+    expect(out).toMatch(/flagged for review/);
+    expect(out).not.toMatch(/discord/i);
+  });
+  test('wordlist reason names the field and links to Discord', () => {
+    const out = utils.flaggedMessageHtml('wordlist:badword in notes');
+    expect(out).toMatch(/flagged word/);
+    expect(out).toMatch(/your notes/);
+    expect(out).toMatch(/discord/i);
+  });
+  test('openai reason joins categories', () => {
+    const out = utils.flaggedMessageHtml('openai:hate,self-harm/intent');
+    expect(out).toMatch(/Content was flagged for: hate, self harm \/ intent/);
+  });
+  test('unknown reason still includes generic message + Discord link', () => {
+    const out = utils.flaggedMessageHtml('admin:banned');
+    expect(out).toMatch(/flagged for review/);
+    expect(out).toMatch(/discord/i);
+  });
+});
+
+describe('mergeMyReportRows', () => {
+  test('collapses published + cloud rows on the same app_id', () => {
+    const published = [{ id: 9, app_id: '730', title: 'CS2', rating: 'platinum', created_at: '2026-06-01T00:00:00Z' }];
+    const cloud = [{ app_id: 730, app_name: 'CS2', updated_at: '2026-06-02T00:00:00Z', is_published: true }];
+    const out = utils.mergeMyReportRows(published, cloud);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toEqual(expect.objectContaining({
+      app_id: '730', cloud: true, published: true, unpublished: false,
+    }));
+  });
+  test('cloud-only row is unpublished', () => {
+    const out = utils.mergeMyReportRows([], [
+      { app_id: '570', app_name: 'Dota 2', updated_at: '2026-06-30T00:00:00Z' },
+    ]);
+    expect(out[0]).toEqual(expect.objectContaining({
+      cloud: true, published: false, unpublished: true,
+    }));
+  });
+  test('sorted by updated_at descending', () => {
+    const out = utils.mergeMyReportRows([
+      { app_id: '1', title: 'A', updated_at: '2026-01-01T00:00:00Z' },
+      { app_id: '2', title: 'B', updated_at: '2026-06-01T00:00:00Z' },
+    ], []);
+    expect(out.map((r) => r.app_id)).toEqual(['2', '1']);
+  });
+  test('flagged flag propagates from any contributing row', () => {
+    const out = utils.mergeMyReportRows([
+      { id: 1, app_id: '1', title: 'A', is_flagged: true, flagged_reason: 'wordlist:x in notes' },
+    ], []);
+    expect(out[0].flagged).toBe(true);
+    expect(out[0].flagged_reason).toBe('wordlist:x in notes');
+  });
+  test('empty inputs return empty array', () => {
+    expect(utils.mergeMyReportRows([], [])).toEqual([]);
+    expect(utils.mergeMyReportRows(null, null)).toEqual([]);
+  });
+});
+
+describe('getPluginLinkCodeFromLocation', () => {
+  test('reads pluginLinkCode from search string', () => {
+    expect(utils.getPluginLinkCodeFromLocation({ search: '?pluginLinkCode=ABC123', hash: '' })).toBe('ABC123');
+  });
+  test('falls back to query inside hash fragment', () => {
+    expect(utils.getPluginLinkCodeFromLocation({ search: '', hash: '#/somewhere?pluginLinkCode=XYZ' })).toBe('XYZ');
+  });
+  test('returns null when absent', () => {
+    expect(utils.getPluginLinkCodeFromLocation({ search: '', hash: '' })).toBeNull();
+  });
+});

--- a/tests/profileUtilsCoverage.test.js
+++ b/tests/profileUtilsCoverage.test.js
@@ -338,6 +338,151 @@ describe('mergeMyReportRows', () => {
   });
 });
 
+describe('parseSteamSystemInfo', () => {
+  test('returns empty object for empty / non-string input', () => {
+    expect(utils.parseSteamSystemInfo('')).toEqual({});
+    expect(utils.parseSteamSystemInfo(null)).toEqual({});
+    expect(utils.parseSteamSystemInfo(undefined)).toEqual({});
+    expect(utils.parseSteamSystemInfo(42)).toEqual({});
+  });
+
+  test('extracts CPU brand and infers vendor from brand when vendor line absent', () => {
+    const out = utils.parseSteamSystemInfo('CPU Brand: AMD Ryzen 7 5800X3D 8-Core Processor\n');
+    expect(out.cpu).toBe('AMD Ryzen 7 5800X3D 8-Core Processor');
+    expect(out.cpuVendor).toBe('amd');
+  });
+
+  test('CPU Vendor: GenuineIntel normalizes to intel', () => {
+    const out = utils.parseSteamSystemInfo('CPU Brand: Core i9-13900K\nCPU Vendor: GenuineIntel\n');
+    expect(out.cpuVendor).toBe('intel');
+  });
+
+  test('"unknown" cpu line treated as absent', () => {
+    const out = utils.parseSteamSystemInfo('CPU Brand: Unknown\n');
+    expect(out.cpu).toBeUndefined();
+  });
+
+  test('Operating System Version multi-line + stripping parentheticals + quotes', () => {
+    const sys = 'Operating System Version:\n    "Arch Linux (rolling)"\n';
+    const out = utils.parseSteamSystemInfo(sys);
+    expect(out.os).toBe('Arch Linux');
+  });
+
+  test('OS Version single-line form', () => {
+    expect(utils.parseSteamSystemInfo('OS Version: SteamOS 3.5.17\n').os).toBe('SteamOS 3.5.17');
+  });
+
+  test('OS with only an "Unknown" payload drops the field', () => {
+    expect(utils.parseSteamSystemInfo('OS Version: Unknown\n').os).toBeUndefined();
+  });
+
+  test('Manufacturer + Model + Kernel fields', () => {
+    const sys = 'Manufacturer: Valve\nModel: Jupiter\nKernel Version: 6.5.0-valve22\n';
+    const out = utils.parseSteamSystemInfo(sys);
+    expect(out.manufacturer).toBe('Valve');
+    expect(out.model).toBe('Jupiter');
+    expect(out.kernel).toBe('6.5.0-valve22');
+  });
+
+  test('GPU via Steam "Driver:" line strips NVIDIA Corporation prefix', () => {
+    const sys = 'Video Card:\n    Driver: NVIDIA Corporation NVIDIA GeForce RTX 4070\n';
+    const out = utils.parseSteamSystemInfo(sys);
+    expect(out.gpu).toBe('GeForce RTX 4070');
+  });
+
+  test('GPU via Steam "Driver:" line strips AMD prefix', () => {
+    const sys = 'Video Card:\n    Driver: Advanced Micro Devices, Inc. Radeon RX 7800 XT\n';
+    const out = utils.parseSteamSystemInfo(sys);
+    expect(out.gpu).toMatch(/Radeon RX 7800 XT/);
+  });
+
+  test('GPU Steam line "unknown" payload drops the field', () => {
+    const sys = 'Driver: unknown\n';
+    expect(utils.parseSteamSystemInfo(sys).gpu).toBeUndefined();
+  });
+
+  test('GPU via form "Video Card: <gpu>" single-line form', () => {
+    expect(utils.parseSteamSystemInfo('Video Card: Intel Arc B580\n').gpu).toBe('Intel Arc B580');
+  });
+
+  test('GPU Vendor explicit line lowercases the value', () => {
+    expect(utils.parseSteamSystemInfo('GPU Vendor: NVIDIA\n').gpuVendor).toBe('nvidia');
+  });
+
+  test('GPU driver line populates gpuDriver verbatim', () => {
+    expect(utils.parseSteamSystemInfo('Driver Version: Mesa 24.1.0\n').gpuDriver).toBe('Mesa 24.1.0');
+  });
+
+  test('VRAM in MB parses to number', () => {
+    expect(utils.parseSteamSystemInfo('VRAM: 8192 Mb\n').vramMb).toBe(8192);
+  });
+
+  test('RAM in MB converts to whole GB', () => {
+    expect(utils.parseSteamSystemInfo('RAM: 32677 Mb\n').ram).toBe('32 GB');
+    expect(utils.parseSteamSystemInfo('RAM: 16384 Mb\n').ram).toBe('16 GB');
+  });
+
+  test('RAM that rounds to 0 GB drops the field', () => {
+    expect(utils.parseSteamSystemInfo('RAM: 256 Mb\n').ram).toBeUndefined();
+  });
+
+  test('full Steam Deck OLED dump rolls up cleanly', () => {
+    const sys = [
+      'Manufacturer: Valve',
+      'Model: Galileo',
+      'CPU Brand: AMD Custom APU 0932',
+      'CPU Vendor: AuthenticAMD',
+      'Video Card:',
+      '    Driver: AMD AMD Custom GPU 0932',
+      'Driver Version: Mesa 24.1.0',
+      'VRAM: 1024 Mb',
+      'RAM: 16384 Mb',
+      'Operating System Version:',
+      '    "SteamOS 3.6 (Jupiter)"',
+      'Kernel Version: 6.5.0-valve22',
+    ].join('\n');
+    const out = utils.parseSteamSystemInfo(sys);
+    expect(out.manufacturer).toBe('Valve');
+    expect(out.model).toBe('Galileo');
+    expect(out.cpu).toMatch(/AMD Custom APU 0932/);
+    expect(out.cpuVendor).toBe('amd');
+    expect(out.gpu).toBe('AMD Custom GPU 0932');
+    expect(out.gpuDriver).toBe('Mesa 24.1.0');
+    expect(out.vramMb).toBe(1024);
+    // #152: anchored RAM regex no longer matches inside "VRAM:".
+    expect(out.ram).toBe('16 GB');
+    expect(out.os).toBe('SteamOS 3.6');
+    expect(out.kernel).toBe('6.5.0-valve22');
+  });
+
+  test('VRAM line above RAM line still extracts RAM correctly (#152)', () => {
+    const sys = 'VRAM: 1024 Mb\nRAM: 32768 Mb\n';
+    const out = utils.parseSteamSystemInfo(sys);
+    expect(out.ram).toBe('32 GB');
+    expect(out.vramMb).toBe(1024);
+  });
+});
+
+describe('parseUploadedSystem', () => {
+  test('parses sysinfo_text and backfills gpuVendor when absent', () => {
+    const row = { sysinfo_text: 'Video Card: NVIDIA GeForce RTX 4070\n' };
+    const out = utils.parseUploadedSystem(row);
+    expect(out.gpu).toContain('GeForce RTX 4070');
+    expect(out.gpuVendor).toBe('nvidia');
+  });
+
+  test('preserves explicit gpuVendor when the sysinfo line already supplies it', () => {
+    const row = { sysinfo_text: 'Video Card: NVIDIA GeForce RTX 4070\nGPU Vendor: amd\n' };
+    const out = utils.parseUploadedSystem(row);
+    expect(out.gpuVendor).toBe('amd');
+  });
+
+  test('falsy row returns empty parse', () => {
+    expect(utils.parseUploadedSystem(null)).toEqual({});
+    expect(utils.parseUploadedSystem({})).toEqual({});
+  });
+});
+
 describe('getPluginLinkCodeFromLocation', () => {
   test('reads pluginLinkCode from search string', () => {
     expect(utils.getPluginLinkCodeFromLocation({ search: '?pluginLinkCode=ABC123', hash: '' })).toBe('ABC123');

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -38,6 +38,7 @@ const {
   confTextColor,
   truncate,
   esc,
+  escWithSpoilers,
   cfgNa,
   configKey,
   hashReportKey,
@@ -534,5 +535,56 @@ describe('hashReportKey', () => {
 
   test('empty string returns a hash', () => {
     expect(hashReportKey('')).toMatch(/^h[0-9a-f]*$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// escWithSpoilers (#22)
+// ---------------------------------------------------------------------------
+//
+// Coverage-side test for escWithSpoilers. The behavioral suite lives in
+// tests/spoilerTags.test.js (loadEsm-based, no instrumentation credit).
+
+describe('escWithSpoilers (require-loaded coverage)', () => {
+  test('returns empty string for falsy input', () => {
+    expect(escWithSpoilers('')).toBe('');
+    expect(escWithSpoilers(null)).toBe('');
+    expect(escWithSpoilers(undefined)).toBe('');
+  });
+
+  test('plain text passes through HTML-escaped, no markup', () => {
+    expect(escWithSpoilers('hello world')).toBe('hello world');
+    expect(escWithSpoilers('<script>x</script>')).toBe('&lt;script&gt;x&lt;/script&gt;');
+  });
+
+  test('wraps {spoiler}...{/spoiler} in a button-role span with nested .spoiler-content', () => {
+    const out = escWithSpoilers('{spoiler}hidden{/spoiler}');
+    expect(out).toContain('class="spoiler" role="button"');
+    expect(out).toContain('<span class="spoiler-content">hidden</span>');
+    expect(out).toContain('onclick=');
+    expect(out).toContain('onkeydown=');
+  });
+
+  test('escapes content inside spoilers (XSS-safe)', () => {
+    const out = escWithSpoilers('{spoiler}<img src=x onerror=alert(1)>{/spoiler}');
+    expect(out).not.toMatch(/<img\b/);
+    expect(out).toContain('&lt;img');
+  });
+
+  test('multiple spoilers in one string all wrap independently', () => {
+    const out = escWithSpoilers('before {spoiler}a{/spoiler} mid {spoiler}b{/spoiler} after');
+    const matches = out.match(/class="spoiler"/g) || [];
+    expect(matches).toHaveLength(2);
+  });
+
+  test('unclosed spoiler tag falls back to plain escaped text (no run-on)', () => {
+    const out = escWithSpoilers('hi {spoiler}forgot to close');
+    expect(out).not.toContain('class="spoiler"');
+    expect(out).toContain('{spoiler}forgot to close');
+  });
+
+  test('case-insensitive on the tag name', () => {
+    expect(escWithSpoilers('{SPOILER}x{/SPOILER}')).toContain('class="spoiler"');
+    expect(escWithSpoilers('{Spoiler}y{/spoiler}')).toContain('class="spoiler"');
   });
 });

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -545,6 +545,50 @@ describe('hashReportKey', () => {
 // Coverage-side test for escWithSpoilers. The behavioral suite lives in
 // tests/spoilerTags.test.js (loadEsm-based, no instrumentation credit).
 
+describe('downloadJson', () => {
+  // Save the original createElement that the esc() helper relies on so we
+  // can restore it after this test. Without that the rest of the file's
+  // esc-based assertions get a different element shape and fail.
+  const origCreateElement = global.document.createElement;
+  const origBlob = global.Blob;
+  const origCreateObjectURL = global.URL.createObjectURL;
+  const origRevokeObjectURL = global.URL.revokeObjectURL;
+
+  afterAll(() => {
+    global.document.createElement = origCreateElement;
+    global.Blob = origBlob;
+    global.URL.createObjectURL = origCreateObjectURL;
+    global.URL.revokeObjectURL = origRevokeObjectURL;
+  });
+
+  test('serializes obj as pretty JSON, creates a Blob, and triggers a download', () => {
+    const created = [];
+    const revoked = [];
+    global.Blob = function (parts, opts) { this.parts = parts; this.type = opts?.type; };
+    global.URL.createObjectURL = (b) => { created.push(b); return 'blob:fake'; };
+    global.URL.revokeObjectURL = (u) => { revoked.push(u); };
+    const clicked = [];
+    global.document.createElement = (tag) => {
+      const el = { tag, click() { clicked.push(el); } };
+      Object.defineProperty(el, 'href', { set(v) { el._href = v; }, get() { return el._href; } });
+      Object.defineProperty(el, 'download', { set(v) { el._download = v; }, get() { return el._download; } });
+      return el;
+    };
+
+    utils.downloadJson({ a: 1, b: ['x'] }, 'My Report / 2026');
+
+    expect(created).toHaveLength(1);
+    const body = created[0].parts[0];
+    expect(JSON.parse(body)).toEqual({ a: 1, b: ['x'] });
+    expect(created[0].type).toBe('application/json');
+    expect(clicked).toHaveLength(1);
+    // Non-filename-safe chars (space, slash) get replaced with underscores.
+    expect(clicked[0]._download).toBe('My_Report___2026.json');
+    expect(clicked[0]._href).toBe('blob:fake');
+    expect(revoked).toEqual(['blob:fake']);
+  });
+});
+
 describe('escWithSpoilers (require-loaded coverage)', () => {
   test('returns empty string for falsy input', () => {
     expect(escWithSpoilers('')).toBe('');


### PR DESCRIPTION
Follow-up to #136. Solidifies the test suite with require-loaded behavioral tests that Istanbul actually instruments, expands the coverage gate scope, and fixes two real bugs surfaced along the way.

Closes:
- #151 detectGpuArch classification gaps (R9 280 -> GCN2, GTX 1080 -> Pascal, UHD Graphics 770 -> Xe, Intel Arc A-series -> Alchemist)
- #152 RAM regex greedy-matched "VRAM:" prefix, so Deck OLED users saw a wrong RAM value in the prefill form

Test suite: 899 -> 1058 tests (+159).

Coverage jumped from 16% (utils.js + permissions.js only) to 95%+ across nine instrumented files (admin/permissions, admin/api/{allReports,analytics,pending}, app/utils, lib/{analytics,app-id,gpu-arch-detector}, profile/utils). See the diff on jest.config.js for the new scope.

Key mechanical change: added a moduleNameMapper entry that strips the ?v=<hash> cache-bust suffix from import paths at test time. That lets babel-jest resolve + instrument the real module files instead of the vm.runInContext workaround the older tests use.

Verified on staging: https://mdeguzis.github.io/proton-pulse-web-staging/ shows v1.5.0 - 0970c3b on the about page.