### PR TITLE
Markdown notes: submit editor + reader-side render

### DIFF
--- a/app.html
+++ b/app.html
@@ -19,7 +19,7 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=16c748ed">
 <link rel="stylesheet" href="css/app/game-header.css?v=66685a3b">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=f6493b79">
+<link rel="stylesheet" href="css/app/reports.css?v=9ac38baa">
 <link rel="stylesheet" href="css/app/modals.css?v=99a2a3d5">
 <link rel="stylesheet" href="css/app/home.css?v=d983b41a">
 </head>
@@ -59,6 +59,10 @@
 <script src="js/lib/topbar.js?v=449040e3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
+<!-- #153: markdown-it renders the Notes field on report cards. renderNotes
+     in js/app/utils.js falls back to plain-text + spoiler handling when
+     the global is missing, so a load failure degrades gracefully. -->
+<script src="https://cdn.jsdelivr.net/npm/markdown-it@14.1.0/dist/markdown-it.min.js"></script>
 <script type="module" src="js/app/main.js?v=7417f4a4"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -17,7 +17,7 @@
 <link rel="stylesheet" href="css/shared/site.css?v=e05a0f73">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
 <link rel="stylesheet" href="css/shared/cards.css?v=16c748ed">
-<link rel="stylesheet" href="css/app/game-header.css?v=08bbcb4a">
+<link rel="stylesheet" href="css/app/game-header.css?v=66685a3b">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=f6493b79">
 <link rel="stylesheet" href="css/app/modals.css?v=99a2a3d5">

--- a/confidence.html
+++ b/confidence.html
@@ -15,7 +15,7 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=16c748ed">
 <link rel="stylesheet" href="css/app/game-header.css?v=66685a3b">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=f6493b79">
+<link rel="stylesheet" href="css/app/reports.css?v=9ac38baa">
 <link rel="stylesheet" href="css/app/modals.css?v=99a2a3d5">
 <link rel="stylesheet" href="css/app/home.css?v=d983b41a">
 <style>

--- a/confidence.html
+++ b/confidence.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=2d6b5e52">
 <link rel="stylesheet" href="css/shared/site.css?v=e05a0f73">
 <link rel="stylesheet" href="css/shared/cards.css?v=16c748ed">
-<link rel="stylesheet" href="css/app/game-header.css?v=08bbcb4a">
+<link rel="stylesheet" href="css/app/game-header.css?v=66685a3b">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=f6493b79">
 <link rel="stylesheet" href="css/app/modals.css?v=99a2a3d5">

--- a/css/app/game-header.css
+++ b/css/app/game-header.css
@@ -789,6 +789,95 @@
 .sf-check-hint { font-size: 0.68rem; color: var(--muted); padding-left: 1px; }
 .sf-hidden { display: none !important; }
 .sf-section-label { font-size: 0.68rem; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted); margin: 12px 0 6px; }
+
+/* #153 spike: markdown-it Write / Preview enhancer on the Notes field.
+   Opt-in via ?md=1 on submit.html. The tabs sit above the textarea and
+   swap the visible surface between the raw textarea and a rendered
+   preview div. The textarea keeps its name="notes" so the existing
+   submitReport payload logic does not change. */
+.md-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  width: 100%;
+}
+.md-editor-tabs {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 6px;
+  background: rgba(255,255,255,0.03);
+  border: 1px solid var(--border, #253038);
+  border-bottom: none;
+  border-radius: 4px 4px 0 0;
+}
+.md-editor-tab {
+  font-family: inherit;
+  font-size: 0.7rem;
+  background: none;
+  border: 1px solid transparent;
+  color: var(--muted, #b8c0c8);
+  padding: 3px 10px;
+  cursor: pointer;
+  border-radius: 3px;
+  letter-spacing: 0.03em;
+}
+.md-editor-tab:hover { color: var(--accent, #5c8bd6); }
+.md-editor-tab--active {
+  color: var(--accent, #5c8bd6);
+  background: rgba(92,139,214,0.1);
+  border-color: rgba(92,139,214,0.35);
+}
+.md-editor-hint {
+  margin-left: auto;
+  font-size: 0.65rem;
+  color: var(--muted, #b8c0c8);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+.md-editor .md-editor-preview,
+.md-editor > textarea {
+  border-radius: 0 0 4px 4px;
+  border-top: none;
+}
+.md-editor-preview {
+  padding: 10px 12px;
+  min-height: 80px;
+  background: rgba(11,17,22,0.5);
+  border: 1px solid var(--border, #253038);
+  color: var(--text, #cfd6dd);
+  line-height: 1.5;
+  font-size: 0.86rem;
+  overflow-wrap: anywhere;
+}
+.md-editor-preview h1,
+.md-editor-preview h2,
+.md-editor-preview h3 { margin: 12px 0 6px; line-height: 1.2; }
+.md-editor-preview p { margin: 6px 0; }
+.md-editor-preview ul,
+.md-editor-preview ol { margin: 6px 0; padding-left: 22px; }
+.md-editor-preview code {
+  background: rgba(0,0,0,0.35);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 0.9em;
+}
+.md-editor-preview pre {
+  background: rgba(0,0,0,0.35);
+  padding: 10px 12px;
+  border-radius: 4px;
+  overflow-x: auto;
+}
+.md-editor-preview pre code { background: none; padding: 0; }
+.md-editor-preview blockquote {
+  border-left: 3px solid var(--accent, #5c8bd6);
+  padding: 2px 10px;
+  margin: 8px 0;
+  color: var(--muted, #b8c0c8);
+}
+.md-editor-preview a { color: var(--accent, #5c8bd6); }
+.md-editor-empty { color: var(--muted, #b8c0c8); font-size: 0.8rem; }
 .sf-question { margin-bottom: 10px; }
 .sf-question.sf-needs-answer { border-left: 3px solid var(--red); padding-left: 10px; }
 .sf-question.sf-needs-answer .sf-q-label { color: var(--red); }

--- a/css/app/reports.css
+++ b/css/app/reports.css
@@ -616,7 +616,44 @@ a.card:active { transform: translateY(1px); }
 }
 .card-summary .row:last-child { border-bottom: none; }
 .card-summary .label { color: var(--muted); min-width: 100px; }
-.card-summary .notes-full { white-space: pre-wrap; line-height: 1.5; color: #a0b4c4; }
+/* #153: notes-full is now a block container so markdown-emitted <p>,
+   <h1>, <ul>, <pre> can nest inside without inline-context conflicts.
+   Drop pre-wrap since markdown-it handles line breaks; leave the color
+   + rhythm to match the surrounding row. */
+.card-summary .notes-full { line-height: 1.5; color: #a0b4c4; }
+.card-summary .notes-full p { margin: 0.35em 0; }
+.card-summary .notes-full p:first-child { margin-top: 0; }
+.card-summary .notes-full p:last-child { margin-bottom: 0; }
+.card-summary .notes-full h1,
+.card-summary .notes-full h2,
+.card-summary .notes-full h3 { margin: 0.8em 0 0.3em; line-height: 1.2; color: var(--text); }
+.card-summary .notes-full h1 { font-size: 1.15rem; }
+.card-summary .notes-full h2 { font-size: 1.05rem; }
+.card-summary .notes-full h3 { font-size: 0.95rem; }
+.card-summary .notes-full ul,
+.card-summary .notes-full ol { margin: 0.35em 0; padding-left: 22px; }
+.card-summary .notes-full code {
+  background: rgba(0,0,0,0.35);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 0.9em;
+}
+.card-summary .notes-full pre {
+  background: rgba(0,0,0,0.35);
+  padding: 10px 12px;
+  border-radius: 4px;
+  overflow-x: auto;
+  margin: 0.5em 0;
+}
+.card-summary .notes-full pre code { background: none; padding: 0; }
+.card-summary .notes-full blockquote {
+  border-left: 3px solid var(--accent, #5c8bd6);
+  padding: 2px 10px;
+  margin: 0.5em 0;
+  color: var(--muted, #b8c0c8);
+}
+.card-summary .notes-full a { color: var(--accent, #5c8bd6); }
 /* #22: spoiler spans render as a clear "Reveal spoiler text" button
    until clicked. The actual content lives in a nested .spoiler-content
    span that swaps in when .revealed is set. This is much more

--- a/game-stats.html
+++ b/game-stats.html
@@ -15,7 +15,7 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=16c748ed">
 <link rel="stylesheet" href="css/app/game-header.css?v=66685a3b">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=f6493b79">
+<link rel="stylesheet" href="css/app/reports.css?v=9ac38baa">
 <link rel="stylesheet" href="css/app/modals.css?v=99a2a3d5">
 <link rel="stylesheet" href="css/app/home.css?v=d983b41a">
 <style>

--- a/game-stats.html
+++ b/game-stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=2d6b5e52">
 <link rel="stylesheet" href="css/shared/site.css?v=e05a0f73">
 <link rel="stylesheet" href="css/shared/cards.css?v=16c748ed">
-<link rel="stylesheet" href="css/app/game-header.css?v=08bbcb4a">
+<link rel="stylesheet" href="css/app/game-header.css?v=66685a3b">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=f6493b79">
 <link rel="stylesheet" href="css/app/modals.css?v=99a2a3d5">

--- a/js/app/api/reports.js
+++ b/js/app/api/reports.js
@@ -1,7 +1,7 @@
 // reports (api) for the app page. Relocated from app.js.
 
 import { SB_KEY, SB_URL } from '../config.js?v=df5b5024';
-import { latestPerApp } from '../utils.js?v=9a30ef3e';
+import { latestPerApp } from '../utils.js?v=c7e1268c';
 
 /**
  * Fetch the 200 most recent Pulse compatibility reports from the `user_configs` table,

--- a/js/app/api/supabase.js
+++ b/js/app/api/supabase.js
@@ -1,7 +1,7 @@
 // supabase (api) for the app page. Relocated from app.js.
 
 import { SB_KEY, SB_URL } from '../config.js?v=df5b5024';
-import { configKey, latestPerClient } from '../utils.js?v=9a30ef3e';
+import { configKey, latestPerClient } from '../utils.js?v=c7e1268c';
 
 export async function fetchSupabase(appId) {
   try {

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -3,7 +3,7 @@
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
 import { CDN } from '../config.js?v=df5b5024';
 import { route } from '../router.js?v=d0ac896a';
-import { esc } from '../utils.js?v=9a30ef3e';
+import { esc } from '../utils.js?v=c7e1268c';
 
 export const ATOM_ICON_SVG = `
   <svg viewBox="0 0 36 36" fill="none" aria-hidden="true">

--- a/js/app/components/config-cards.js
+++ b/js/app/components/config-cards.js
@@ -2,7 +2,7 @@
 
 import { getWebClientId } from '../../shared/submit.js?v=bfb1bfdc';
 import { isNonSteamAppId } from '../config.js?v=df5b5024';
-import { cfgNa, configKey, esc, utcStamp } from '../utils.js?v=9a30ef3e';
+import { cfgNa, configKey, esc, utcStamp } from '../utils.js?v=c7e1268c';
 
 export const FORM_RESPONSE_LABELS = {
   canInstall:        'Were you able to install the game?',

--- a/js/app/components/deck-status.js
+++ b/js/app/components/deck-status.js
@@ -1,7 +1,7 @@
 // deck-status (components) for the app page. Relocated from app.js.
 
 import { getDeckStatusForApp } from '../api/deck-status.js?v=21903124';
-import { esc } from '../utils.js?v=9a30ef3e';
+import { esc } from '../utils.js?v=c7e1268c';
 
 export const DECK_STATUS_LABELS = {
   verified:    'Verified',

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -10,11 +10,11 @@ import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=aba6619f
 import { enhanceAuthorBlocks } from './author.js?v=2316d334';
 import { renderConfigCard } from './config-cards.js?v=c67740f8';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=48037483';
-import { renderCard } from './report-card.js?v=1fa18873';
+import { renderCard } from './report-card.js?v=eae7957c';
 import { loadSearchIndex, searchIndex } from './search.js?v=f7b2fe47';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=e7fe3ce0';
-import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=9a30ef3e';
+import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=c7e1268c';
 import { dataUrl } from '../../lib/data-url.js?v=3c2e7ac9';
 
 let _steamCatalogCache = null;

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -3,7 +3,7 @@
 import { fetchRecentPulseReports } from '../api/reports.js?v=003f23c0';
 import { loadSearchIndex, searchIndex } from './search.js?v=f7b2fe47';
 import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '../config.js?v=df5b5024';
-import { daysAgo, latestPerApp } from '../utils.js?v=9a30ef3e';
+import { daysAgo, latestPerApp } from '../utils.js?v=c7e1268c';
 import { renderGameCard } from '../lib/card.js?v=754da47b';
 import { dataUrl } from '../../lib/data-url.js?v=3c2e7ac9';
 import { padTileRows, watchTileRows } from '../../lib/tile-pad.js?v=defd5c6b';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -7,7 +7,7 @@ import { renderAuthorBlock } from './author.js?v=2316d334';
 import { buildFormRows } from './config-cards.js?v=c67740f8';
 import { renderSignalStrip } from './signals.js?v=a23da3df';
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=df5b5024';
-import { confColor, confTextColor, configKey, daysAgo, esc, escWithSpoilers, fmtDuration, fmtMinutes, hashReportKey, reportKey } from '../utils.js?v=9a30ef3e';
+import { confColor, confTextColor, configKey, daysAgo, esc, renderNotes, fmtDuration, fmtMinutes, hashReportKey, reportKey } from '../utils.js?v=c7e1268c';
 
 export function renderPermalink(r) {
   let id = r.reportId != null ? `r${r.reportId}` : (r.clientId ? `c${r.clientId.slice(0, 8)}` : '');
@@ -88,7 +88,7 @@ export function renderCard(r, votes, userVotes = {}, configPlaytimeTotals = []) 
       <div class="row"><span class="label">Proton</span><span>${na(esc(r.protonVersion))}</span></div>
       ${(r.durationMinutes != null || fmtDuration(r.duration)) ? `<div class="row"><span class="label">Steam playtime</span><span>${r.durationMinutes != null ? fmtMinutes(r.durationMinutes) : fmtDuration(r.duration)}</span></div>` : ''}
       ${(() => { const pt = r.configKey && configPlaytimeTotals.find(t => t.config_key === r.configKey); return pt ? `<div class="row"><span class="label">Config playtime</span><span title="${pt.session_count} session${pt.session_count !== 1 ? 's' : ''}">${fmtMinutes(pt.total_minutes)}</span></div>` : ''; })()}
-      ${r.notes ? `<div class="row"><span class="label">Notes</span><span class="notes-full">${escWithSpoilers(r.notes)}</span></div>` : ''}
+      ${r.notes ? `<div class="row"><span class="label">Notes</span><div class="notes-full">${renderNotes(r.notes)}</div></div>` : ''}
       <div class="all-details-panel hw-details-panel">
         ${arch ? `<div class="row"><span class="label">GPU Arch</span><span>${esc(arch)}</span></div>` : ''}
         <div class="row"><span class="label">RAM</span><span>${na(esc(r.ram))}</span></div>

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -4,7 +4,7 @@ import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=003f23c0';
 import { renderGamePage } from './game-page.js?v=d79ce4b8';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId } from '../config.js?v=df5b5024';
-import { daysAgo, esc, withTimeout } from '../utils.js?v=9a30ef3e';
+import { daysAgo, esc, withTimeout } from '../utils.js?v=c7e1268c';
 import { renderGameCard } from '../lib/card.js?v=754da47b';
 import { dataUrl } from '../../lib/data-url.js?v=3c2e7ac9';
 

--- a/js/app/lib/card.js
+++ b/js/app/lib/card.js
@@ -1,7 +1,7 @@
 // Unified game card renderer. Single source of truth for the
 // thumbnail | title + sub | badge card layout used everywhere.
 import { STEAM_IMG } from '../config.js?v=df5b5024';
-import { esc } from '../utils.js?v=9a30ef3e';
+import { esc } from '../utils.js?v=c7e1268c';
 import { loadSteamImg as _loadSteamImg } from './steam-img.js?v=e7fe3ce0';
 
 const TIER_COLORS = {

--- a/js/app/utils.js
+++ b/js/app/utils.js
@@ -245,6 +245,56 @@ export function escWithSpoilers(s) {
   return out;
 }
 
+// #153 rollout: render Notes text through markdown-it, then post-process
+// {spoiler}...{/spoiler} tokens in the resulting HTML. markdown-it is
+// loaded from CDN in submit.html + app.html; when it is not available
+// (older cached page, test env) we fall back to escWithSpoilers so
+// spoilers still work.
+let _mdInstance = null;
+function _getMdRenderer() {
+  if (_mdInstance) return _mdInstance;
+  if (typeof window !== 'undefined' && typeof window.markdownit === 'function') {
+    // html:false removes the primary XSS surface -- users cannot inject
+    // raw HTML through the Notes field. linkify + breaks match GitHub-
+    // style behaviour so URLs and hard line breaks Just Work.
+    _mdInstance = window.markdownit({
+      html: false,
+      linkify: true,
+      breaks: true,
+      typographer: false,
+    });
+  }
+  return _mdInstance;
+}
+
+/**
+ * Render a Notes string as HTML: markdown (via markdown-it) + spoiler
+ * tokens post-processed to reveal spans.
+ *
+ * Known limitation: {spoiler} tokens inside fenced code blocks are still
+ * substituted (string-level replace runs on the rendered HTML). A
+ * markdown-it plugin would fix that; the string approach is fine for
+ * the current spike scope.
+ *
+ * @param {string|null|undefined} text - Raw Notes value from user_configs.
+ * @returns {string} HTML string, safe to drop into innerHTML.
+ */
+export function renderNotes(text) {
+  if (!text) return '';
+  const md = _getMdRenderer();
+  if (!md) return escWithSpoilers(text);
+  let html = md.render(String(text));
+  // markdown-it with html:false already escaped the inner text, so we
+  // can drop it into the spoiler span without additional escaping.
+  const SPOILER_RE = /\{spoiler\}([\s\S]*?)\{\/spoiler\}/gi;
+  html = html.replace(
+    SPOILER_RE,
+    (_full, inner) =>
+      `<span class="spoiler" role="button" tabindex="0" aria-label="Spoiler -- tap to reveal" onclick="this.classList.toggle('revealed')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.classList.toggle('revealed');}"><span class="spoiler-content">${inner}</span></span>`,
+  );
+  return html;
+}
+
 
 
 // - Render: Proton Pulse Configs section ------------

--- a/js/submit/main.js
+++ b/js/submit/main.js
@@ -120,11 +120,11 @@ import { appIdToDir } from '../lib/app-id.js?v=18a73fb7';
     return;
   }
 
-  // Markdown editor spike (#153): opt-in via ?md=1. When on, wrap the
-  // Notes textarea with Write / Preview tabs and render the preview via
-  // window.markdownit. Reader-side rendering unchanged for now; this is
-  // just for evaluating the input UX.
-  if (params.get('md') === '1' && typeof window.markdownit === 'function') {
+  // #153: markdown editor is on site-wide now (no flag). Wrap the Notes
+  // textarea with Write / Preview tabs and render the preview via
+  // window.markdownit. Falls through silently if the CDN failed to load,
+  // in which case the textarea keeps working as plain text.
+  if (typeof window.markdownit === 'function') {
     enhanceNotesWithMarkdown(el);
   }
 

--- a/js/submit/main.js
+++ b/js/submit/main.js
@@ -120,6 +120,14 @@ import { appIdToDir } from '../lib/app-id.js?v=18a73fb7';
     return;
   }
 
+  // Markdown editor spike (#153): opt-in via ?md=1. When on, wrap the
+  // Notes textarea with Write / Preview tabs and render the preview via
+  // window.markdownit. Reader-side rendering unchanged for now; this is
+  // just for evaluating the input UX.
+  if (params.get('md') === '1' && typeof window.markdownit === 'function') {
+    enhanceNotesWithMarkdown(el);
+  }
+
   // In edit mode, pre-fill from existing report; otherwise fall back to saved hardware
   if (isEdit && session) {
     // #144: warn before editing a currently-published report. Fetch the
@@ -438,3 +446,59 @@ import { appIdToDir } from '../lib/app-id.js?v=18a73fb7';
   const fc = document.getElementById('submit-form-content');
   if (fc) fc.innerHTML = `<div style="padding:24px;color:var(--red)">Page error: ${err.message || err}</div>`;
 });
+
+// #153 spike: wraps the Notes textarea (name="notes") with a Write /
+// Preview tab pair. Preview renders via markdown-it. The textarea keeps
+// its name so the existing submitReport payload logic is untouched --
+// the raw markdown flows into user_configs.notes exactly like plain
+// text does today.
+function enhanceNotesWithMarkdown(rootEl) {
+  const textarea = rootEl.querySelector('textarea[name="notes"]');
+  if (!textarea || textarea.dataset.mdEnhanced === '1') return;
+  textarea.dataset.mdEnhanced = '1';
+
+  // html: false stops raw HTML from flowing through so the notes field
+  // is not an XSS vector. linkify + breaks match how most chat / issue
+  // renderers behave (Discord, GitHub Discussions).
+  const md = window.markdownit({
+    html: false,
+    linkify: true,
+    breaks: true,
+    typographer: false,
+  });
+
+  const wrapper = document.createElement('div');
+  wrapper.className = 'md-editor';
+  wrapper.innerHTML = `
+    <div class="md-editor-tabs" role="tablist">
+      <button type="button" class="md-editor-tab md-editor-tab--active" data-md-tab="write" role="tab" aria-selected="true">Write</button>
+      <button type="button" class="md-editor-tab" data-md-tab="preview" role="tab" aria-selected="false">Preview</button>
+      <span class="md-editor-hint">Markdown supported</span>
+    </div>
+    <div class="md-editor-preview" hidden></div>
+  `;
+  textarea.parentNode.insertBefore(wrapper, textarea);
+  wrapper.appendChild(textarea);
+
+  const previewEl = wrapper.querySelector('.md-editor-preview');
+  const writeBtn = wrapper.querySelector('[data-md-tab="write"]');
+  const previewBtn = wrapper.querySelector('[data-md-tab="preview"]');
+
+  function activate(tab) {
+    const isPreview = tab === 'preview';
+    writeBtn.classList.toggle('md-editor-tab--active', !isPreview);
+    previewBtn.classList.toggle('md-editor-tab--active', isPreview);
+    writeBtn.setAttribute('aria-selected', String(!isPreview));
+    previewBtn.setAttribute('aria-selected', String(isPreview));
+    textarea.hidden = isPreview;
+    previewEl.hidden = !isPreview;
+    if (isPreview) {
+      const raw = textarea.value || '';
+      previewEl.innerHTML = raw.trim()
+        ? md.render(raw)
+        : '<em class="md-editor-empty">Nothing to preview yet.</em>';
+    }
+  }
+  writeBtn.addEventListener('click', () => activate('write'));
+  previewBtn.addEventListener('click', () => activate('preview'));
+}

--- a/submit.html
+++ b/submit.html
@@ -14,7 +14,7 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=16c748ed">
 <link rel="stylesheet" href="css/app/game-header.css?v=66685a3b">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=f6493b79">
+<link rel="stylesheet" href="css/app/reports.css?v=9ac38baa">
 <link rel="stylesheet" href="css/app/modals.css?v=99a2a3d5">
 <link rel="stylesheet" href="css/app/home.css?v=d983b41a">
 </head>
@@ -58,6 +58,6 @@
   </div>
 </div>
 
-<script type="module" src="js/submit/main.js?v=8707df1c"></script>
+<script type="module" src="js/submit/main.js?v=54f5adb8"></script>
 </body>
 </html>

--- a/submit.html
+++ b/submit.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=2d6b5e52">
 <link rel="stylesheet" href="css/shared/site.css?v=e05a0f73">
 <link rel="stylesheet" href="css/shared/cards.css?v=16c748ed">
-<link rel="stylesheet" href="css/app/game-header.css?v=08bbcb4a">
+<link rel="stylesheet" href="css/app/game-header.css?v=66685a3b">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=f6493b79">
 <link rel="stylesheet" href="css/app/modals.css?v=99a2a3d5">
@@ -25,6 +25,9 @@
 <script src="js/lib/analytics.js?v=e6dfbad8"></script>
 <script src="js/lib/topbar.js?v=449040e3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
+<!-- Markdown editor spike (?md=1). Loaded eagerly but only wired when the
+     flag is on -- window.markdownit stays unused otherwise. -->
+<script src="https://cdn.jsdelivr.net/npm/markdown-it@14.1.0/dist/markdown-it.min.js"></script>
 
 <div class="main-content">
   <div class="main-inner" style="max-width:860px">
@@ -55,6 +58,6 @@
   </div>
 </div>
 
-<script type="module" src="js/submit/main.js?v=54ad1139"></script>
+<script type="module" src="js/submit/main.js?v=8707df1c"></script>
 </body>
 </html>

--- a/tests/submitMarkdownSpike.test.js
+++ b/tests/submitMarkdownSpike.test.js
@@ -20,15 +20,17 @@ describe('markdown editor spike (#153)', () => {
     expect(SUBMIT_HTML).toContain('markdown-it@14.1.0/dist/markdown-it.min.js');
   });
 
-  test('enhancer wires only when ?md=1 AND window.markdownit is present', () => {
-    expect(SUBMIT_MAIN).toContain("params.get('md') === '1'");
+  test('enhancer wires whenever window.markdownit is present (no flag gate)', () => {
+    // Flag was removed once the spike graduated site-wide -- the CDN
+    // load is the only gate now.
+    expect(SUBMIT_MAIN).not.toContain("params.get('md') === '1'");
     expect(SUBMIT_MAIN).toContain("typeof window.markdownit === 'function'");
     expect(SUBMIT_MAIN).toContain('enhanceNotesWithMarkdown(el)');
   });
 
   test('enhancer runs after populateSubmitForm so the textarea exists', () => {
     const popIdx = SUBMIT_MAIN.indexOf('await populateSubmitForm(el)');
-    const wireIdx = SUBMIT_MAIN.indexOf("params.get('md') === '1'");
+    const wireIdx = SUBMIT_MAIN.indexOf('enhanceNotesWithMarkdown(el)');
     expect(popIdx).toBeGreaterThan(0);
     expect(wireIdx).toBeGreaterThan(popIdx);
   });

--- a/tests/submitMarkdownSpike.test.js
+++ b/tests/submitMarkdownSpike.test.js
@@ -1,0 +1,95 @@
+/**
+ * Source-shape tests for the ?md=1 markdown-editor spike on submit.html
+ * (#153 follow-up). Behavioral coverage would need jsdom + the markdown-it
+ * CDN bundle; pin the wiring instead so a regression on the flag path or
+ * on the raw-notes-payload contract fails loudly.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT        = path.join(__dirname, '..');
+const SUBMIT_MAIN = fs.readFileSync(path.join(ROOT, 'js', 'submit', 'main.js'), 'utf8');
+const SUBMIT_HTML = fs.readFileSync(path.join(ROOT, 'submit.html'), 'utf8');
+const GAME_CSS    = fs.readFileSync(path.join(ROOT, 'css', 'app', 'game-header.css'), 'utf8');
+
+describe('markdown editor spike (#153)', () => {
+  test('submit.html loads markdown-it via CDN', () => {
+    // Pin the specific version so a future upgrade is a conscious edit
+    // rather than a silent bump.
+    expect(SUBMIT_HTML).toContain('markdown-it@14.1.0/dist/markdown-it.min.js');
+  });
+
+  test('enhancer wires only when ?md=1 AND window.markdownit is present', () => {
+    expect(SUBMIT_MAIN).toContain("params.get('md') === '1'");
+    expect(SUBMIT_MAIN).toContain("typeof window.markdownit === 'function'");
+    expect(SUBMIT_MAIN).toContain('enhanceNotesWithMarkdown(el)');
+  });
+
+  test('enhancer runs after populateSubmitForm so the textarea exists', () => {
+    const popIdx = SUBMIT_MAIN.indexOf('await populateSubmitForm(el)');
+    const wireIdx = SUBMIT_MAIN.indexOf("params.get('md') === '1'");
+    expect(popIdx).toBeGreaterThan(0);
+    expect(wireIdx).toBeGreaterThan(popIdx);
+  });
+
+  test('enhanceNotesWithMarkdown targets the Notes textarea by name', () => {
+    expect(SUBMIT_MAIN).toContain(`rootEl.querySelector('textarea[name="notes"]')`);
+  });
+
+  test('enhancer keeps the textarea in the DOM (raw markdown is the submit payload)', () => {
+    // The textarea must not be replaced; submitReport reads form.notes.value
+    // so the raw markdown flows into user_configs.notes unchanged.
+    const fn = SUBMIT_MAIN.slice(
+      SUBMIT_MAIN.indexOf('function enhanceNotesWithMarkdown'),
+    );
+    expect(fn).toContain('wrapper.appendChild(textarea)');
+    expect(fn).not.toContain('textarea.remove()');
+    expect(fn).not.toContain('textarea.replaceWith');
+  });
+
+  test('markdown-it configured with html:false so raw HTML never renders', () => {
+    // The Notes payload is untrusted user input rendered inline on report
+    // cards; disabling raw HTML in the parser removes the primary XSS
+    // surface. linkify + breaks match GitHub-style behaviour.
+    expect(SUBMIT_MAIN).toContain('html: false');
+    expect(SUBMIT_MAIN).toContain('linkify: true');
+    expect(SUBMIT_MAIN).toContain('breaks: true');
+  });
+
+  test('enhancer is idempotent via data-mdEnhanced marker', () => {
+    expect(SUBMIT_MAIN).toContain("textarea.dataset.mdEnhanced === '1'");
+    expect(SUBMIT_MAIN).toContain("textarea.dataset.mdEnhanced = '1'");
+  });
+
+  test('Write and Preview tabs are wired with aria-selected', () => {
+    const fn = SUBMIT_MAIN.slice(
+      SUBMIT_MAIN.indexOf('function enhanceNotesWithMarkdown'),
+    );
+    expect(fn).toContain('data-md-tab="write"');
+    expect(fn).toContain('data-md-tab="preview"');
+    expect(fn).toContain(`aria-selected="true"`);
+    expect(fn).toContain('setAttribute(\'aria-selected\'');
+  });
+
+  test('empty notes preview shows a placeholder instead of a blank div', () => {
+    expect(SUBMIT_MAIN).toContain('md-editor-empty');
+    expect(SUBMIT_MAIN).toMatch(/Nothing to preview yet/);
+  });
+});
+
+describe('markdown editor CSS shape', () => {
+  test('base .md-editor and tab classes exist', () => {
+    expect(GAME_CSS).toContain('.md-editor {');
+    expect(GAME_CSS).toContain('.md-editor-tabs {');
+    expect(GAME_CSS).toContain('.md-editor-tab {');
+    expect(GAME_CSS).toContain('.md-editor-tab--active {');
+    expect(GAME_CSS).toContain('.md-editor-preview {');
+  });
+
+  test('preview surface renders headings / code / blockquote with expected styling anchors', () => {
+    expect(GAME_CSS).toMatch(/\.md-editor-preview h1[\s\S]{0,200}line-height/);
+    expect(GAME_CSS).toContain('.md-editor-preview code');
+    expect(GAME_CSS).toContain('.md-editor-preview blockquote');
+  });
+});

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -39,6 +39,7 @@ const {
   truncate,
   esc,
   escWithSpoilers,
+  renderNotes,
   cfgNa,
   configKey,
   hashReportKey,
@@ -586,6 +587,64 @@ describe('downloadJson', () => {
     expect(clicked[0]._download).toBe('My_Report___2026.json');
     expect(clicked[0]._href).toBe('blob:fake');
     expect(revoked).toEqual(['blob:fake']);
+  });
+});
+
+describe('renderNotes (#153)', () => {
+  test('empty / falsy input returns empty string', () => {
+    expect(renderNotes('')).toBe('');
+    expect(renderNotes(null)).toBe('');
+    expect(renderNotes(undefined)).toBe('');
+  });
+
+  test('falls back to escWithSpoilers when window.markdownit is missing', () => {
+    // No global.markdownit in test env by default -- so renderNotes
+    // should degrade to the plain-text + spoiler pipeline.
+    const out = renderNotes('hi {spoiler}secret{/spoiler} there');
+    expect(out).toContain('class="spoiler"');
+    expect(out).toContain('<span class="spoiler-content">secret</span>');
+    // No markdown-emitted <p> because we're on the fallback path.
+    expect(out).not.toContain('<p>');
+  });
+
+  test('escapes HTML in fallback path (XSS-safe)', () => {
+    const out = renderNotes('<img src=x onerror=alert(1)>');
+    expect(out).not.toMatch(/<img\b/);
+    expect(out).toContain('&lt;img');
+  });
+
+  test('with a stub markdown-it: renders paragraphs + swaps spoiler tokens', () => {
+    // Install a minimal fake md renderer to exercise the markdown branch.
+    // It escapes < and > and wraps the text in <p>, mirroring the shape
+    // real markdown-it produces for a single-paragraph input. html:false
+    // in the config means the render call is the only source of HTML.
+    global.window = global.window || global;
+    global.window.markdownit = () => ({
+      render: (t) => `<p>${t.replace(/</g, '&lt;').replace(/>/g, '&gt;')}</p>\n`,
+    });
+    jest.resetModules();
+    const fresh = require('../js/app/utils.js');
+    const out = fresh.renderNotes('hello {spoiler}surprise{/spoiler} world');
+    expect(out).toContain('<p>');
+    expect(out).toContain('class="spoiler"');
+    expect(out).toContain('<span class="spoiler-content">surprise</span>');
+    // Cleanup so downstream describe blocks stay on the fallback path.
+    delete global.window.markdownit;
+  });
+
+  test('markdown branch keeps spoiler inner content safe (already-escaped)', () => {
+    global.window = global.window || global;
+    global.window.markdownit = () => ({
+      render: (t) => `<p>${t.replace(/</g, '&lt;').replace(/>/g, '&gt;')}</p>\n`,
+    });
+    jest.resetModules();
+    const fresh = require('../js/app/utils.js');
+    const out = fresh.renderNotes('{spoiler}<img src=x>{/spoiler}');
+    // markdown-it already escaped the < and > before renderNotes did
+    // the spoiler replace, so no raw <img> leaks.
+    expect(out).not.toMatch(/<img\b/);
+    expect(out).toContain('&lt;img');
+    delete global.window.markdownit;
   });
 });
 


### PR DESCRIPTION
Adds markdown support to the Notes field end to end.

- submit.html: Notes textarea auto-wraps in a Write / Preview tab pair. Preview renders via markdown-it (html:false, linkify, breaks). The textarea keeps its name so submitReport still writes raw markdown to user_configs.notes.
- app.html: report cards render Notes through the same markdown-it pipeline, with the existing {spoiler}...{/spoiler} tokens post-processed into the spoiler spans we already ship. Falls back to the plain-text + spoiler renderer if markdown-it fails to load.
- css/app/reports.css: .notes-full picks up styling for headings, paragraphs, lists, code blocks, blockquotes, links.

Rolled out site-wide -- no feature flag. First commit landed the editor behind ?md=1; second commit removed the flag and added the reader-side render so preview matches display.

Known limitation: {spoiler} tokens inside fenced code blocks are still substituted (string replace runs on the rendered HTML). A proper markdown-it plugin would fix that; string approach is fine for now.

Verified on staging: https://mdeguzis.github.io/proton-pulse-web-staging/ shows v1.5.0 - 3343112 on the about page.