### PR TITLE
Adult filter narrowed to descriptors {3, 4} + store URL parser

### DIFF
--- a/about.html
+++ b/about.html
@@ -195,7 +195,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script src="js/lib/analytics.js?v=e6dfbad8"></script>
-<script src="js/lib/topbar.js?v=a7958ed7"></script>
+<script src="js/lib/topbar.js?v=48d8ca3b"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/about/version.js?v=dd0d91d0"></script>
 </body>

--- a/admin.html
+++ b/admin.html
@@ -329,7 +329,7 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script src="js/lib/analytics.js?v=e6dfbad8"></script>
-<script src="js/lib/topbar.js?v=a7958ed7"></script>
+<script src="js/lib/topbar.js?v=48d8ca3b"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/admin/main.js?v=81f29c16"></script>
 </body>

--- a/app.html
+++ b/app.html
@@ -56,7 +56,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script src="js/lib/analytics.js?v=e6dfbad8"></script>
-<script src="js/lib/topbar.js?v=a7958ed7"></script>
+<script src="js/lib/topbar.js?v=48d8ca3b"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
 <!-- #153: markdown-it renders the Notes field on report cards. renderNotes

--- a/confidence.html
+++ b/confidence.html
@@ -203,7 +203,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=a7958ed7"></script>
+<script src="js/lib/topbar.js?v=48d8ca3b"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/game-stats.html
+++ b/game-stats.html
@@ -309,7 +309,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=a7958ed7"></script>
+<script src="js/lib/topbar.js?v=48d8ca3b"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/gh-pages-manifest.txt
+++ b/gh-pages-manifest.txt
@@ -107,6 +107,7 @@ js/lib/toast.js
 js/lib/data-url.js
 js/lib/tile-pad.js
 js/lib/adult-filter.js
+js/lib/store-url-parser.js
 js/lib/gh-gist.js
 js/lib/gh-auth.js
 js/lib/scoring/gameStats.js

--- a/index.html
+++ b/index.html
@@ -217,7 +217,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script src="js/lib/analytics.js?v=e6dfbad8"></script>
-<script src="js/lib/topbar.js?v=a7958ed7"></script>
+<script src="js/lib/topbar.js?v=48d8ca3b"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/index/main.js?v=6c03af02"></script>
 </body>

--- a/js/lib/store-url-parser.js
+++ b/js/lib/store-url-parser.js
@@ -1,0 +1,100 @@
+// Parse a Steam / GOG / Epic store URL into { store, appId, slug, canonicalId }.
+//
+// The topbar search, the app-page grouped search dispatch, and the submit
+// form's app-id field all take user input. Today they only handle numeric
+// Steam ids and title text -- pasting a store URL gets treated as free text
+// and misses the exact match. This parser runs before that dispatch so a
+// URL routes straight to the game's page.
+//
+// Steam URLs carry the canonical Steam appId directly in the path. GOG and
+// Epic URLs carry a human slug instead (canonical id lookup requires the
+// catalog files; that resolution is a caller concern, not this parser's).
+//
+// Returns null if the input isn't a recognised store URL so the caller can
+// fall back to free-text search.
+
+const STEAM_HOSTS = new Set([
+  'store.steampowered.com',
+  'steamcommunity.com',
+  's.team',
+]);
+const GOG_HOSTS = new Set(['www.gog.com', 'gog.com']);
+const EPIC_HOSTS = new Set(['store.epicgames.com', 'www.epicgames.com']);
+
+const LOCALE_RE = /^[a-z]{2}(-[a-z]{2})?$/i;
+
+function _tryUrl(input) {
+  const s = String(input || '').trim();
+  if (!s) return null;
+  // Accept bare host-less input (e.g. store.steampowered.com/app/...) too --
+  // users often strip the protocol when pasting.
+  const withProto = /^https?:\/\//i.test(s) ? s : `https://${s}`;
+  try {
+    return new URL(withProto);
+  } catch {
+    return null;
+  }
+}
+
+// Extract Steam appId from any of:
+//   /app/480490
+//   /app/480490/
+//   /app/480490/Prey/
+//   /sub/12345 (package -- skipped; we don't index those)
+//   /agecheck/app/480490 (age gate wrapper)
+function _steamFromUrl(u) {
+  const parts = u.pathname.split('/').filter(Boolean);
+  // Walk the parts looking for an "app" segment followed by a numeric id.
+  for (let i = 0; i < parts.length - 1; i++) {
+    if (parts[i].toLowerCase() === 'app') {
+      const id = parts[i + 1];
+      if (/^\d+$/.test(id)) return { store: 'steam', appId: id, canonicalId: id, slug: null };
+    }
+  }
+  return null;
+}
+
+// GOG URL shapes:
+//   https://www.gog.com/en/game/star_wars_knights_of_the_old_republic
+//   https://www.gog.com/game/witcher_3          (no locale)
+//   https://www.gog.com/en/movie/...            (not a game -- skip)
+// The slug is not the canonical id we store (which is gog:<numericProductId>).
+// Callers that need the canonical id look up the slug in gog-catalog-cache.json.
+function _gogFromUrl(u) {
+  const parts = u.pathname.split('/').filter(Boolean);
+  if (!parts.length) return null;
+  // Optional locale prefix ("en", "de", "pt-br", etc.).
+  let idx = 0;
+  if (LOCALE_RE.test(parts[0])) idx = 1;
+  if (parts[idx] !== 'game') return null;
+  const slug = parts[idx + 1];
+  if (!slug) return null;
+  return { store: 'gog', appId: null, canonicalId: null, slug };
+}
+
+// Epic URL shapes:
+//   https://store.epicgames.com/en-US/p/portal-2-cf80c3
+//   https://store.epicgames.com/p/portal-2                 (no locale)
+//   https://store.epicgames.com/en-US/product/portal-2     (older /product/ path)
+// Same slug -> canonical (epic:<namespace>) resolution note as GOG.
+function _epicFromUrl(u) {
+  const parts = u.pathname.split('/').filter(Boolean);
+  if (!parts.length) return null;
+  let idx = 0;
+  if (LOCALE_RE.test(parts[0])) idx = 1;
+  const kind = parts[idx];
+  if (kind !== 'p' && kind !== 'product') return null;
+  const slug = parts[idx + 1];
+  if (!slug) return null;
+  return { store: 'epic', appId: null, canonicalId: null, slug };
+}
+
+export function parseStoreUrl(input) {
+  const u = _tryUrl(input);
+  if (!u) return null;
+  const host = u.hostname.toLowerCase();
+  if (STEAM_HOSTS.has(host)) return _steamFromUrl(u);
+  if (GOG_HOSTS.has(host))   return _gogFromUrl(u);
+  if (EPIC_HOSTS.has(host))  return _epicFromUrl(u);
+  return null;
+}

--- a/js/lib/topbar.js
+++ b/js/lib/topbar.js
@@ -735,6 +735,45 @@
       return 'https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/' + appId + '/header.jpg';
     }
 
+    // Store URL parser (#116). Inline copy of js/lib/store-url-parser.js
+    // because topbar loads as a classic <script> and can't ES-import.
+    // KEEP IN SYNC with the module. Tests live at tests/storeUrlParser.test.js.
+    var _STEAM_HOSTS = { 'store.steampowered.com': 1, 'steamcommunity.com': 1, 's.team': 1 };
+    var _GOG_HOSTS   = { 'www.gog.com': 1, 'gog.com': 1 };
+    var _EPIC_HOSTS  = { 'store.epicgames.com': 1, 'www.epicgames.com': 1 };
+    var _LOCALE_RE   = /^[a-z]{2}(-[a-z]{2})?$/i;
+    function _parseStoreUrl(input) {
+      var s = String(input || '').trim();
+      if (!s) return null;
+      var withProto = /^https?:\/\//i.test(s) ? s : 'https://' + s;
+      var u;
+      try { u = new URL(withProto); } catch (e) { return null; }
+      var host = u.hostname.toLowerCase();
+      var parts = u.pathname.split('/').filter(Boolean);
+      if (_STEAM_HOSTS[host]) {
+        for (var i = 0; i < parts.length - 1; i++) {
+          if (parts[i].toLowerCase() === 'app' && /^\d+$/.test(parts[i + 1])) {
+            return { store: 'steam', appId: parts[i + 1], canonicalId: parts[i + 1], slug: null };
+          }
+        }
+        return null;
+      }
+      if (_GOG_HOSTS[host]) {
+        var gidx = 0;
+        if (parts[0] && _LOCALE_RE.test(parts[0])) gidx = 1;
+        if (parts[gidx] !== 'game' || !parts[gidx + 1]) return null;
+        return { store: 'gog', appId: null, canonicalId: null, slug: parts[gidx + 1] };
+      }
+      if (_EPIC_HOSTS[host]) {
+        var eidx = 0;
+        if (parts[0] && _LOCALE_RE.test(parts[0])) eidx = 1;
+        var kind = parts[eidx];
+        if ((kind !== 'p' && kind !== 'product') || !parts[eidx + 1]) return null;
+        return { store: 'epic', appId: null, canonicalId: null, slug: parts[eidx + 1] };
+      }
+      return null;
+    }
+
     function render(results, query) {
       focusIdx = -1;
       visible = results;
@@ -835,6 +874,21 @@
         }
         const q = input.value.trim();
         if (!q) return;
+        // Store URL paste path (#116): route directly to the game page
+        // when the input is a recognised Steam / GOG / Epic URL. Keep
+        // this inline copy in sync with js/lib/store-url-parser.js --
+        // topbar loads as a classic script and can't ES-import.
+        const parsed = _parseStoreUrl(q);
+        if (parsed && parsed.canonicalId) {
+          window.location.href = 'app.html#/app/' + parsed.canonicalId;
+          return;
+        }
+        if (parsed && parsed.slug) {
+          // GOG / Epic slug -- no canonical id lookup here; hand it to
+          // the full search page and let it match against the catalog.
+          window.location.href = 'app.html?q=' + encodeURIComponent(parsed.slug);
+          return;
+        }
         if (/^\d+$/.test(q)) {
           window.location.href = 'app.html#/app/' + q;
         } else {

--- a/options.html
+++ b/options.html
@@ -218,7 +218,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script src="js/lib/analytics.js?v=e6dfbad8"></script>
-<script src="js/lib/topbar.js?v=a7958ed7"></script>
+<script src="js/lib/topbar.js?v=48d8ca3b"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/options/main.js?v=428d8388"></script>
 </body>

--- a/privacy.html
+++ b/privacy.html
@@ -90,7 +90,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script src="js/lib/analytics.js?v=e6dfbad8"></script>
-<script src="js/lib/topbar.js?v=a7958ed7"></script>
+<script src="js/lib/topbar.js?v=48d8ca3b"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -293,7 +293,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script src="js/lib/analytics.js?v=e6dfbad8"></script>
-<script src="js/lib/topbar.js?v=a7958ed7"></script>
+<script src="js/lib/topbar.js?v=48d8ca3b"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/profile/main.js?v=7207779a"></script>
 </body>

--- a/scoring.html
+++ b/scoring.html
@@ -493,7 +493,7 @@ h2 small {
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script src="js/lib/analytics.js?v=e6dfbad8"></script>
-<script src="js/lib/topbar.js?v=a7958ed7"></script>
+<script src="js/lib/topbar.js?v=48d8ca3b"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/scripts/pipeline/common.py
+++ b/scripts/pipeline/common.py
@@ -17,12 +17,16 @@ DEFAULT_STEAM_DESCRIPTORS_CACHE_PATH = Path(__file__).resolve().parents[2] / ".c
 STEAM_DESCRIPTORS_CACHE_MAX_AGE_SECONDS = 30 * 86400  # 30 days
 # Steam descriptor IDs that flag a game as adult-only for our purposes.
 # Reference: https://partner.steamgames.com/doc/store/community_engagement/content_descriptors
-# 1 = Some Nudity or Sexual Content
+# 1 = Some Nudity or Sexual Content          (NOT filtered -- too broad; catches
+#                                             BG3, Cyberpunk 2077, Rust, GTA V,
+#                                             etc. -- mainstream M-rated games)
 # 2 = Frequent Violence or Gore              (NOT filtered -- most action games)
 # 3 = Adult Only Sexual Content              (porn / VN games)
-# 4 = Frequent Nudity or Sexual Content
+# 4 = Frequent Nudity or Sexual Content      (softcore / hentai)
 # 5 = General Mature Content                 (NOT filtered -- CS2, DBD, Rust, etc.)
-ADULT_DESCRIPTOR_IDS = {1, 3, 4}
+# Trust Steam's developer self-flagging; hide only 3 and 4 which are the
+# adult-only categories. Genuine porn / hentai should carry one of these.
+ADULT_DESCRIPTOR_IDS = {3, 4}
 
 # In-memory Steam title cache (loaded once per run)
 _steam_title_cache: dict[str, dict] | None = None

--- a/stats.html
+++ b/stats.html
@@ -664,7 +664,7 @@ h2 {
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script src="js/lib/analytics.js?v=e6dfbad8"></script>
-<script src="js/lib/topbar.js?v=a7958ed7"></script>
+<script src="js/lib/topbar.js?v=48d8ca3b"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/submit.html
+++ b/submit.html
@@ -23,7 +23,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script src="js/lib/analytics.js?v=e6dfbad8"></script>
-<script src="js/lib/topbar.js?v=a7958ed7"></script>
+<script src="js/lib/topbar.js?v=48d8ca3b"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <!-- Markdown editor spike (?md=1). Loaded eagerly but only wired when the
      flag is on -- window.markdownit stays unused otherwise. -->

--- a/system-edit.html
+++ b/system-edit.html
@@ -19,7 +19,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script src="js/lib/analytics.js?v=e6dfbad8"></script>
-<script src="js/lib/topbar.js?v=a7958ed7"></script>
+<script src="js/lib/topbar.js?v=48d8ca3b"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/terms.html
+++ b/terms.html
@@ -92,7 +92,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script src="js/lib/analytics.js?v=e6dfbad8"></script>
-<script src="js/lib/topbar.js?v=a7958ed7"></script>
+<script src="js/lib/topbar.js?v=48d8ca3b"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/tests/storeUrlParser.test.js
+++ b/tests/storeUrlParser.test.js
@@ -1,0 +1,136 @@
+/**
+ * Tests for parseStoreUrl (#116).
+ *
+ * Covers each store's URL shapes, locale prefixes, trailing slashes,
+ * query strings, and the no-match fallback (which the search box uses
+ * to fall back to free-text search).
+ */
+
+const { parseStoreUrl } = require('../js/lib/store-url-parser.js');
+
+describe('parseStoreUrl - Steam', () => {
+  test('canonical /app/<id>/<slug>/ shape returns numeric appId', () => {
+    expect(parseStoreUrl('https://store.steampowered.com/app/480490/Prey/'))
+      .toEqual({ store: 'steam', appId: '480490', canonicalId: '480490', slug: null });
+  });
+
+  test('no trailing slug or slash still works', () => {
+    expect(parseStoreUrl('https://store.steampowered.com/app/480490'))
+      .toEqual({ store: 'steam', appId: '480490', canonicalId: '480490', slug: null });
+  });
+
+  test('query string on the end is ignored', () => {
+    expect(parseStoreUrl('https://store.steampowered.com/app/480490/?utm_source=x'))
+      .toEqual({ store: 'steam', appId: '480490', canonicalId: '480490', slug: null });
+  });
+
+  test('agecheck wrapper URL still yields the appId', () => {
+    expect(parseStoreUrl('https://store.steampowered.com/agecheck/app/292030/'))
+      .toEqual({ store: 'steam', appId: '292030', canonicalId: '292030', slug: null });
+  });
+
+  test('steamcommunity.com hub URLs also parse', () => {
+    expect(parseStoreUrl('https://steamcommunity.com/app/480490'))
+      .toEqual({ store: 'steam', appId: '480490', canonicalId: '480490', slug: null });
+  });
+
+  test('protocol-less input (host-only) still parses', () => {
+    expect(parseStoreUrl('store.steampowered.com/app/480490'))
+      .toEqual({ store: 'steam', appId: '480490', canonicalId: '480490', slug: null });
+  });
+
+  test('sub (package) URLs are not games -- returns null', () => {
+    // We don't index packages; caller should fall back to text search.
+    expect(parseStoreUrl('https://store.steampowered.com/sub/12345/')).toBeNull();
+  });
+
+  test('non-numeric appId slot bails out', () => {
+    expect(parseStoreUrl('https://store.steampowered.com/app/notanumber')).toBeNull();
+  });
+});
+
+describe('parseStoreUrl - GOG', () => {
+  test('URL with locale prefix returns slug', () => {
+    expect(parseStoreUrl('https://www.gog.com/en/game/star_wars_knights_of_the_old_republic'))
+      .toEqual({ store: 'gog', appId: null, canonicalId: null, slug: 'star_wars_knights_of_the_old_republic' });
+  });
+
+  test('URL without locale prefix returns slug', () => {
+    expect(parseStoreUrl('https://www.gog.com/game/witcher_3_wild_hunt'))
+      .toEqual({ store: 'gog', appId: null, canonicalId: null, slug: 'witcher_3_wild_hunt' });
+  });
+
+  test('bare host without www still parses', () => {
+    expect(parseStoreUrl('https://gog.com/en/game/star_wars_kotor'))
+      .toEqual({ store: 'gog', appId: null, canonicalId: null, slug: 'star_wars_kotor' });
+  });
+
+  test('multi-part locale like pt-br works', () => {
+    expect(parseStoreUrl('https://www.gog.com/pt-br/game/gwent'))
+      .toEqual({ store: 'gog', appId: null, canonicalId: null, slug: 'gwent' });
+  });
+
+  test('non-game paths (movies, promos) return null', () => {
+    expect(parseStoreUrl('https://www.gog.com/en/movie/some_movie')).toBeNull();
+    expect(parseStoreUrl('https://www.gog.com/en/promo/summer_sale')).toBeNull();
+  });
+
+  test('trailing slash + query string ignored', () => {
+    expect(parseStoreUrl('https://www.gog.com/en/game/witcher_3/?bg=1'))
+      .toEqual({ store: 'gog', appId: null, canonicalId: null, slug: 'witcher_3' });
+  });
+});
+
+describe('parseStoreUrl - Epic', () => {
+  test('modern /p/<slug> with locale prefix', () => {
+    expect(parseStoreUrl('https://store.epicgames.com/en-US/p/portal-2-cf80c3'))
+      .toEqual({ store: 'epic', appId: null, canonicalId: null, slug: 'portal-2-cf80c3' });
+  });
+
+  test('modern /p/<slug> without locale', () => {
+    expect(parseStoreUrl('https://store.epicgames.com/p/rocket-league'))
+      .toEqual({ store: 'epic', appId: null, canonicalId: null, slug: 'rocket-league' });
+  });
+
+  test('legacy /product/<slug> path still parses', () => {
+    expect(parseStoreUrl('https://store.epicgames.com/en-US/product/portal-2'))
+      .toEqual({ store: 'epic', appId: null, canonicalId: null, slug: 'portal-2' });
+  });
+
+  test('epicgames.com (marketing site) also accepted', () => {
+    expect(parseStoreUrl('https://www.epicgames.com/en-US/p/portal-2'))
+      .toEqual({ store: 'epic', appId: null, canonicalId: null, slug: 'portal-2' });
+  });
+
+  test('non-store paths return null', () => {
+    expect(parseStoreUrl('https://store.epicgames.com/en-US/news/some-article')).toBeNull();
+  });
+});
+
+describe('parseStoreUrl - fallback / bad input', () => {
+  test('empty / null / undefined returns null', () => {
+    expect(parseStoreUrl('')).toBeNull();
+    expect(parseStoreUrl(null)).toBeNull();
+    expect(parseStoreUrl(undefined)).toBeNull();
+  });
+
+  test('free-text title search returns null (caller falls back)', () => {
+    expect(parseStoreUrl('Portal 2')).toBeNull();
+    expect(parseStoreUrl('star wars')).toBeNull();
+  });
+
+  test('numeric app id (not a URL) returns null so caller keeps its numeric path', () => {
+    // The existing search dispatch treats a bare numeric input as an
+    // appId directly; we don't want to interfere with that.
+    expect(parseStoreUrl('480490')).toBeNull();
+  });
+
+  test('unknown host returns null', () => {
+    expect(parseStoreUrl('https://example.com/app/480490')).toBeNull();
+  });
+
+  test('garbage URL string returns null instead of throwing', () => {
+    expect(parseStoreUrl('http://')).toBeNull();
+    expect(parseStoreUrl('://not a url')).toBeNull();
+  });
+});

--- a/tests/test_content_descriptors.py
+++ b/tests/test_content_descriptors.py
@@ -2,7 +2,7 @@
 adult-games hide-by-default feature.
 
 The pipeline attaches `adult: true` to a row whenever Steam's appdetails
-response for that app includes any of ADULT_DESCRIPTOR_IDS (1, 3, 4).
+response for that app includes any of ADULT_DESCRIPTOR_IDS (3, 4).
 The frontend hides those rows unless the user opts in via the site
 options "Show adult games" toggle.
 """
@@ -39,11 +39,12 @@ def _reset_descriptor_cache(tmp_path, monkeypatch):
 
 
 def test_adult_descriptor_ids_covers_the_three_relevant_flags():
-    # Steam publishes these IDs for nudity / sexual content descriptors.
-    # 1 = some, 3 = adult only, 4 = frequent. ID 5 is "General Mature
-    # Content" (CS2 / DBD / Rust get it) -- NOT adult, do not include.
-    # ID 2 is violence/gore. Adding a new ID is a conscious edit here.
-    assert ADULT_DESCRIPTOR_IDS == {1, 3, 4}
+    # 3 = Adult Only Sexual Content, 4 = Frequent Nudity or Sexual Content.
+    # ID 1 (Some Nudity or Sexual Content) is too broad -- catches BG3,
+    # Cyberpunk 2077, Rust, GTA V, etc. ID 2 is violence/gore. ID 5 is
+    # "General Mature Content" (CS2 / DBD / Rust). Trust Steam devs to
+    # self-flag genuine adult games with 3 or 4.
+    assert ADULT_DESCRIPTOR_IDS == {3, 4}
 
 
 def test_fetch_returns_empty_list_when_appdetails_is_unsuccessful():
@@ -102,14 +103,30 @@ def test_is_adult_app_false_when_only_mature_content_id_5_present():
 
 
 def test_is_adult_app_false_when_only_non_adult_ids_present():
+    # 2 = violence/gore, 1 = "Some Nudity or Sexual Content" (mainstream
+    # M-rated flag, deliberately not filtered). Neither triggers adult.
     payload = {
         "88888": {
             "success": True,
-            "data": {"content_descriptors": {"ids": [2, 3]}},
+            "data": {"content_descriptors": {"ids": [1, 2]}},
         },
     }
     with patch("scripts.pipeline.common.fetch_json", return_value=payload):
         assert is_adult_app("88888") is False
+
+
+def test_is_adult_app_false_when_only_descriptor_1_present_bg3_case():
+    # Regression: BG3 / Cyberpunk 2077 / Rust / GTA V all set descriptor 1
+    # ("Some Nudity or Sexual Content"). Filtering them under the adult
+    # gate is a broken UX. Only IDs 3 (adult only) and 4 (frequent) count.
+    payload = {
+        "1086940": {  # Baldur's Gate 3
+            "success": True,
+            "data": {"content_descriptors": {"ids": [1, 2]}},
+        },
+    }
+    with patch("scripts.pipeline.common.fetch_json", return_value=payload):
+        assert is_adult_app("1086940") is False
 
 
 def test_is_adult_app_false_when_no_descriptors_at_all():


### PR DESCRIPTION
Two commits ready for prod:

- **#172 Adult filter tightened to {3, 4} only.** Descriptor 1 (Some Nudity or Sexual Content) is a self-flag that mainstream M-rated games commonly set: BG3, Cyberpunk 2077, Rust, GTA V. The current {1, 3, 4} mapping hides them. Trust Steam devs to self-flag genuine adult titles with 3 (Adult Only) or 4 (Frequent). Wiki page + tests updated in the same commit.
  - **Requires a full pipeline rerun after merge** so most_played.json and search-index.json rewrite the adult column with the tightened set. Descriptor cache is warm, so it'll be a fast run.

- **#116 Parse pasted store URLs.** New js/lib/store-url-parser.js takes a Steam / GOG / Epic URL and returns { store, appId, canonicalId, slug }. Wired into the topbar search Enter handler -- pasting a Steam store URL now routes straight to /app/<id>. 24 test cases + a Store-APIs-and-Images wiki page covering the per-store endpoints.

All confirmed on staging (v1.5.0 - 99b6ea1).
