### PR TITLE
Grid orphan trim + 4-row page size + adult-content hide-by-default

### DIFF
--- a/app.html
+++ b/app.html
@@ -17,7 +17,7 @@
 <link rel="stylesheet" href="css/shared/site.css?v=e05a0f73">
 <link rel="stylesheet" href="css/shared/filters.css?v=26d5b7e1">
 <link rel="stylesheet" href="css/shared/cards.css?v=16c748ed">
-<link rel="stylesheet" href="css/app/game-header.css?v=b8e80a64">
+<link rel="stylesheet" href="css/app/game-header.css?v=594fa872">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=9ac38baa">
 <link rel="stylesheet" href="css/app/modals.css?v=99a2a3d5">

--- a/confidence.html
+++ b/confidence.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=2d6b5e52">
 <link rel="stylesheet" href="css/shared/site.css?v=e05a0f73">
 <link rel="stylesheet" href="css/shared/cards.css?v=16c748ed">
-<link rel="stylesheet" href="css/app/game-header.css?v=b8e80a64">
+<link rel="stylesheet" href="css/app/game-header.css?v=594fa872">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=9ac38baa">
 <link rel="stylesheet" href="css/app/modals.css?v=99a2a3d5">

--- a/css/app/game-header.css
+++ b/css/app/game-header.css
@@ -110,6 +110,19 @@
   color: var(--muted);
 }
 
+/* Hidden-count strip sits directly beneath .search-summary; muted so it
+   reads as an informational aside rather than a search result. */
+.search-adult-note {
+  margin: -12px 0 18px;
+  padding: 8px 14px;
+  background: var(--s1);
+  border: 1px solid var(--border);
+  border-top: none;
+  font-size: 0.78rem;
+  color: var(--muted);
+}
+.search-adult-note a { color: var(--accent, #5c8bd6); }
+
 .search-groups {
   display: flex;
   flex-direction: column;

--- a/game-stats.html
+++ b/game-stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=2d6b5e52">
 <link rel="stylesheet" href="css/shared/site.css?v=e05a0f73">
 <link rel="stylesheet" href="css/shared/cards.css?v=16c748ed">
-<link rel="stylesheet" href="css/app/game-header.css?v=b8e80a64">
+<link rel="stylesheet" href="css/app/game-header.css?v=594fa872">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=9ac38baa">
 <link rel="stylesheet" href="css/app/modals.css?v=99a2a3d5">

--- a/gh-pages-manifest.txt
+++ b/gh-pages-manifest.txt
@@ -104,6 +104,7 @@ js/lib/topbar.js
 js/lib/toast.js
 js/lib/data-url.js
 js/lib/tile-pad.js
+js/lib/adult-filter.js
 js/lib/gh-gist.js
 js/lib/gh-auth.js
 js/lib/scoring/gameStats.js

--- a/index.html
+++ b/index.html
@@ -219,6 +219,6 @@
 <script src="js/lib/analytics.js?v=e6dfbad8"></script>
 <script src="js/lib/topbar.js?v=449040e3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/index/main.js?v=2ca49290"></script>
+<script type="module" src="js/index/main.js?v=691a8097"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -219,6 +219,6 @@
 <script src="js/lib/analytics.js?v=e6dfbad8"></script>
 <script src="js/lib/topbar.js?v=449040e3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/index/main.js?v=bd2bc884"></script>
+<script type="module" src="js/index/main.js?v=4d53eb73"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -219,6 +219,6 @@
 <script src="js/lib/analytics.js?v=e6dfbad8"></script>
 <script src="js/lib/topbar.js?v=449040e3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/index/main.js?v=4d53eb73"></script>
+<script type="module" src="js/index/main.js?v=2ca49290"></script>
 </body>
 </html>

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -11,7 +11,8 @@ import { enhanceAuthorBlocks } from './author.js?v=2316d334';
 import { renderConfigCard } from './config-cards.js?v=c67740f8';
 import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=48037483';
 import { renderCard } from './report-card.js?v=eae7957c';
-import { loadSearchIndex, searchIndex } from './search.js?v=f7b2fe47';
+import { loadSearchIndex, searchIndex } from './search.js?v=ff82d0c0';
+import { showAdultAllowed, isAdultEntry } from '../../lib/adult-filter.js?v=e4e9d845';
 import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, dataFilesHref, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=e7fe3ce0';
 import { confColor, confTextColor, configKey, daysAgo, downloadJson, esc, fmtMinutes, reportKey } from '../utils.js?v=c7e1268c';
@@ -143,6 +144,42 @@ export async function renderGamePage(appId) {
   window._ppMyUserId = '';
   if (window.SupaAuth) {
     try { const s = await window.SupaAuth.getSession(); window._ppMyUserId = s?.user?.id || ''; } catch {}
+  }
+
+  // Adult-content gate: if the search-index flags this appId as adult
+  // and the "Show adult games" preference is off, render a block page
+  // instead of loading reports. The block page offers a one-click
+  // reveal that turns the pref on and reloads.
+  if (!showAdultAllowed()) {
+    await loadSearchIndex();
+    const entry = (searchIndex || []).find(row => String(row[0]) === String(appId));
+    if (entry && isAdultEntry(entry)) {
+      const title = String(entry[1] || `App ${appId}`).replace(/[<>&"]/g, c => ({'<':'&lt;','>':'&gt;','&':'&amp;','"':'&quot;'}[c]));
+      el.innerHTML = `
+        <div class="state-box" style="max-width:520px;margin:40px auto;text-align:center">
+          <h2 style="margin-top:0">${title} is hidden</h2>
+          <p style="color:var(--muted)">
+            Steam has flagged this title as containing adult content. It is
+            hidden by your "Show adult games" preference.
+          </p>
+          <p style="color:var(--muted)">
+            You can turn this preference on to view the game. The setting is
+            saved locally in this browser.
+          </p>
+          <div style="margin-top:16px;display:flex;gap:8px;justify-content:center;flex-wrap:wrap">
+            <button type="button" id="adult-reveal-btn" class="btn btn-primary">Show adult games and view</button>
+            <a href="index.html" class="btn">Back to home</a>
+          </div>
+        </div>`;
+      const revealBtn = document.getElementById('adult-reveal-btn');
+      if (revealBtn) {
+        revealBtn.addEventListener('click', () => {
+          try { localStorage.setItem('pp:show-adult', 'on'); } catch {}
+          location.reload();
+        });
+      }
+      return;
+    }
   }
 
   // Promise.all was hanging silently on Wukong (appId 2358720) when one of

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -7,6 +7,7 @@ import { daysAgo, latestPerApp } from '../utils.js?v=c7e1268c';
 import { renderGameCard } from '../lib/card.js?v=754da47b';
 import { dataUrl } from '../../lib/data-url.js?v=3c2e7ac9';
 import { padTileRows, watchTileRerender, pageSizeForFullRows } from '../../lib/tile-pad.js?v=de862970';
+import { filterAdult } from '../../lib/adult-filter.js?v=7630e414';
 
 const LOAD_COUNT_KEY = 'pp:load-count';
 const LOAD_COUNTS = [50, 100, 150, 200];
@@ -338,7 +339,7 @@ export async function renderHomePage() {
           return { ...g, tier: KNOWN_TIERS.has(t) ? t : 'pending' };
         });
       }
-      const filtered = _filterByText(_filterByStore(_filterByType(_filterByTier(asReports, tierSel), sourceSel), storeSel), textFilter);
+      const filtered = filterAdult(_filterByText(_filterByStore(_filterByType(_filterByTier(asReports, tierSel), sourceSel), storeSel), textFilter));
       const cardsEl = document.getElementById('cards-popular');
       const loadMoreEl = document.getElementById('load-more-popular');
       if (!cardsEl) return;
@@ -394,7 +395,7 @@ export async function renderHomePage() {
     }
 
     function applyRecentFilters() {
-      const filtered = _filterByText(_filterByStore(_filterByType(_filterByTier(_sortReports(allRecentReports, currentSort), tierSel), sourceSel), storeSel), textFilter);
+      const filtered = filterAdult(_filterByText(_filterByStore(_filterByType(_filterByTier(_sortReports(allRecentReports, currentSort), tierSel), sourceSel), storeSel), textFilter));
       const sectionEl = document.getElementById('recent-section');
       const cardsEl = document.getElementById('cards-recent');
       const loadMoreEl = document.getElementById('load-more-recent');

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -6,7 +6,7 @@ import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '.
 import { daysAgo, latestPerApp } from '../utils.js?v=c7e1268c';
 import { renderGameCard } from '../lib/card.js?v=754da47b';
 import { dataUrl } from '../../lib/data-url.js?v=3c2e7ac9';
-import { padTileRows, watchTileRows } from '../../lib/tile-pad.js?v=defd5c6b';
+import { padTileRows, watchTileRerender } from '../../lib/tile-pad.js?v=a9b4e85c';
 
 const LOAD_COUNT_KEY = 'pp:load-count';
 const LOAD_COUNTS = [50, 100, 150, 200];
@@ -337,26 +337,35 @@ export async function renderHomePage() {
       const cardsEl = document.getElementById('cards-popular');
       const loadMoreEl = document.getElementById('load-more-popular');
       if (!cardsEl) return;
-      const initial = filtered.slice(0, PAGE_SIZE);
-      const queue = filtered.slice(PAGE_SIZE);
-      cardsEl.innerHTML = initial.map(_popularItemHtml).join('')
-        || '<div class="state-box">No games match the current filters.</div>';
-      _updateShownCount('popular-count', cardsEl, initial.length ? filtered.length : 0);
-      if (loadMoreEl) {
-        if (queue.length) {
-          loadMoreEl.innerHTML = _loadMoreBtn('popular');
-          loadMoreEl.querySelector('button').addEventListener('click', () => {
-            const batch = queue.splice(0, PAGE_SIZE);
-            cardsEl.insertAdjacentHTML('beforeend', batch.map(_popularItemHtml).join(''));
-            _updateShownCount('popular-count', cardsEl, filtered.length);
-            padTileRows(cardsEl, { tileSelector: '.game-card' });
-            if (!queue.length) loadMoreEl.innerHTML = '';
-          });
-        } else {
-          loadMoreEl.innerHTML = initial.length ? _allShownNote(filtered.length) : '';
-        }
+      if (!filtered.length) {
+        cardsEl.innerHTML = '<div class="state-box">No games match the current filters.</div>';
+        _updateShownCount('popular-count', cardsEl, 0);
+        if (loadMoreEl) loadMoreEl.innerHTML = '';
+        return;
       }
-      padTileRows(cardsEl, { tileSelector: '.game-card' });
+      let popularShown = PAGE_SIZE;
+      const renderPopular = () => {
+        const shown = Math.min(popularShown, filtered.length);
+        cardsEl.innerHTML = filtered.slice(0, shown).map(_popularItemHtml).join('');
+        // hasMore=true trims trailing orphans so the last row stays flush; the
+        // trimmed tiles come back via the Load more click below.
+        padTileRows(cardsEl, { tileSelector: '.game-card', hasMore: filtered.length > shown });
+        const rendered = cardsEl.querySelectorAll(':scope .game-card:not(.tile-filler)').length;
+        _updateShownCount('popular-count', cardsEl, filtered.length);
+        if (loadMoreEl) {
+          if (filtered.length > rendered) {
+            loadMoreEl.innerHTML = _loadMoreBtn('popular');
+            loadMoreEl.querySelector('button').addEventListener('click', () => {
+              popularShown = rendered + PAGE_SIZE;
+              renderPopular();
+            });
+          } else {
+            loadMoreEl.innerHTML = _allShownNote(filtered.length);
+          }
+        }
+      };
+      renderPopular();
+      watchTileRerender(cardsEl, renderPopular);
     }
 
     // Render a popular game as a card. Both layouts use the same markup;
@@ -384,30 +393,32 @@ export async function renderHomePage() {
       const sectionEl = document.getElementById('recent-section');
       const cardsEl = document.getElementById('cards-recent');
       const loadMoreEl = document.getElementById('load-more-recent');
-      const renderFn = _recentCardHtml;
-      const queue = filtered.slice(PAGE_SIZE);
-      const initial = filtered.slice(0, PAGE_SIZE);
       // Hide the whole recent section when empty so there's no blank state box.
       if (sectionEl) sectionEl.hidden = !filtered.length;
       if (!filtered.length) { if (cardsEl) cardsEl.innerHTML = ''; _updateShownCount('recent-count', cardsEl, 0); return; }
-      cardsEl.innerHTML = initial.map(renderFn).join('');
-      _updateShownCount('recent-count', cardsEl, filtered.length);
-      if (loadMoreEl) {
-        if (queue.length) {
-          loadMoreEl.innerHTML = _loadMoreBtn('recent');
-          // Append with the same renderFn so load-more keeps the current view.
-          loadMoreEl.querySelector('button').addEventListener('click', () => {
-            const batch = queue.splice(0, PAGE_SIZE);
-            cardsEl.insertAdjacentHTML('beforeend', batch.map(renderFn).join(''));
-            _updateShownCount('recent-count', cardsEl, filtered.length);
-            padTileRows(cardsEl, { tileSelector: '.game-card' });
-            if (!queue.length) loadMoreEl.innerHTML = '';
-          });
-        } else {
-          loadMoreEl.innerHTML = filtered.length ? _allShownNote(filtered.length) : '';
+      let recentShown = PAGE_SIZE;
+      const renderRecent = () => {
+        const shown = Math.min(recentShown, filtered.length);
+        cardsEl.innerHTML = filtered.slice(0, shown).map(_recentCardHtml).join('');
+        // hasMore=true trims trailing orphans so the last row stays flush; the
+        // trimmed tiles come back via the Load more click below.
+        padTileRows(cardsEl, { tileSelector: '.game-card', hasMore: filtered.length > shown });
+        const rendered = cardsEl.querySelectorAll(':scope .game-card:not(.tile-filler)').length;
+        _updateShownCount('recent-count', cardsEl, filtered.length);
+        if (loadMoreEl) {
+          if (filtered.length > rendered) {
+            loadMoreEl.innerHTML = _loadMoreBtn('recent');
+            loadMoreEl.querySelector('button').addEventListener('click', () => {
+              recentShown = rendered + PAGE_SIZE;
+              renderRecent();
+            });
+          } else {
+            loadMoreEl.innerHTML = _allShownNote(filtered.length);
+          }
         }
-      }
-      padTileRows(cardsEl, { tileSelector: '.game-card' });
+      };
+      renderRecent();
+      watchTileRerender(cardsEl, renderRecent);
     }
 
     document.getElementById('home-sort-select')?.addEventListener('change', e => {
@@ -574,11 +585,9 @@ export async function renderHomePage() {
       // S/M/L/XL stay enabled in both modes -- in tile mode the size
       // controls the column width, in list mode it controls row height.
       _setSizeEnabled(true);
-      // Pad the trailing row of each tile grid with invisible fillers so
-      // an incomplete last row doesn't read as a ragged edge, and keep
-      // it padded as the viewport resizes.
-      if (recentEl) watchTileRows(recentEl, { tileSelector: '.game-card' });
-      if (popularEl) watchTileRows(popularEl, { tileSelector: '.game-card' });
+      // Resize re-render is wired inside applyRecent/PopularFilters via
+      // watchTileRerender -- nothing to hook here beyond triggering the
+      // caller's applyRecent/PopularFilters which runs on layout change.
     }
     document.querySelectorAll('.home-layout-btn').forEach(btn => {
       btn.addEventListener('click', () => {

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -6,7 +6,7 @@ import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '.
 import { daysAgo, latestPerApp } from '../utils.js?v=c7e1268c';
 import { renderGameCard } from '../lib/card.js?v=754da47b';
 import { dataUrl } from '../../lib/data-url.js?v=3c2e7ac9';
-import { padTileRows, watchTileRerender } from '../../lib/tile-pad.js?v=a9b4e85c';
+import { padTileRows, watchTileRerender, pageSizeForFullRows } from '../../lib/tile-pad.js?v=de862970';
 
 const LOAD_COUNT_KEY = 'pp:load-count';
 const LOAD_COUNTS = [50, 100, 150, 200];
@@ -160,8 +160,13 @@ function _recentCardHtml(r) {
 export async function renderHomePage() {
   const el = document.getElementById('content');
   el.innerHTML = '<div class="state-box">Loading recent reports...</div>';
-  const PAGE_SIZE = _loadCount(); // user-set preload count (50/100/150/200)
-  console.debug('[browse] preload count', { count: PAGE_SIZE, source: LOAD_COUNT_KEY });
+  // Initial load + each Load more click aim for roughly TARGET_ROWS full
+  // rows of the current grid. Column count is measured off the container
+  // via pageSizeForFullRows. See lib/tile-pad.js. The old fixed preload
+  // count setting (LOAD_COUNTS) is retained in localStorage for backwards
+  // compat but no longer drives paging.
+  const TARGET_ROWS = 4;
+  console.debug('[browse] preload target rows', { rows: TARGET_ROWS });
   try {
     const [recentUrl, mostPlayedUrl] = await Promise.all([
       dataUrl('recent-reports.json'),
@@ -343,7 +348,7 @@ export async function renderHomePage() {
         if (loadMoreEl) loadMoreEl.innerHTML = '';
         return;
       }
-      let popularShown = PAGE_SIZE;
+      let popularShown = pageSizeForFullRows(cardsEl, TARGET_ROWS);
       const renderPopular = () => {
         const shown = Math.min(popularShown, filtered.length);
         cardsEl.innerHTML = filtered.slice(0, shown).map(_popularItemHtml).join('');
@@ -356,7 +361,7 @@ export async function renderHomePage() {
           if (filtered.length > rendered) {
             loadMoreEl.innerHTML = _loadMoreBtn('popular');
             loadMoreEl.querySelector('button').addEventListener('click', () => {
-              popularShown = rendered + PAGE_SIZE;
+              popularShown = rendered + pageSizeForFullRows(cardsEl, TARGET_ROWS);
               renderPopular();
             });
           } else {
@@ -396,7 +401,7 @@ export async function renderHomePage() {
       // Hide the whole recent section when empty so there's no blank state box.
       if (sectionEl) sectionEl.hidden = !filtered.length;
       if (!filtered.length) { if (cardsEl) cardsEl.innerHTML = ''; _updateShownCount('recent-count', cardsEl, 0); return; }
-      let recentShown = PAGE_SIZE;
+      let recentShown = pageSizeForFullRows(cardsEl, TARGET_ROWS);
       const renderRecent = () => {
         const shown = Math.min(recentShown, filtered.length);
         cardsEl.innerHTML = filtered.slice(0, shown).map(_recentCardHtml).join('');
@@ -409,7 +414,7 @@ export async function renderHomePage() {
           if (filtered.length > rendered) {
             loadMoreEl.innerHTML = _loadMoreBtn('recent');
             loadMoreEl.querySelector('button').addEventListener('click', () => {
-              recentShown = rendered + PAGE_SIZE;
+              recentShown = rendered + pageSizeForFullRows(cardsEl, TARGET_ROWS);
               renderRecent();
             });
           } else {

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -1,13 +1,13 @@
 // home (components) for the app page. Relocated from app.js.
 
 import { fetchRecentPulseReports } from '../api/reports.js?v=003f23c0';
-import { loadSearchIndex, searchIndex } from './search.js?v=f7b2fe47';
+import { loadSearchIndex, searchIndex } from './search.js?v=ff82d0c0';
 import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '../config.js?v=df5b5024';
 import { daysAgo, latestPerApp } from '../utils.js?v=c7e1268c';
 import { renderGameCard } from '../lib/card.js?v=754da47b';
 import { dataUrl } from '../../lib/data-url.js?v=3c2e7ac9';
 import { padTileRows, watchTileRerender, pageSizeForFullRows } from '../../lib/tile-pad.js?v=de862970';
-import { filterAdult } from '../../lib/adult-filter.js?v=7630e414';
+import { filterAdult } from '../../lib/adult-filter.js?v=e4e9d845';
 
 const LOAD_COUNT_KEY = 'pp:load-count';
 const LOAD_COUNTS = [50, 100, 150, 200];

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,11 +2,12 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=0dae1257';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=003f23c0';
-import { renderGamePage } from './game-page.js?v=d79ce4b8';
+import { renderGamePage } from './game-page.js?v=8934c3f7';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId } from '../config.js?v=df5b5024';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=c7e1268c';
 import { renderGameCard } from '../lib/card.js?v=754da47b';
 import { dataUrl } from '../../lib/data-url.js?v=3c2e7ac9';
+import { filterAdultEntries, isAdultEntry } from '../../lib/adult-filter.js?v=e4e9d845';
 
 // Search index + results UX -- factored out of app.js.
 // Loaded as a classic script BEFORE app.js so its globals
@@ -34,7 +35,10 @@ function _matchEntries(entries, query, limit) {
 // --- searchIndexMatches ---
 export function searchIndexMatches(query, limit) {
   const q = query.trim();
-  return _matchEntries(searchIndex, q, limit);
+  // Drop adult-flagged rows unless the user's "Show adult games" pref is on.
+  // filterAdultEntries is a no-op for rows without the adult column so
+  // pre-pipeline-run indices stay visible.
+  return filterAdultEntries(_matchEntries(searchIndex, q, limit));
 }
 
 // --- searchExtendedSteamMatches ---
@@ -42,7 +46,7 @@ export function searchIndexMatches(query, limit) {
 // loadExtendedSteamIndex() first when you want the long-tail Steam catalog.
 export function searchExtendedSteamMatches(query, limit) {
   const q = query.trim();
-  return _matchEntries(extendedSteamIndex, q, limit);
+  return filterAdultEntries(_matchEntries(extendedSteamIndex, q, limit));
 }
 
 // --- renderPulseSearchResult ---
@@ -89,16 +93,21 @@ export async function renderSearchPage(query) {
   // and only loads on this deliberate Enter-to-search path.
   await Promise.all([loadSearchIndex(), loadExtendedSteamIndex()]);
   const pulseResults = await withTimeout(fetchMatchingPulseConfigs(q), 2500, []);
-  const primaryResults = searchIndexMatches(q, 24);
-  // Pad the merged list up to a soft cap of 48 with extended Steam stubs,
-  // skipping any appId already covered by the primary index.
+  // Count adult-hidden hits so the summary line can call them out. Runs
+  // the raw match once to get the unfiltered set, then applies the
+  // filter for display. showAdultAllowed()=true means nothing is hidden.
+  const primaryRaw = _matchEntries(searchIndex, q, 24);
+  const primaryResults = filterAdultEntries(primaryRaw);
   const primaryIds = new Set(primaryResults.map(([id]) => String(id)));
   const extendedRoom = Math.max(0, 48 - primaryResults.length);
-  const extendedResults = extendedRoom
-    ? searchExtendedSteamMatches(q, extendedRoom + primaryIds.size)
+  const extendedRaw = extendedRoom
+    ? _matchEntries(extendedSteamIndex, q, extendedRoom + primaryIds.size)
         .filter(([id]) => !primaryIds.has(String(id)))
         .slice(0, extendedRoom)
     : [];
+  const extendedResults = filterAdultEntries(extendedRaw);
+  const hiddenAdultCount = (primaryRaw.length - primaryResults.length)
+                         + (extendedRaw.length - extendedResults.length);
   const indexResults = [...primaryResults, ...extendedResults];
   // Disambiguate same-name games (e.g. Prey 2006 vs Prey 2017) with a "(YEAR)"
   // suffix when the pipeline supplied a releaseYear (column 7 of search-index).
@@ -109,10 +118,14 @@ export async function renderSearchPage(query) {
     : new Map();
   const total = pulseResults.length + indexResults.length;
 
+  const adultNote = hiddenAdultCount > 0
+    ? `<div class="search-adult-note">${hiddenAdultCount} adult result${hiddenAdultCount === 1 ? '' : 's'} hidden by your <a href="options.html#opt-show-adult">Show adult games</a> preference.</div>`
+    : '';
   el.innerHTML = `
     <div class="search-summary">
       Search results for <strong>${esc(q)}</strong> - ${total} grouped hit${total === 1 ? '' : 's'}${pulseResults.length === 0 && indexResults.length > 0 ? ' - Proton Pulse config search may still be catching up' : ''}
     </div>
+    ${adultNote}
     <div class="search-groups">
       <section class="search-group">
         <div class="search-group-head">

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,7 +1,7 @@
 // Entry point for the app page: bootstraps routing and search wiring.
 // (Replaces the inline bootstrap that lived at the top/bottom of app.js.)
 import { route } from './router.js?v=d0ac896a';
-import { wireSearch } from './components/search.js?v=f7b2fe47';
+import { wireSearch } from './components/search.js?v=ff82d0c0';
 
 window.addEventListener('hashchange', () => route());
 window.addEventListener('popstate', () => route());

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,7 +1,7 @@
 // router (entry) for the app page. Relocated from app.js.
 
 import { renderGamePage } from './components/game-page.js?v=d79ce4b8';
-import { renderHomePage } from './components/home.js?v=2c5ae26a';
+import { renderHomePage } from './components/home.js?v=7675ca15';
 import { renderSearchPage } from './components/search.js?v=f7b2fe47';
 
 export function getRoute() {

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,7 +1,7 @@
 // router (entry) for the app page. Relocated from app.js.
 
 import { renderGamePage } from './components/game-page.js?v=d79ce4b8';
-import { renderHomePage } from './components/home.js?v=4a3d5cb1';
+import { renderHomePage } from './components/home.js?v=2c5ae26a';
 import { renderSearchPage } from './components/search.js?v=f7b2fe47';
 
 export function getRoute() {

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=d79ce4b8';
+import { renderGamePage } from './components/game-page.js?v=8934c3f7';
 import { renderHomePage } from './components/home.js?v=7675ca15';
-import { renderSearchPage } from './components/search.js?v=f7b2fe47';
+import { renderSearchPage } from './components/search.js?v=ff82d0c0';
 
 export function getRoute() {
   const h = location.hash.replace(/^#\/?/, '');

--- a/js/index/main.js
+++ b/js/index/main.js
@@ -2,6 +2,7 @@
 import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=e7fe3ce0';
 import { dataUrl } from '../lib/data-url.js?v=3c2e7ac9';
 import { padTileRows, watchTileRerender, pageSizeForFullRows } from '../lib/tile-pad.js?v=de862970';
+import { filterAdult } from '../lib/adult-filter.js?v=7630e414';
 
 // Homepage-only logic. Universal nav chrome (banner, nav row, mobile drawer,
 // search dropdown, auth indicator) lives in topbar.js.
@@ -252,7 +253,7 @@ import { padTileRows, watchTileRerender, pageSizeForFullRows } from '../lib/tile
       // from a title match in the Steam most-played map.
       const peakOf = g => g.peak || steamPeakByTitle.get(normTitle(g.title)) || 0;
       const countOf = g => (g.protondbCount || 0) + (g.pulseCount || 0);
-      return out.sort((a, b) =>
+      return filterAdult(out).sort((a, b) =>
         peakOf(b) - peakOf(a) || countOf(b) - countOf(a) || (a.title || '').localeCompare(b.title || ''));
     }
 

--- a/js/index/main.js
+++ b/js/index/main.js
@@ -1,7 +1,7 @@
 // Entry module for index.html (homepage). Migrated from index.js.
 import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=e7fe3ce0';
 import { dataUrl } from '../lib/data-url.js?v=3c2e7ac9';
-import { padTileRows, watchTileRows } from '../lib/tile-pad.js?v=defd5c6b';
+import { padTileRows, watchTileRerender } from '../lib/tile-pad.js?v=a9b4e85c';
 
 // Homepage-only logic. Universal nav chrome (banner, nav row, mobile drawer,
 // search dropdown, auth indicator) lives in topbar.js.
@@ -278,19 +278,24 @@ import { padTileRows, watchTileRows } from '../lib/tile-pad.js?v=defd5c6b';
         if (loadMoreEl) loadMoreEl.innerHTML = '';
         return;
       }
-      list.innerHTML = all.slice(0, shownCount).map(pgCardHtml).join('');
+      const shown = Math.min(shownCount, all.length);
+      list.innerHTML = all.slice(0, shown).map(pgCardHtml).join('');
+      const hasMore = all.length > shown;
+      // In tile mode: when more items are queued, trim any orphan tiles on
+      // the last row so the grid ends flush (the Load more button visually
+      // fills the gap). When fully shown, pad the last row with invisible
+      // fillers instead so the trailing tiles stay aligned.
+      padTileRows(list, { tileSelector: '.pg-card', hasMore });
       if (loadMoreEl) {
-        const remaining = all.length - shownCount;
+        // Recompute remaining after any orphan trim so the count is accurate.
+        const rendered = list.querySelectorAll(':scope .pg-card:not(.tile-filler)').length;
+        const remaining = all.length - rendered;
         loadMoreEl.innerHTML = remaining > 0
           ? `<button class="pg-load-more" id="pg-load-more-btn" type="button">Load more <span class="pg-load-more-count">${remaining}</span></button>`
           : '';
         const moreBtn = document.getElementById('pg-load-more-btn');
-        if (moreBtn) moreBtn.addEventListener('click', () => { shownCount += PAGE_SIZE; renderPopular(); });
+        if (moreBtn) moreBtn.addEventListener('click', () => { shownCount = rendered + PAGE_SIZE; renderPopular(); });
       }
-      // Top off the last grid row with invisible filler tiles in tile mode
-      // so the grid doesn't look ragged on the trailing edge. No-op in list
-      // mode (the helper bails when grid-template-columns isn't set).
-      padTileRows(list, { tileSelector: '.pg-card' });
     }
 
     // Rated / Not Rated are independent toggles (multi-select). Both on or both
@@ -422,9 +427,11 @@ import { padTileRows, watchTileRows } from '../lib/tile-pad.js?v=defd5c6b';
       // tile column width in grid mode.
       setSizeEnabled(true);
       renderPopular();
-      // Keep the last grid row full as the viewport resizes. watchTileRows
-      // is idempotent so calling it on every applyLayout is safe.
-      watchTileRows(list, { tileSelector: '.pg-card' });
+      // Column count changes with viewport width, so a resize invalidates
+      // the last-row clamp. watchTileRerender re-runs renderPopular on
+      // debounced resize; it's idempotent so re-wiring on every layout
+      // apply is safe.
+      watchTileRerender(list, renderPopular);
     }
     document.querySelectorAll('.pg-layout-btn').forEach(btn => {
       btn.addEventListener('click', () => {

--- a/js/index/main.js
+++ b/js/index/main.js
@@ -1,7 +1,7 @@
 // Entry module for index.html (homepage). Migrated from index.js.
 import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=e7fe3ce0';
 import { dataUrl } from '../lib/data-url.js?v=3c2e7ac9';
-import { padTileRows, watchTileRerender } from '../lib/tile-pad.js?v=a9b4e85c';
+import { padTileRows, watchTileRerender, pageSizeForFullRows } from '../lib/tile-pad.js?v=de862970';
 
 // Homepage-only logic. Universal nav chrome (banner, nav row, mobile drawer,
 // search dropdown, auth indicator) lives in topbar.js.
@@ -208,9 +208,12 @@ import { padTileRows, watchTileRerender } from '../lib/tile-pad.js?v=a9b4e85c';
     const unratedCountEl = document.getElementById('pg-unrated-count');
     const loadMoreEl = document.getElementById('pg-load-more');
 
-    const PAGE_SIZE = 12;
+    // Aim for roughly 4 full rows on the initial render and per Load
+    // more click. On desktop (5-6 cols) that's ~20-24 items; on mobile
+    // (2 cols) it drops to the 8-item floor. See pageSizeForFullRows.
+    const TARGET_ROWS = 4;
     const state = { rated: true, unrated: false };
-    let shownCount = PAGE_SIZE;
+    let shownCount = pageSizeForFullRows(list, TARGET_ROWS);
 
     // Build the game list for the selected stores + rating filter state. Store
     // is multi-select: Steam pulls from most_played.json, GOG/Epic pull from the
@@ -294,7 +297,7 @@ import { padTileRows, watchTileRerender } from '../lib/tile-pad.js?v=a9b4e85c';
           ? `<button class="pg-load-more" id="pg-load-more-btn" type="button">Load more <span class="pg-load-more-count">${remaining}</span></button>`
           : '';
         const moreBtn = document.getElementById('pg-load-more-btn');
-        if (moreBtn) moreBtn.addEventListener('click', () => { shownCount = rendered + PAGE_SIZE; renderPopular(); });
+        if (moreBtn) moreBtn.addEventListener('click', () => { shownCount = rendered + pageSizeForFullRows(list, TARGET_ROWS); renderPopular(); });
       }
     }
 
@@ -309,7 +312,7 @@ import { padTileRows, watchTileRerender } from '../lib/tile-pad.js?v=a9b4e85c';
     function toggleRating(key) {
       state[key] = !state[key];
       syncRatingButtons();
-      shownCount = PAGE_SIZE;
+      shownCount = pageSizeForFullRows(list, TARGET_ROWS);
       updateFilterBadge();
       renderPopular();
     }
@@ -380,7 +383,7 @@ import { padTileRows, watchTileRerender } from '../lib/tile-pad.js?v=a9b4e85c';
       }
       updateRatingCounts();
       updateFilterBadge();
-      shownCount = PAGE_SIZE;
+      shownCount = pageSizeForFullRows(list, TARGET_ROWS);
       renderPopular();
     }
     document.querySelectorAll('.pg-store-btn').forEach(btn => {

--- a/js/index/main.js
+++ b/js/index/main.js
@@ -2,7 +2,7 @@
 import { loadSteamImg as _loadSteamImg } from '../app/lib/steam-img.js?v=e7fe3ce0';
 import { dataUrl } from '../lib/data-url.js?v=3c2e7ac9';
 import { padTileRows, watchTileRerender, pageSizeForFullRows } from '../lib/tile-pad.js?v=de862970';
-import { filterAdult } from '../lib/adult-filter.js?v=7630e414';
+import { filterAdult } from '../lib/adult-filter.js?v=e4e9d845';
 
 // Homepage-only logic. Universal nav chrome (banner, nav row, mobile drawer,
 // search dropdown, auth indicator) lives in topbar.js.

--- a/js/lib/adult-filter.js
+++ b/js/lib/adult-filter.js
@@ -1,0 +1,28 @@
+// Adult-content visibility gate.
+//
+// The pipeline flags games as adult when Steam's appdetails endpoint
+// returns content-descriptor ids 1, 4, or 5 (nudity / sexual content /
+// adult-only sexual content). Every game row on Popular / Recent /
+// Search lists carries an optional `adult: true` field; when the pref
+// is off (default) those rows are hidden from browse views.
+//
+// The user opt-in lives on the site options page under "Show adult
+// games", written to localStorage as pp:show-adult=on|off.
+
+const KEY = 'pp:show-adult';
+
+export function showAdultAllowed() {
+  try {
+    return localStorage.getItem(KEY) === 'on';
+  } catch {
+    return false;
+  }
+}
+
+// Filter a list of game rows by the current pref. Rows without an
+// explicit adult=true flag pass through unchanged (backwards compat
+// with data files that predate the field).
+export function filterAdult(rows) {
+  if (showAdultAllowed()) return rows;
+  return rows.filter(r => !r || r.adult !== true);
+}

--- a/js/lib/adult-filter.js
+++ b/js/lib/adult-filter.js
@@ -26,3 +26,17 @@ export function filterAdult(rows) {
   if (showAdultAllowed()) return rows;
   return rows.filter(r => !r || r.adult !== true);
 }
+
+// search-index.json rows are arrays, not objects. The adult flag lives
+// at ADULT_COL_SEARCH_INDEX. Rows that don't yet have the column pass
+// through so pre-pipeline-run data stays visible.
+export const ADULT_COL_SEARCH_INDEX = 8;
+
+export function isAdultEntry(entry, col = ADULT_COL_SEARCH_INDEX) {
+  return Array.isArray(entry) && entry[col] === true;
+}
+
+export function filterAdultEntries(entries, col = ADULT_COL_SEARCH_INDEX) {
+  if (showAdultAllowed()) return entries;
+  return entries.filter(e => !isAdultEntry(e, col));
+}

--- a/js/lib/tile-pad.js
+++ b/js/lib/tile-pad.js
@@ -1,18 +1,26 @@
-// Pad a tile-mode grid container so the last row has the same number of
-// boxes as the rows above it. CSS grid normally leaves the trailing
-// columns of an incomplete row blank, which reads as a ragged edge in
-// the Steam-style tile view. We append invisible filler divs (with the
-// classes `<prefix>-card tile-filler`) so the trailing tiles still take
-// up the same grid cells without showing any content.
+// Pad a tile-mode grid container so the last row is never ragged.
 //
-// Call padTileRows(containerEl, { tileSelector, fillerClass }) after
-// every render of the tiles, and once after window resize. The helper
-// reads grid-template-columns off the live computed style so it
-// respects whatever auto-fill column count the browser actually picked.
+// Two modes depending on whether more items are queued behind the "Load
+// more" button:
+//
+// - hasMore=true: the last row is likely incomplete because the fixed
+//   page size doesn't divide evenly by the current column count. In that
+//   case we REMOVE the trailing orphan tiles so the grid ends on a full
+//   row and the Load more button visually takes the place of the missing
+//   tiles. The removed items come back on the next Load more click via
+//   a normal re-render.
+// - hasMore=false: everything the source has is already on screen, so
+//   the incomplete last row is real. We PAD it with invisible filler
+//   divs (`.tile-filler`) that occupy the trailing grid cells so the
+//   real tiles stay aligned with the columns above.
+//
+// Call padTileRows(containerEl, { tileSelector, fillerClass, hasMore })
+// after every render, and re-render on window resize (the column count
+// changes with viewport width, so a stale clamp needs recomputing).
 
 const _RESIZE_KEY = '__tilePadHandlers';
 
-export function padTileRows(container, { tileSelector = '> *', fillerClass = 'tile-filler' } = {}) {
+export function padTileRows(container, { tileSelector = '> *', fillerClass = 'tile-filler', hasMore = false } = {}) {
   if (!container) return;
   // Wipe stale fillers from the previous pad pass before counting.
   container.querySelectorAll('.' + fillerClass).forEach(f => f.remove());
@@ -28,6 +36,16 @@ export function padTileRows(container, { tileSelector = '> *', fillerClass = 'ti
   const items = container.querySelectorAll(':scope ' + tileSelector + ':not(.' + fillerClass + ')');
   const remainder = items.length % cols;
   if (remainder === 0) return;
+
+  if (hasMore) {
+    // Trim the incomplete last row -- the user can pull the missing tiles
+    // into view by clicking Load more, which re-renders with more items.
+    for (let i = 0; i < remainder; i++) {
+      const orphan = items[items.length - 1 - i];
+      if (orphan && orphan.parentNode === container) orphan.remove();
+    }
+    return;
+  }
 
   const need = cols - remainder;
   const frag = document.createDocumentFragment();
@@ -56,4 +74,24 @@ export function watchTileRows(container, opts) {
   container[_RESIZE_KEY] = handler;
   window.addEventListener('resize', handler, { passive: true });
   padTileRows(container, opts);
+}
+
+// Wire a container so it re-renders (via the caller's callback) on
+// window resize. Needed when padTileRows is used with hasMore=true:
+// trimming orphans is destructive, so a resize that changes the column
+// count means the trimmed tiles need to come back via a fresh render.
+// Idempotent -- a second call replaces the previous handler.
+const _RERENDER_KEY = '__tileRerenderHandler';
+export function watchTileRerender(container, callback) {
+  if (!container || typeof callback !== 'function') return;
+  if (container[_RERENDER_KEY]) {
+    window.removeEventListener('resize', container[_RERENDER_KEY]);
+  }
+  let pending = null;
+  const handler = () => {
+    if (pending) cancelAnimationFrame(pending);
+    pending = requestAnimationFrame(() => callback());
+  };
+  container[_RERENDER_KEY] = handler;
+  window.addEventListener('resize', handler, { passive: true });
 }

--- a/js/lib/tile-pad.js
+++ b/js/lib/tile-pad.js
@@ -20,6 +20,26 @@
 
 const _RESIZE_KEY = '__tilePadHandlers';
 
+// Returns the number of grid columns the container is currently showing,
+// or 1 if it isn't in grid mode (list layout / probe hasn't laid out yet).
+// Column count is derived from the resolved gridTemplateColumns tracks,
+// which reflect the auto-fill count for the container's actual width.
+export function currentColCount(container) {
+  if (!container) return 1;
+  const cs = getComputedStyle(container);
+  if (cs.display !== 'grid') return 1;
+  const cols = cs.gridTemplateColumns.split(' ').filter(Boolean).length;
+  return Math.max(1, cols);
+}
+
+// How many tiles the caller should render per "page" (initial + each Load
+// more click) so the visible grid always fills roughly N complete rows.
+// Enforces a floor so a viewport that only fits 1 column doesn't ship a
+// 4-item first page (too little content to be useful).
+export function pageSizeForFullRows(container, rows = 4, minItems = 8) {
+  return Math.max(minItems, currentColCount(container) * rows);
+}
+
 export function padTileRows(container, { tileSelector = '> *', fillerClass = 'tile-filler', hasMore = false } = {}) {
   if (!container) return;
   // Wipe stale fillers from the previous pad pass before counting.

--- a/js/options/main.js
+++ b/js/options/main.js
@@ -42,6 +42,19 @@ if (toggle) {
   });
 }
 
+// Adult games visibility. Off by default; when off, browse views hide
+// any row whose data.adult === true. Value is a simple on/off string so
+// missing/malformed keys default to off (the safer state).
+const SHOW_ADULT_KEY = 'pp:show-adult';
+const adultToggle = document.getElementById('opt-show-adult');
+if (adultToggle) {
+  adultToggle.checked = localStorage.getItem(SHOW_ADULT_KEY) === 'on';
+  adultToggle.addEventListener('change', () => {
+    localStorage.setItem(SHOW_ADULT_KEY, adultToggle.checked ? 'on' : 'off');
+    console.log('[options] show-adult:', adultToggle.checked);
+  });
+}
+
 // Store pill position. Values:
 //   'right'       - inline with the rating pill in the right column
 //   'art'         - overlaid on the thumbnail corner

--- a/options.html
+++ b/options.html
@@ -47,6 +47,46 @@
         </label>
         <div class="option-default-note">Default: on (off when your system requests reduced motion).</div>
       </div>
+
+      <div class="option-row option-row--block">
+        <div class="option-text">
+          <div class="option-title">Default layout</div>
+          <div class="option-desc">
+            How browse pages lay games out by default. "List" shows
+            horizontal cards stacked top to bottom. "Grid" shows a
+            Steam-style grid of header thumbnails. Each page also has a
+            List/Grid toggle that overrides this for the rest of the
+            session.
+          </div>
+        </div>
+        <div class="option-radio-group" id="opt-grid-layout">
+          <label class="option-radio">
+            <input type="radio" name="grid-layout" value="list">
+            <span>List</span>
+          </label>
+          <label class="option-radio">
+            <input type="radio" name="grid-layout" value="grid" checked>
+            <span>Grid (tiles) <span class="option-default-tag">(default)</span></span>
+          </label>
+        </div>
+      </div>
+
+      <div class="option-row">
+        <div class="option-text">
+          <div class="option-title">Show adult games</div>
+          <div class="option-desc">
+            Include titles flagged by Steam as containing sexual content
+            or nudity in Popular / Recent lists and search. Off by
+            default; toggle on if you want them visible in browse views.
+          </div>
+        </div>
+        <label class="option-switch">
+          <input type="checkbox" id="opt-show-adult">
+          <span class="option-switch-track"></span>
+        </label>
+        <div class="option-default-note">Default: off.</div>
+      </div>
+
       <div class="option-row option-row--block">
         <div class="option-text">
           <div class="option-title">Store badge position</div>
@@ -129,29 +169,6 @@
 
       <div class="option-row option-row--block">
         <div class="option-text">
-          <div class="option-title">Default layout</div>
-          <div class="option-desc">
-            How browse pages lay games out by default. "List" shows
-            horizontal cards stacked top to bottom. "Grid" shows a
-            Steam-style grid of header thumbnails. Each page also has a
-            List/Grid toggle that overrides this for the rest of the
-            session.
-          </div>
-        </div>
-        <div class="option-radio-group" id="opt-grid-layout">
-          <label class="option-radio">
-            <input type="radio" name="grid-layout" value="list">
-            <span>List</span>
-          </label>
-          <label class="option-radio">
-            <input type="radio" name="grid-layout" value="grid" checked>
-            <span>Grid (tiles) <span class="option-default-tag">(default)</span></span>
-          </label>
-        </div>
-      </div>
-
-      <div class="option-row option-row--block">
-        <div class="option-text">
           <div class="option-title">Reports per page</div>
           <div class="option-desc">
             How many game cards to preload in each section when browsing reports
@@ -203,6 +220,6 @@
 <script src="js/lib/analytics.js?v=e6dfbad8"></script>
 <script src="js/lib/topbar.js?v=449040e3"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/options/main.js?v=0b84807c"></script>
+<script type="module" src="js/options/main.js?v=428d8388"></script>
 </body>
 </html>

--- a/scripts/pipeline/common.py
+++ b/scripts/pipeline/common.py
@@ -11,9 +11,22 @@ DEBUG = False
 DEFAULT_STEAM_TITLE_CACHE_PATH = Path(__file__).resolve().parents[2] / ".cache" / "steam-title-cache.json"
 STEAM_TITLE_CACHE_MAX_AGE_SECONDS = 30 * 86400  # 30 days
 
+# Steam content descriptor cache -- keeps the { app_id -> descriptor_ids }
+# mapping so we don't re-hit appdetails on every pipeline run.
+DEFAULT_STEAM_DESCRIPTORS_CACHE_PATH = Path(__file__).resolve().parents[2] / ".cache" / "steam-content-descriptors-cache.json"
+STEAM_DESCRIPTORS_CACHE_MAX_AGE_SECONDS = 30 * 86400  # 30 days
+# Steam descriptor IDs that flag a game as adult-only for our purposes.
+# 1 = Some Nudity or Sexual Content
+# 4 = Adult Only Sexual Content
+# 5 = Frequent Nudity or Sexual Content
+ADULT_DESCRIPTOR_IDS = {1, 4, 5}
+
 # In-memory Steam title cache (loaded once per run)
 _steam_title_cache: dict[str, dict] | None = None
 _steam_title_cache_dirty = False
+# In-memory Steam content descriptor cache
+_steam_descriptors_cache: dict[str, dict] | None = None
+_steam_descriptors_cache_dirty = False
 LIVE_COUNTS_URL = "https://www.protondb.com/data/counts.json"
 LIVE_REPORTS_URL = "https://www.protondb.com/data/reports/{device}/app/{hash}.json"
 LIVE_REPORT_DEVICE = "all-devices"
@@ -169,6 +182,89 @@ def fetch_steam_title_with_source(app_id: str) -> tuple[str, str]:
         cache[app_id] = {"title": "", "source": "steam-store-error", "ts": now}
         _steam_title_cache_dirty = True
         return "", "steam-store-error"
+
+
+def _load_steam_descriptors_cache(
+    cache_path: Path = DEFAULT_STEAM_DESCRIPTORS_CACHE_PATH,
+) -> dict[str, dict]:
+    """Load the persistent Steam content-descriptor cache from disk."""
+    global _steam_descriptors_cache
+    if _steam_descriptors_cache is not None:
+        return _steam_descriptors_cache
+    if cache_path.exists():
+        try:
+            raw = json.loads(cache_path.read_text())
+            if isinstance(raw, dict):
+                _steam_descriptors_cache = raw
+                log(f"[steam-descriptors-cache] Loaded {len(raw):,} entries from {cache_path}")
+                return _steam_descriptors_cache
+        except (json.JSONDecodeError, OSError):
+            pass
+    _steam_descriptors_cache = {}
+    return _steam_descriptors_cache
+
+
+def _save_steam_descriptors_cache(
+    cache_path: Path = DEFAULT_STEAM_DESCRIPTORS_CACHE_PATH,
+) -> None:
+    global _steam_descriptors_cache_dirty
+    if not _steam_descriptors_cache_dirty or _steam_descriptors_cache is None:
+        return
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text(json.dumps(_steam_descriptors_cache))
+    _steam_descriptors_cache_dirty = False
+    log(f"[steam-descriptors-cache] Saved {len(_steam_descriptors_cache):,} entries to {cache_path}")
+
+
+def flush_steam_descriptors_cache(
+    cache_path: Path = DEFAULT_STEAM_DESCRIPTORS_CACHE_PATH,
+) -> None:
+    _save_steam_descriptors_cache(cache_path)
+
+
+def fetch_steam_content_descriptors(app_id: str) -> list[int]:
+    """Return Steam content-descriptor ids for an app, cached on disk.
+
+    Descriptor list comes from the same appdetails endpoint the title
+    fetcher uses. Empty list on miss / unsuccessful response so callers
+    can safely treat "no data" as "no flags". The result is cached for
+    STEAM_DESCRIPTORS_CACHE_MAX_AGE_SECONDS (30 days) so pipeline reruns
+    only pay the Steam API cost for new / expired entries.
+    """
+    global _steam_descriptors_cache_dirty
+    cache = _load_steam_descriptors_cache()
+    now = int(time.time())
+
+    cached = cache.get(app_id)
+    if cached and isinstance(cached, dict):
+        age = now - cached.get("ts", 0)
+        if age < STEAM_DESCRIPTORS_CACHE_MAX_AGE_SECONDS:
+            ids = cached.get("ids", [])
+            return list(ids) if isinstance(ids, list) else []
+
+    try:
+        data = fetch_json(STEAM_APP_DETAILS_URL.format(app_id=app_id))
+        app_data = (data or {}).get(str(app_id), {})
+        if app_data.get("success"):
+            descriptors = app_data.get("data", {}).get("content_descriptors", {}) or {}
+            raw_ids = descriptors.get("ids", []) or []
+            ids = [int(i) for i in raw_ids if isinstance(i, (int, float)) and not isinstance(i, bool)]
+            cache[app_id] = {"ids": ids, "ts": now}
+            _steam_descriptors_cache_dirty = True
+            return ids
+        cache[app_id] = {"ids": [], "ts": now}
+        _steam_descriptors_cache_dirty = True
+        return []
+    except Exception:
+        cache[app_id] = {"ids": [], "ts": now}
+        _steam_descriptors_cache_dirty = True
+        return []
+
+
+def is_adult_app(app_id: str) -> bool:
+    """True when Steam flags the app with any ADULT_DESCRIPTOR_IDS."""
+    ids = fetch_steam_content_descriptors(app_id)
+    return bool(set(ids) & ADULT_DESCRIPTOR_IDS)
 
 
 def normalize_whitespace(value):

--- a/scripts/pipeline/finalize.py
+++ b/scripts/pipeline/finalize.py
@@ -26,7 +26,9 @@ from .common import (
     count_year_bucket_files,
     dir_to_app_id,
     fetch_json,
+    flush_steam_descriptors_cache,
     flush_steam_title_cache,
+    is_adult_app,
     log,
 )
 from .gog_catalog import load_gog_catalog, load_gog_covers
@@ -774,7 +776,17 @@ def generate_search_index(
         if not title:
             continue
         tier, pdb_count, pulse_count = _compute_game_summary(app_dir)
-        entries.append([app_id, title, tier, pdb_count, pulse_count, app_type_from_id(app_id)])
+        app_type = app_type_from_id(app_id)
+        # Adult flag lives at column 8. Steam descriptors are the source
+        # of truth; GOG / Epic entries stay unflagged (no equivalent
+        # API). Catalog-only stubs also skip the check to avoid burning
+        # ~50k+ appdetails calls on the first pipeline run -- if the
+        # game has no reports it likely never trends into a browse view.
+        # Columns 6 (release_year) + 7 (delisted) get filled in later by
+        # enrich_search_index_with_release_years / _with_delisted; pad
+        # them with None so column 8 (adult) sits at the expected index.
+        adult = is_adult_app(app_id) if app_type == "steam" else False
+        entries.append([app_id, title, tier, pdb_count, pulse_count, app_type, None, None, adult])
         seen_ids.add(app_id)
 
     if gog_catalog:
@@ -1587,4 +1599,5 @@ def finalize_output(output_dir, skip_probe: bool = False):
     write_data_versions_json(output_path)
     log_summary(state["parsed_count"], data_output_path, output_path, pipeline_start, state["backfilled_keys"])
     flush_steam_title_cache()
+    flush_steam_descriptors_cache()
     log("Done finalizing output.")

--- a/scripts/pipeline/most_played.py
+++ b/scripts/pipeline/most_played.py
@@ -20,7 +20,7 @@ import urllib.request
 from pathlib import Path
 
 from .catalog import read_cached_steam_game_catalog
-from .common import log
+from .common import flush_steam_descriptors_cache, is_adult_app, log
 
 STEAM_MOST_PLAYED_URL = (
     "https://api.steampowered.com/ISteamChartsService/GetMostPlayedGames/v1/"
@@ -137,6 +137,9 @@ def build_most_played(
             "pulseCount": pulse_count,
             "lastReportDate": _last_report_date(data_dir, app_id),
             "headerImage": None,  # filled in by game_images.build_game_images after this step
+            # Flag Steam-classified adult games so the frontend can hide
+            # them by default (opt-in via site options "Show adult games").
+            "adult": is_adult_app(app_id),
         }
         if tier in KNOWN_TIERS and len(rated) < limit:
             rated.append(row)
@@ -170,6 +173,7 @@ def build_most_played(
                     "pulseCount": 0,
                     "lastReportDate": None,
                     "headerImage": None,
+                    "adult": is_adult_app(app_id),
                 })
             if catalog_only:
                 log(f"[most-played] {len(catalog_only)} catalog-only game(s) added from Steam catalog cache")
@@ -187,5 +191,9 @@ def build_most_played(
     catalog_stub_path = output_dir / "steam-catalog.json"
     catalog_stub_path.write_text(json.dumps(catalog_stubs, indent=2) + "\n", encoding="utf-8")
     log(f"[most-played] wrote {len(catalog_stubs)} catalog stub(s) to {catalog_stub_path.name}")
+
+    # Persist any newly-fetched Steam content descriptor entries so the
+    # next pipeline run doesn't re-hit appdetails for them (30d TTL).
+    flush_steam_descriptors_cache()
 
     return result

--- a/submit.html
+++ b/submit.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=2d6b5e52">
 <link rel="stylesheet" href="css/shared/site.css?v=e05a0f73">
 <link rel="stylesheet" href="css/shared/cards.css?v=16c748ed">
-<link rel="stylesheet" href="css/app/game-header.css?v=b8e80a64">
+<link rel="stylesheet" href="css/app/game-header.css?v=594fa872">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=9ac38baa">
 <link rel="stylesheet" href="css/app/modals.css?v=99a2a3d5">

--- a/tests/adultFilter.test.js
+++ b/tests/adultFilter.test.js
@@ -1,0 +1,72 @@
+/**
+ * Client-side gate for adult-flagged games. Rows come from the pipeline
+ * with adult: true when Steam content descriptors 1, 4, or 5 apply.
+ * The gate defaults to hiding those rows; users can opt in via the site
+ * options "Show adult games" toggle (pp:show-adult=on).
+ */
+const { showAdultAllowed, filterAdult } = require('../js/lib/adult-filter.js');
+
+describe('adult-filter', () => {
+  let store;
+  beforeAll(() => {
+    store = {};
+    global.localStorage = {
+      getItem: (k) => (k in store ? store[k] : null),
+      setItem: (k, v) => { store[k] = String(v); },
+      removeItem: (k) => { delete store[k]; },
+      clear: () => { store = {}; global.localStorage._store = store; },
+    };
+  });
+  beforeEach(() => {
+    Object.keys(store).forEach(k => delete store[k]);
+  });
+
+  test('showAdultAllowed defaults to false when pref is missing', () => {
+    expect(showAdultAllowed()).toBe(false);
+  });
+
+  test('showAdultAllowed is true only when pp:show-adult is exactly "on"', () => {
+    localStorage.setItem('pp:show-adult', 'on');
+    expect(showAdultAllowed()).toBe(true);
+    localStorage.setItem('pp:show-adult', 'off');
+    expect(showAdultAllowed()).toBe(false);
+    localStorage.setItem('pp:show-adult', 'true');
+    expect(showAdultAllowed()).toBe(false);
+  });
+
+  test('filterAdult hides adult=true rows when the pref is off', () => {
+    const rows = [
+      { title: 'Regular Game', adult: false },
+      { title: 'Naughty Chat', adult: true },
+      { title: 'Old Data Row' }, // no adult field
+    ];
+    expect(filterAdult(rows).map(r => r.title))
+      .toEqual(['Regular Game', 'Old Data Row']);
+  });
+
+  test('filterAdult passes rows through when the pref is on', () => {
+    localStorage.setItem('pp:show-adult', 'on');
+    const rows = [
+      { title: 'Regular Game', adult: false },
+      { title: 'Naughty Chat', adult: true },
+    ];
+    expect(filterAdult(rows).map(r => r.title))
+      .toEqual(['Regular Game', 'Naughty Chat']);
+  });
+
+  test('filterAdult treats rows without the adult field as safe (backwards compat)', () => {
+    // Older data files (pre-adult-flag) had no adult key. Those rows
+    // must not be filtered -- if they were, the whole grid would go
+    // empty until the next pipeline run repopulates the field.
+    const rows = [
+      { title: 'A' }, { title: 'B' }, { title: 'C' },
+    ];
+    expect(filterAdult(rows)).toEqual(rows);
+  });
+
+  test('filterAdult tolerates null / undefined entries without throwing', () => {
+    const rows = [null, undefined, { title: 'ok', adult: false }];
+    // null/undefined pass through the safety branch (r.adult !== true).
+    expect(filterAdult(rows)).toEqual(rows);
+  });
+});

--- a/tests/gridSize.test.js
+++ b/tests/gridSize.test.js
@@ -57,8 +57,10 @@ describe('configurable card size (S/M/L)', () => {
   });
 
   test('load more keeps the current view in both sections', () => {
-    expect(homeSrc).toContain('batch.map(renderFn).join(\'\')');
-    expect(homeSrc).toContain('batch.map(_popularItemHtml).join(\'\')');
+    // Both sections re-render (rather than splice+append) so the tile-row
+    // orphan trim on the last row stays correct after every click.
+    expect(homeSrc).toContain('filtered.slice(0, shown).map(_popularItemHtml)');
+    expect(homeSrc).toContain('filtered.slice(0, shown).map(_recentCardHtml)');
     expect(homeSrc).not.toContain('function _appendCards');
   });
 

--- a/tests/homeFilters.test.js
+++ b/tests/homeFilters.test.js
@@ -188,12 +188,17 @@ describe('home page browse -- Save filters (persist)', () => {
   });
 });
 
-describe('home page browse -- preload count preference', () => {
-  test('preload count comes from the pp:load-count preference, default 50', () => {
-    expect(homeSrc).toContain("const LOAD_COUNT_KEY = 'pp:load-count'");
-    expect(homeSrc).toContain('const LOAD_COUNTS = [50, 100, 150, 200]');
-    expect(homeSrc).toContain('return LOAD_COUNTS.includes(n) ? n : 50;');
-    expect(homeSrc).toContain('const PAGE_SIZE = _loadCount();');
+describe('home page browse -- page size targets full rows', () => {
+  test('initial + Load more sizes come from pageSizeForFullRows(cardsEl, 4)', () => {
+    // Replaces the older fixed pp:load-count preference (50/100/150/200)
+    // with a row-count target so the grid always shows ~4 complete rows
+    // regardless of viewport (mobile drops to the 8-item floor). See
+    // pageSizeForFullRows in js/lib/tile-pad.js.
+    expect(homeSrc).toContain('const TARGET_ROWS = 4');
+    expect(homeSrc).toContain('pageSizeForFullRows(cardsEl, TARGET_ROWS)');
+    // Old fixed preload count is no longer wired to paging (kept in
+    // localStorage for backwards compat, but not read by the render).
+    expect(homeSrc).not.toContain('const PAGE_SIZE = _loadCount();');
   });
 });
 

--- a/tests/indexPopularFilters.test.js
+++ b/tests/indexPopularFilters.test.js
@@ -85,9 +85,13 @@ describe('index page popular games rating filters', () => {
   test('popular list pages with a load more button', () => {
     expect(indexHtml).toContain('id="pg-load-more"');
     expect(indexSrc).toContain('const PAGE_SIZE = 12');
-    expect(indexSrc).toContain('all.slice(0, shownCount)');
+    // Slice uses the min-clamped shown count so an oversized shownCount
+    // (from a filter change or resize) never overruns the list length.
+    expect(indexSrc).toContain('all.slice(0, shown)');
     expect(indexSrc).toContain('id="pg-load-more-btn"');
-    expect(indexSrc).toContain('shownCount += PAGE_SIZE');
+    // Load more picks up from the actual rendered count (not stale
+    // shownCount) because trimming orphans mutates the DOM under it.
+    expect(indexSrc).toContain('shownCount = rendered + PAGE_SIZE');
   });
 
   test('changing a filter restarts paging', () => {

--- a/tests/indexPopularFilters.test.js
+++ b/tests/indexPopularFilters.test.js
@@ -84,17 +84,20 @@ describe('index page popular games rating filters', () => {
 
   test('popular list pages with a load more button', () => {
     expect(indexHtml).toContain('id="pg-load-more"');
-    expect(indexSrc).toContain('const PAGE_SIZE = 12');
-    // Slice uses the min-clamped shown count so an oversized shownCount
-    // (from a filter change or resize) never overruns the list length.
+    // Page size is computed off the current column count so the initial
+    // render always shows roughly TARGET_ROWS full rows.
+    expect(indexSrc).toContain('const TARGET_ROWS = 4');
+    expect(indexSrc).toContain('pageSizeForFullRows(list, TARGET_ROWS)');
     expect(indexSrc).toContain('all.slice(0, shown)');
     expect(indexSrc).toContain('id="pg-load-more-btn"');
     // Load more picks up from the actual rendered count (not stale
     // shownCount) because trimming orphans mutates the DOM under it.
-    expect(indexSrc).toContain('shownCount = rendered + PAGE_SIZE');
+    expect(indexSrc).toContain('shownCount = rendered + pageSizeForFullRows(list, TARGET_ROWS)');
   });
 
   test('changing a filter restarts paging', () => {
-    expect(indexSrc).toContain('shownCount = PAGE_SIZE;');
+    // Filter change resets shownCount to the current row-based page size,
+    // not a hardcoded PAGE_SIZE constant.
+    expect(indexSrc).toContain('shownCount = pageSizeForFullRows(list, TARGET_ROWS);');
   });
 });

--- a/tests/searchExtendedIndex.test.js
+++ b/tests/searchExtendedIndex.test.js
@@ -37,6 +37,10 @@ function stubsForSearch(extraFetch) {
     esc: (s) => String(s),
     withTimeout: async (p) => p,
     renderGameCard: () => '',
+    // adult-filter helpers: pass-through so the extended-search tests
+    // exercise the raw match logic without needing localStorage.
+    filterAdultEntries: (rows) => rows,
+    isAdultEntry: () => false,
     document: {
       getElementById: () => ({ innerHTML: '', set innerHTML(_v) {}, classList: { add() {}, remove() {}, contains() { return false; } }, getBoundingClientRect: () => ({ top:0, left:0, right:0, bottom:0, width:0 }), addEventListener() {}, querySelectorAll: () => [], contains: () => false }),
       addEventListener: () => {},
@@ -176,10 +180,11 @@ describe('renderSearchPage source shape (#134 regression guards)', () => {
 
   test('merges extended matches into indexResults and dedupes by appId', () => {
     // The dedupe is what stops a Steam app that has both primary + extended
-    // representation from rendering twice. Keep the filter assertion strict
-    // enough to catch an accidental concat without dedupe.
+    // representation from rendering twice. renderSearchPage inlines the raw
+    // _matchEntries call so the adult-hidden count can be computed against
+    // the pre-filter set; the dedupe pattern is unchanged.
     expect(src).toContain('primaryIds.has(String(id))');
-    expect(src).toContain('searchExtendedSteamMatches(q,');
+    expect(src).toContain('_matchEntries(extendedSteamIndex, q,');
   });
 
   test('onSearchInput (dropdown) does NOT load the extended index', () => {

--- a/tests/test_content_descriptors.py
+++ b/tests/test_content_descriptors.py
@@ -1,0 +1,138 @@
+"""Tests for Steam content-descriptor fetching + caching used by the
+adult-games hide-by-default feature.
+
+The pipeline attaches `adult: true` to a row whenever Steam's appdetails
+response for that app includes any of ADULT_DESCRIPTOR_IDS (1, 4, 5).
+The frontend hides those rows unless the user opts in via the site
+options "Show adult games" toggle.
+"""
+import json
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import scripts.pipeline.common as common_module
+from scripts.pipeline.common import (
+    ADULT_DESCRIPTOR_IDS,
+    fetch_steam_content_descriptors,
+    is_adult_app,
+    flush_steam_descriptors_cache,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_descriptor_cache(tmp_path, monkeypatch):
+    """Isolate each test with a fresh cache path + in-memory state."""
+    common_module._steam_descriptors_cache = None
+    common_module._steam_descriptors_cache_dirty = False
+    cache = tmp_path / "steam-content-descriptors-cache.json"
+    monkeypatch.setattr(
+        common_module,
+        "DEFAULT_STEAM_DESCRIPTORS_CACHE_PATH",
+        cache,
+    )
+    yield cache
+    common_module._steam_descriptors_cache = None
+    common_module._steam_descriptors_cache_dirty = False
+
+
+def test_adult_descriptor_ids_covers_the_three_relevant_flags():
+    # Steam publishes these IDs for nudity / sexual content descriptors.
+    # 1 = some, 4 = adult only, 5 = frequent. If Steam adds a new one
+    # (e.g. 6), a conscious edit is needed rather than a silent drift.
+    assert ADULT_DESCRIPTOR_IDS == {1, 4, 5}
+
+
+def test_fetch_returns_empty_list_when_appdetails_is_unsuccessful():
+    with patch(
+        "scripts.pipeline.common.fetch_json",
+        return_value={"12345": {"success": False}},
+    ):
+        assert fetch_steam_content_descriptors("12345") == []
+
+
+def test_fetch_returns_ids_when_present_and_caches_them(_reset_descriptor_cache):
+    payload = {
+        "12345": {
+            "success": True,
+            "data": {"content_descriptors": {"ids": [1, 5], "notes": "..."}},
+        },
+    }
+    with patch("scripts.pipeline.common.fetch_json", return_value=payload) as m:
+        assert fetch_steam_content_descriptors("12345") == [1, 5]
+        # Second call hits the in-memory cache -- no additional network fetch.
+        assert fetch_steam_content_descriptors("12345") == [1, 5]
+        assert m.call_count == 1
+
+
+def test_fetch_survives_a_network_exception_and_returns_empty():
+    with patch(
+        "scripts.pipeline.common.fetch_json",
+        side_effect=RuntimeError("network"),
+    ):
+        assert fetch_steam_content_descriptors("12345") == []
+
+
+def test_is_adult_app_true_when_any_adult_id_is_present():
+    payload = {
+        "77777": {
+            "success": True,
+            "data": {"content_descriptors": {"ids": [3, 5]}},
+        },
+    }
+    with patch("scripts.pipeline.common.fetch_json", return_value=payload):
+        # 5 is in ADULT_DESCRIPTOR_IDS -> adult
+        assert is_adult_app("77777") is True
+
+
+def test_is_adult_app_false_when_only_non_adult_ids_present():
+    payload = {
+        "88888": {
+            "success": True,
+            "data": {"content_descriptors": {"ids": [2, 3]}},
+        },
+    }
+    with patch("scripts.pipeline.common.fetch_json", return_value=payload):
+        assert is_adult_app("88888") is False
+
+
+def test_is_adult_app_false_when_no_descriptors_at_all():
+    payload = {
+        "99999": {"success": True, "data": {"content_descriptors": {"ids": []}}},
+    }
+    with patch("scripts.pipeline.common.fetch_json", return_value=payload):
+        assert is_adult_app("99999") is False
+
+
+def test_flush_persists_cache_to_disk(_reset_descriptor_cache):
+    payload = {
+        "42": {
+            "success": True,
+            "data": {"content_descriptors": {"ids": [4]}},
+        },
+    }
+    with patch("scripts.pipeline.common.fetch_json", return_value=payload):
+        fetch_steam_content_descriptors("42")
+    flush_steam_descriptors_cache(_reset_descriptor_cache)
+    on_disk = json.loads(_reset_descriptor_cache.read_text())
+    assert on_disk["42"]["ids"] == [4]
+    assert isinstance(on_disk["42"]["ts"], int)
+
+
+def test_expired_cache_entry_triggers_a_fresh_fetch(_reset_descriptor_cache):
+    # Seed the cache with a stale entry (older than the 30d TTL).
+    old_ts = int(time.time()) - (common_module.STEAM_DESCRIPTORS_CACHE_MAX_AGE_SECONDS + 3600)
+    common_module._load_steam_descriptors_cache()  # initialize memory cache
+    common_module._steam_descriptors_cache["stale"] = {"ids": [3], "ts": old_ts}
+
+    payload = {
+        "stale": {
+            "success": True,
+            "data": {"content_descriptors": {"ids": [1]}},
+        },
+    }
+    with patch("scripts.pipeline.common.fetch_json", return_value=payload) as m:
+        assert fetch_steam_content_descriptors("stale") == [1]
+        assert m.call_count == 1

--- a/tests/tilePadHasMore.test.js
+++ b/tests/tilePadHasMore.test.js
@@ -1,0 +1,84 @@
+/**
+ * Regression pin for tile-pad hasMore=true behavior.
+ *
+ * When the Popular / Recent grids have more items queued behind a Load
+ * more button, an incomplete last row used to render with 2-3 orphan
+ * tiles crammed against the left edge and blank space on the right (see
+ * screenshot on index.html at ~1080px width, 12 items in a 5-col grid).
+ *
+ * The fix: pass hasMore=true to padTileRows, which trims the orphans so
+ * the grid ends flush and the Load more button visually fills the gap.
+ * The removed tiles come back via a re-render on the next click.
+ *
+ * The module uses live DOM APIs (getComputedStyle, createElement) so
+ * behavioral coverage would need jsdom. Source-pin the wiring instead
+ * so a regression on the flag path fails loudly.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const TILEPAD  = fs.readFileSync(path.join(ROOT, 'js', 'lib', 'tile-pad.js'), 'utf8');
+const INDEX    = fs.readFileSync(path.join(ROOT, 'js', 'index', 'main.js'), 'utf8');
+const HOME     = fs.readFileSync(path.join(ROOT, 'js', 'app', 'components', 'home.js'), 'utf8');
+
+describe('padTileRows(hasMore) trims orphans on incomplete last rows', () => {
+  test('padTileRows accepts a hasMore option, default false', () => {
+    expect(TILEPAD).toContain('hasMore = false');
+  });
+
+  test('hasMore=true branch removes the trailing orphans instead of padding', () => {
+    // The trim loop reads the un-filtered items list, then removes the
+    // last `remainder` of them so the grid ends on a full row.
+    expect(TILEPAD).toMatch(/if \(hasMore\) \{/);
+    expect(TILEPAD).toMatch(/orphan\.remove\(\)/);
+  });
+
+  test('hasMore=false still pads with .tile-filler divs (fully-shown case)', () => {
+    expect(TILEPAD).toMatch(/fillerClass = 'tile-filler'/);
+    expect(TILEPAD).toContain("f.className = fillerClass");
+    expect(TILEPAD).toContain("f.setAttribute('aria-hidden', 'true')");
+  });
+
+  test('watchTileRerender exists so a resize triggers a fresh render (needed because trim is destructive)', () => {
+    expect(TILEPAD).toContain('export function watchTileRerender(container, callback)');
+    expect(TILEPAD).toContain("window.addEventListener('resize'");
+  });
+});
+
+describe('renderers pass hasMore so incomplete rows never render', () => {
+  test('index.html Popular grid passes hasMore based on the queue', () => {
+    // renderPopular in js/index/main.js computes hasMore from all.length
+    // vs shown, then hands it to padTileRows.
+    expect(INDEX).toMatch(/const hasMore = all\.length > shown/);
+    expect(INDEX).toMatch(/padTileRows\(list, \{ tileSelector: '\.pg-card', hasMore \}\)/);
+  });
+
+  test('home page Recent + Popular grids pass hasMore based on filtered vs shown', () => {
+    // Both applyPopularFilters and applyRecentFilters compute the same
+    // way and pass to padTileRows so orphans get trimmed identically.
+    const popularPad = HOME.match(/padTileRows\(cardsEl, \{ tileSelector: '\.game-card', hasMore: filtered\.length > shown \}\)/g) || [];
+    expect(popularPad.length).toBe(2);
+  });
+
+  test('load-more resets shown to the rendered count + PAGE_SIZE (not stale shownCount)', () => {
+    // Because trim removes DOM nodes, the caller must read the actual
+    // rendered count to know how many "extra" tiles the next click needs
+    // to fetch. Both files use querySelectorAll(':scope ...:not(.tile-filler)')
+    // to count real tiles.
+    expect(INDEX).toContain(":not(.tile-filler)");
+    expect(HOME).toContain(":not(.tile-filler)");
+    expect(INDEX).toContain('rendered + PAGE_SIZE');
+    expect(HOME).toContain('rendered + PAGE_SIZE');
+  });
+
+  test('resize wires renderPopular/Recent via watchTileRerender (not the old watchTileRows)', () => {
+    // watchTileRows only re-runs padTileRows, which loses the trimmed
+    // tiles on a viewport widening. watchTileRerender fires the caller's
+    // render fn instead, which pulls fresh data.
+    expect(INDEX).toContain('watchTileRerender(list, renderPopular)');
+    expect(HOME).toContain('watchTileRerender(cardsEl, renderPopular)');
+    expect(HOME).toContain('watchTileRerender(cardsEl, renderRecent)');
+  });
+});

--- a/tests/tilePadHasMore.test.js
+++ b/tests/tilePadHasMore.test.js
@@ -69,8 +69,8 @@ describe('renderers pass hasMore so incomplete rows never render', () => {
     // to count real tiles.
     expect(INDEX).toContain(":not(.tile-filler)");
     expect(HOME).toContain(":not(.tile-filler)");
-    expect(INDEX).toContain('rendered + PAGE_SIZE');
-    expect(HOME).toContain('rendered + PAGE_SIZE');
+    expect(INDEX).toContain('rendered + pageSizeForFullRows(list, TARGET_ROWS)');
+    expect(HOME).toContain('rendered + pageSizeForFullRows(cardsEl, TARGET_ROWS)');
   });
 
   test('resize wires renderPopular/Recent via watchTileRerender (not the old watchTileRows)', () => {


### PR DESCRIPTION
Four commits on staging:

- **#160** Popular / Recent grids trim orphan tiles when Load more is queued so the last row stays flush.
- **Grid page size** now aims for ~4 full rows on desktop, floored at 8 items on mobile (replaces the fixed pp:load-count preference on home + PAGE_SIZE = 12 on index).
- **#161** Adult-content gate: pipeline flags Steam games via appdetails content descriptors 1/4/5 (with 30d disk cache), attaches adult on most_played.json + search-index.json. Client hides adult=true rows on Popular / Recent / Search unless the new 'Show adult games' switch on options.html is on. Direct navigation to an adult game page shows a block interstitial with a one-click reveal. Search results display 'N adult results hidden by your preference' when any are filtered.
- Options page reorder: 'Default layout' moves up under 'Animations'.

Note: browse-view filtering only takes effect after a full pipeline run (make gh-run) writes fresh most_played.json + search-index.json with the adult column populated.