### PR TITLE
fix(steam-metadata): steamcmd needs app_info_request to hit fresh PICS

### DIFF
--- a/scripts/pipeline/steam_metadata.py
+++ b/scripts/pipeline/steam_metadata.py
@@ -246,10 +246,19 @@ def run_steamcmd_app_info(app_id: int, timeout: int = 60) -> str:
     """
     if not steamcmd_available():
         raise RuntimeError(f"steamcmd not on PATH ({STEAMCMD_BINARY}); install it first")
+    # `+app_info_request <id>` forces PICS to fetch fresh product info for
+    # this app. `+app_info_print` alone reads the local cache, which is
+    # empty on a fresh runner -- that produced our first-run 'no_manifest'
+    # miss. `+app_info_update 1` refreshes the general changelist.
+    # `+delay 3` gives PICS a moment to answer before print runs. This
+    # combination matches what SteamDB / ArchiSteamFarm docs recommend
+    # for anonymous PICS access.
     cmd = [
         STEAMCMD_BINARY,
         "+login", "anonymous",
         "+app_info_update", "1",
+        "+app_info_request", str(app_id),
+        "+delay", "3",
         "+app_info_print", str(app_id),
         "+quit",
     ]
@@ -343,11 +352,18 @@ def fetch_and_store(app_id: int, sleep_between: float = 3.0) -> tuple[str, int]:
         return "error", 0
     parsed = parse_app_info(raw)
     if parsed is None:
-        upsert_fetch_status(app_id, "no_public_manifest", 0, None)
+        # Log a short tail of the raw steamcmd stdout so a workflow log
+        # reader can tell whether steamcmd hit a login banner, a rate
+        # limit, or actually returned an appid block we then failed to
+        # parse. Truncated to keep GH Actions logs readable.
+        tail = (raw or "").strip().splitlines()[-6:]
+        log(f"steam-metadata: app={app_id} no appinfo block, steamcmd tail={tail}")
+        upsert_fetch_status(app_id, "no_public_manifest", 0, "no appinfo block in steamcmd output")
         return "no_public_manifest", 0
     rows = extract_depot_rows(app_id, parsed)
     if not rows:
-        upsert_fetch_status(app_id, "no_public_manifest", 0, None)
+        log(f"steam-metadata: app={app_id} parsed but no rows -- depots={list((parsed.get('depots') or {}).keys())[:8]}")
+        upsert_fetch_status(app_id, "no_public_manifest", 0, "parsed appinfo but no OS-bound depot rows")
         return "no_public_manifest", 0
     n = upsert_depot_rows(rows)
     upsert_fetch_status(app_id, "ok", n, None)

--- a/tests/test_steam_metadata.py
+++ b/tests/test_steam_metadata.py
@@ -229,7 +229,13 @@ class TestFetchAndStoreOffline:
         assert status == "no_public_manifest"
         assert n == 0
         assert upserts == []
-        assert status_calls == [(1, "no_public_manifest", 0, None)]
+        # Error column now carries a short reason string so a workflow log
+        # reader can tell 'no appinfo block' apart from 'parsed but no
+        # OS-bound depots'.
+        assert len(status_calls) == 1
+        app_id, name, count, reason = status_calls[0]
+        assert (app_id, name, count) == (1, "no_public_manifest", 0)
+        assert reason and ("appinfo" in reason.lower() or "depot" in reason.lower())
 
     def test_error_status_when_steamcmd_raises(self, monkeypatch):
         def boom(*a, **kw):


### PR DESCRIPTION
The first Hollow Knight (367520) seed run returned no_manifest even though steamcmd itself loaded fine (Steam Console Client 1782532820). Root cause: `+app_info_print` alone reads the LOCAL cache which is empty on a fresh runner. PICS has to be pulled explicitly with `+app_info_request <appId>` first, plus a short delay so the async fetch completes before print runs. Matches what SteamDB / ArchiSteamFarm docs recommend for anonymous PICS access.

Also improves the diagnostic path so future misses are debuggable:
- log a short stdout tail when the appinfo block is missing
- log the depot key list when parsed but yielded zero OS-bound rows
- carry a reason string in the fetch_status.error column so 'no appinfo block' and 'parsed but no depots' are distinguishable

## Test plan

- [ ] After merge, re-dispatch **Steam Metadata Fetch (depot dates)** with app_ids=367520
- [ ] Confirm steam_depot_updates has rows for 367520 (Hollow Knight ships windows / macos / linux depots)
- [ ] Confirm Metadata modal on /app/#/app/367520 shows real First seen + Last update in the OS table (not the 'pending' placeholder)
- [ ] `python -m pytest tests/test_steam_metadata.py` still 12/12