### PR TITLE
steam-metadata: PICS branch-level fix + ISteamNews fallback + hardening tests

### DIFF
--- a/js/app/api/deck-status.js
+++ b/js/app/api/deck-status.js
@@ -206,6 +206,35 @@ export async function fetchAppMetadata(appId) {
  * still ramping up its coverage; callers should fall back to the
  * SteamDB deep link when found is false.
  */
+/**
+ * Cached fetch of the most recent ISteamNews/GetNewsForApp entries via
+ * the steam-news edge function proxy. Returns { found: bool, newest_ts,
+ * items[] } or null on network error. Called by the Metadata modal as
+ * a fallback when the PICS depot cache is empty for this app -- the
+ * newest news date acts as a "when was this game last updated" signal
+ * with no per-OS granularity but full public-endpoint coverage.
+ */
+const _appNewsCache = {};
+export function fetchAppNews(appId, { count = 3, maxlength = 200 } = {}) {
+  if (!appId) return Promise.resolve(null);
+  const key = `${appId}|${count}|${maxlength}`;
+  if (_appNewsCache[key] !== undefined) return _appNewsCache[key];
+  const p = (async () => {
+    try {
+      const base = (typeof window !== 'undefined' && window.SUPABASE_URL) || '';
+      if (!base) return null;
+      const url = `${base}/functions/v1/steam-news?appId=${encodeURIComponent(appId)}&count=${count}&maxlength=${maxlength}`;
+      const r = await fetch(url);
+      if (!r.ok) return null;
+      return await r.json();
+    } catch {
+      return null;
+    }
+  })();
+  _appNewsCache[key] = p;
+  return p;
+}
+
 const _depotInfoCache = {};
 export function fetchAppDepotInfo(appId) {
   if (!appId) return Promise.resolve(null);

--- a/js/app/components/deck-status.js
+++ b/js/app/components/deck-status.js
@@ -1,6 +1,6 @@
 // deck-status (components) for the app page. Relocated from app.js.
 
-import { getDeckStatusForApp } from '../api/deck-status.js?v=c5df5310';
+import { getDeckStatusForApp } from '../api/deck-status.js?v=09d5c67e';
 import { esc } from '../utils.js?v=c7e1268c';
 
 export const DECK_STATUS_LABELS = {

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -4,7 +4,7 @@ import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=b4fbb7ef';
 import { populateScoringTooltip, pulseTierFromReports, tierFromReports } from '../../shared/scoring.js?v=1b8ae722';
 import { computeCompatTrend, RECENT_DAYS, PRIOR_WINDOW_DAYS } from '../../lib/scoring/gameStats.js?v=8dc92cf7';
 import { getWebClientId } from '../../shared/submit.js?v=339c68ea';
-import { fetchAppDepotInfo, fetchAppMetadata, fetchDeckStatusForApp, fetchMinRequirements, fetchLinuxNativeSupport } from '../api/deck-status.js?v=c5df5310';
+import { fetchAppDepotInfo, fetchAppMetadata, fetchAppNews, fetchDeckStatusForApp, fetchMinRequirements, fetchLinuxNativeSupport } from '../api/deck-status.js?v=09d5c67e';
 import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=083594fa';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=01961c8d';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=aba6619f';
@@ -239,11 +239,16 @@ async function _openMetadataModal(appId) {
     if (e.key === 'Escape') { close(); document.removeEventListener('keydown', onKey); }
   });
 
-  const [meta, depotInfo] = await Promise.all([
+  const [meta, depotInfo, newsInfo] = await Promise.all([
     fetchAppMetadata(appId).catch(() => null),
-    // Fire in parallel; #215 pipeline may not have populated this app yet
-    // and that is expected -- the fallback SteamDB link stays in place.
+    // Depot info from the PICS pipeline (#215). Populated nightly; may
+    // not exist for this app yet.
     fetchAppDepotInfo(appId).catch(() => null),
+    // ISteamNews fallback: even when PICS is empty for the app we can
+    // still show a 'last patch note' date via a public HTTP endpoint.
+    // Global (not per-OS) so it degrades gracefully alongside the OS
+    // table.
+    fetchAppNews(appId).catch(() => null),
   ]);
   const body = modal.querySelector('#game-metadata-body');
   if (!body) return;
@@ -303,7 +308,11 @@ async function _openMetadataModal(appId) {
     return `<table class="gm-plat-table">
       <thead><tr><th>OS</th><th>First seen</th><th>Last update</th></tr></thead>
       <tbody>${row('windows','Windows')}${row('mac','macOS')}${row('linux','Linux')}</tbody>
-      <tfoot><tr><td colspan="3" class="gm-plat-foot">Dates from Steam depot manifests (PICS). Community report dates live in the game's report cards, not here.</td></tr></tfoot>
+      <tfoot><tr><td colspan="3" class="gm-plat-foot">Dates from Steam depot manifests (PICS). ${
+        newsInfo?.found && newsInfo.newest_ts
+          ? `App-wide 'Last patch note' below (${esc(new Date(newsInfo.newest_ts * 1000).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }))}) is the public-API fallback when a specific OS row shows 'pending'.`
+          : ''
+      } Community report dates live in the game's report cards, not here.</td></tr></tfoot>
     </table>`;
   };
   // System requirements: fold into one collapsible block per OS. Text is
@@ -367,6 +376,16 @@ async function _openMetadataModal(appId) {
       ? `<a href="${esc(meta.website)}" target="_blank" rel="noopener">${esc(meta.website)} -&gt;</a>` : ''),
     section('Content notes', meta.contentDescriptors.length
       ? list(meta.contentDescriptors) : ''),
+    section('Last patch note',
+      newsInfo?.found && newsInfo.items?.length
+        ? (() => {
+            const it = newsInfo.items[0];
+            const d = it.date ? new Date(it.date * 1000) : null;
+            const dstr = d ? d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }) : '';
+            return `<span class="gm-depot-date" title="Most recent ISteamNews entry -- a public 'last updated' signal that works even when the PICS depot cache is empty">${esc(dstr)}</span>
+                <div class="gm-mute" style="margin-top:2px">${esc(it.title || '')}</div>${it.url ? ` <a href="${esc(it.url)}" target="_blank" rel="noopener">news post -&gt;</a>` : ''}`;
+          })()
+        : ''),
   ].join('') + `
     <div class="gm-raw-wrap">
       <button type="button" class="gm-raw-toggle" id="gm-raw-toggle" aria-expanded="false">Show raw appdetails JSON</button>

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=1b8ae722';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=003f23c0';
-import { renderGamePage } from './game-page.js?v=9eb6ee34';
+import { renderGamePage } from './game-page.js?v=14a4ee6e';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId, fetchDataWithProdFallback } from '../config.js?v=f9591262';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=c7e1268c';
 import { renderGameCard } from '../lib/card.js?v=5642a459';

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,6 +1,6 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=9eb6ee34';
+import { renderGamePage } from './components/game-page.js?v=14a4ee6e';
 import { renderHomePage } from './components/home.js?v=1aa3e1ab';
 import { renderSearchPage } from './components/search.js?v=598aaad1';
 

--- a/js/submit/main.js
+++ b/js/submit/main.js
@@ -1,7 +1,7 @@
 // Entry module for submit.html. Migrated from the page's inline script.
 import { FAULT_KEYS_WEB } from '../shared/scoring.js?v=1b8ae722';
 import { applyDraftSnapshot, populateSubmitForm, prefillSubmitFormFromMyHardware, renderVerifiedOwnerStatus, setRunTypeNativeAvailable, submitReport } from '../shared/submit.js?v=339c68ea';
-import { fetchLinuxNativeSupport } from '../app/api/deck-status.js?v=c5df5310';
+import { fetchLinuxNativeSupport } from '../app/api/deck-status.js?v=09d5c67e';
 import { deleteDraft, getDraft, snapshotFormData, upsertDraft } from '../shared/drafts.js?v=da9caf1e';
 import { SupaAuth } from '../shared/config.js?v=f6f2c00a';
 import { appIdToDir } from '../lib/app-id.js?v=18a73fb7';

--- a/scripts/pipeline/steam_metadata.py
+++ b/scripts/pipeline/steam_metadata.py
@@ -176,16 +176,62 @@ def parse_app_info(text: str) -> dict | None:
     return None
 
 
+def _branch_timeupdated(depots: dict, branch: str = "public") -> int:
+    """Read `depots.branches.<branch>.timeupdated` -- the app-level 'when
+    was this branch last updated' timestamp. PICS puts the branch info
+    at the SAME LEVEL as the depot IDs inside the depots dict; the
+    depot dicts themselves do not carry a per-depot timestamp in
+    app_info_print output (SteamKit / ValvePython/steam / patchforge
+    all read the branch-level timeupdated for the per-app 'last update'
+    signal). Individual depot manifest timestamps live in the depot
+    manifest headers -- fetching those requires a separate PICS call
+    per depot which we skip for now.
+    """
+    if not isinstance(depots, dict):
+        return 0
+    branches = depots.get("branches")
+    if not isinstance(branches, dict):
+        return 0
+    entry = branches.get(branch)
+    if not isinstance(entry, dict):
+        return 0
+    ts = entry.get("timeupdated")
+    try:
+        return int(ts) if ts is not None else 0
+    except (TypeError, ValueError):
+        return 0
+
+
 def extract_depot_rows(app_id: int, parsed: dict) -> list[DepotRow]:
     """Turn a parsed app_info dict into normalized DepotRow entries. One
-    row per (depot_id, os) pair. Depots that carry an oslist we do not
-    recognize get filed under 'other' so we can surface them if useful.
+    row per (depot_id, os) pair.
+
+    Data source shape (matches SteamKit / ValvePython/steam / patchforge):
+        depots.<depotId>.config.oslist         -> which OS this depot ships
+        depots.<depotId>.manifests.public.gid  -> current manifest id
+        depots.branches.public.timeupdated     -> app-level last-updated
+
+    Individual depots do NOT carry a per-depot timestamp in the PICS
+    app_info dump; the branch-level timeupdated is the shared 'this app
+    last got a public update at this time' signal (same value SteamDB
+    displays on the depot page's Last Update column when no per-depot
+    manifest fetch has run).
+
+    Depots that carry an oslist we do not recognize get filed under
+    'other' so we can surface them if useful. Depots with no oslist
+    are language/shared data -- skipped.
     """
     if not isinstance(parsed, dict):
         return []
     depots = parsed.get("depots") or {}
+    if not isinstance(depots, dict):
+        return []
     common = parsed.get("common") or {}
     app_name = common.get("name") if isinstance(common, dict) else None
+    # Public branch timeupdated is the shared last-update timestamp for
+    # every OS-tagged depot; the depot dict itself has no timestamp.
+    branch_ts = _branch_timeupdated(depots, "public")
+
     out: list[DepotRow] = []
     for depot_id, depot in depots.items():
         if not depot_id.isdigit():
@@ -202,21 +248,26 @@ def extract_depot_rows(app_id: int, parsed: dict) -> list[DepotRow]:
             if part.strip()
         }
         if not oses:
-            # A depot with no oslist usually ships common data (localization,
-            # shaders). Skip -- it is not tied to any OS build.
+            # A depot with no oslist usually ships localization / shared
+            # data. Skip -- it is not tied to any OS build.
             continue
-        # Newest manifest wins. PICS carries manifests[<branch>].timeupdated;
-        # public branch is what non-beta users install.
+        # A per-depot manifests.public.timeupdated wins if it exists (rare;
+        # SteamPipe leaves this field off on most published apps), then
+        # fall back to the branch-level timestamp which every OS depot
+        # inherits.
         manifests = depot.get("manifests") if isinstance(depot.get("manifests"), dict) else {}
         public    = manifests.get("public") if isinstance(manifests.get("public"), dict) else {}
-        ts = public.get("timeupdated")
+        depot_ts_raw = public.get("timeupdated") if isinstance(public, dict) else None
         try:
-            ts_int = int(ts) if ts is not None else 0
+            depot_ts = int(depot_ts_raw) if depot_ts_raw is not None else 0
         except (TypeError, ValueError):
-            ts_int = 0
+            depot_ts = 0
+        ts_int = depot_ts if depot_ts > 0 else branch_ts
         if ts_int <= 0:
             continue
-        manifest_id = public.get("gid") or public.get("manifest") or None
+        manifest_id = None
+        if isinstance(public, dict):
+            manifest_id = public.get("gid") or public.get("manifest")
         depot_name = depot.get("name") or app_name
         for os_key in oses:
             out.append(DepotRow(

--- a/scripts/pipeline/steam_metadata.py
+++ b/scripts/pipeline/steam_metadata.py
@@ -362,7 +362,22 @@ def fetch_and_store(app_id: int, sleep_between: float = 3.0) -> tuple[str, int]:
         return "no_public_manifest", 0
     rows = extract_depot_rows(app_id, parsed)
     if not rows:
-        log(f"steam-metadata: app={app_id} parsed but no rows -- depots={list((parsed.get('depots') or {}).keys())[:8]}")
+        depots = parsed.get("depots") or {}
+        depot_keys = list(depots.keys())[:8]
+        log(f"steam-metadata: app={app_id} parsed but no rows -- depots={depot_keys}")
+        # Dump the shape of the first numerically-keyed depot dict so the
+        # workflow log tells us EXACTLY what fields PICS returned. My
+        # sample data assumed depot.config.oslist + depot.manifests.public
+        # .timeupdated; if real PICS uses different field names or nesting
+        # we will see it here without needing to add steamcmd to Termux.
+        first_num_key = next((k for k in depots.keys() if k.isdigit()), None)
+        if first_num_key:
+            sample = depots.get(first_num_key)
+            try:
+                sample_json = json.dumps(sample, sort_keys=True)[:1500]
+            except (TypeError, ValueError):
+                sample_json = str(sample)[:1500]
+            log(f"steam-metadata: app={app_id} sample_depot={first_num_key} shape={sample_json}")
         upsert_fetch_status(app_id, "no_public_manifest", 0, "parsed appinfo but no OS-bound depot rows")
         return "no_public_manifest", 0
     n = upsert_depot_rows(rows)

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -31,6 +31,9 @@ verify_jwt = false
 [functions.steam-depot-info]
 verify_jwt = false
 
+[functions.steam-news]
+verify_jwt = false
+
 [functions.image-refetch]
 verify_jwt = false
 

--- a/supabase/functions/steam-news/index.ts
+++ b/supabase/functions/steam-news/index.ts
@@ -1,0 +1,85 @@
+// steam-news: CORS proxy for ISteamNews/GetNewsForApp.
+//
+// This is our "when was the game last updated" fallback for apps that
+// the steamcmd PICS pipeline (#215) has not cached yet. The Steamworks
+// Web API endpoint is public HTTP but does not send an
+// Access-Control-Allow-Origin header to third-party origins, so a
+// direct browser fetch is blocked. This function forwards the request
+// server-side and re-serves it with an open CORS header + 10 min cache.
+//
+// Trade-offs the caller should know about (Metadata modal is the main
+// consumer):
+//   - This surfaces the most recent patch note timestamp, not a
+//     per-OS depot manifest date. Devs who skip news for silent patches
+//     leave a gap.
+//   - No first-seen date. That data only exists in PICS.
+//
+// The steamcmd pipeline still wins when it has data for the app; the
+// modal only falls through to this endpoint on a PICS cache miss.
+//
+// Public (verify_jwt = false). #219 filed for a longer-term SteamKit
+// listener that would eliminate the fallback entirely.
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+};
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders });
+
+  const url = new URL(req.url);
+  const appId = (url.searchParams.get("appId") || "").trim();
+  if (!/^\d+$/.test(appId)) {
+    return Response.json(
+      { error: "appId must be a numeric Steam app ID" },
+      { status: 400, headers: corsHeaders },
+    );
+  }
+  const count = Math.max(1, Math.min(20, Number(url.searchParams.get("count") || "5") | 0));
+  const maxlength = Math.max(0, Math.min(2000, Number(url.searchParams.get("maxlength") || "300") | 0));
+
+  const upstream = `https://api.steampowered.com/ISteamNews/GetNewsForApp/v2/?appid=${appId}&count=${count}&maxlength=${maxlength}`;
+  try {
+    const r = await fetch(upstream, { headers: { Accept: "application/json" } });
+    if (!r.ok) {
+      console.log(`[steam-news] appId=${appId} upstream=${r.status} source=steam-news-error`);
+      return Response.json(
+        { appId, found: false, error: `Steam upstream ${r.status}` },
+        { status: 502, headers: corsHeaders },
+      );
+    }
+    const body = await r.json();
+    const items = Array.isArray(body?.appnews?.newsitems) ? body.appnews.newsitems : [];
+    if (items.length === 0) {
+      console.log(`[steam-news] appId=${appId} found=false source=steam-news-empty`);
+      return Response.json(
+        { appId, found: false, items: [] },
+        { status: 200, headers: { ...corsHeaders, "Cache-Control": "public, max-age=600" } },
+      );
+    }
+    // Reshape to the compact shape the Metadata modal wants.
+    const compact = items.map((it: Record<string, unknown>) => ({
+      title:      it.title      ?? null,
+      url:        it.url        ?? null,
+      author:     it.author     ?? null,
+      date:       typeof it.date === "number" ? it.date : null,
+      feedlabel:  it.feedlabel  ?? null,
+      contents:   typeof it.contents === "string" ? String(it.contents).slice(0, 400) : null,
+    }));
+    const newest = compact[0]?.date ?? null;
+    console.log(`[steam-news] appId=${appId} count=${compact.length} newest=${newest} source=steam-news-ok`);
+    return Response.json(
+      { appId, found: true, items: compact, newest_ts: newest },
+      { status: 200, headers: { ...corsHeaders, "Cache-Control": "public, max-age=600" } },
+    );
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.error(`[steam-news] appId=${appId} error=${msg} url=${upstream}`);
+    return Response.json(
+      { appId, found: false, error: msg },
+      { status: 502, headers: corsHeaders },
+    );
+  }
+});

--- a/tests/test_steam_metadata.py
+++ b/tests/test_steam_metadata.py
@@ -215,6 +215,109 @@ class TestRunnerAvailability:
         assert steam_metadata.steamcmd_available() is False
 
 
+class TestRunnerCommandShape:
+    """Regression guards on the steamcmd command line. PR #220 added
+    +app_info_request + +delay so a fresh runner actually pulls PICS
+    instead of reading the empty local cache. If any of these tokens
+    go missing the seed silently degrades to 'nothing to parse'."""
+
+    def _captured_cmd(self, monkeypatch, app_id=367520):
+        captured = {}
+        class FakeProc:
+            returncode = 0; stdout = ""; stderr = ""
+        def fake_run(cmd, **kw):
+            captured["cmd"] = cmd
+            captured["kw"] = kw
+            return FakeProc()
+        monkeypatch.setattr(steam_metadata.shutil, "which", lambda name: "/fake/steamcmd")
+        monkeypatch.setattr(steam_metadata.subprocess, "run", fake_run)
+        steam_metadata.run_steamcmd_app_info(app_id)
+        return captured
+
+    def test_uses_anonymous_login(self, monkeypatch):
+        cmd = self._captured_cmd(monkeypatch)["cmd"]
+        assert cmd[cmd.index("+login") + 1] == "anonymous"
+
+    def test_calls_app_info_request_before_print(self, monkeypatch):
+        cmd = self._captured_cmd(monkeypatch)["cmd"]
+        assert "+app_info_request" in cmd
+        assert "+app_info_print"   in cmd
+        assert cmd.index("+app_info_request") < cmd.index("+app_info_print")
+
+    def test_carries_delay_between_request_and_print(self, monkeypatch):
+        cmd = self._captured_cmd(monkeypatch)["cmd"]
+        assert "+delay" in cmd
+        delay = int(cmd[cmd.index("+delay") + 1])
+        assert delay >= 1
+
+    def test_refreshes_app_info_cache(self, monkeypatch):
+        cmd = self._captured_cmd(monkeypatch)["cmd"]
+        assert "+app_info_update" in cmd
+        assert cmd[cmd.index("+app_info_update") + 1] == "1"
+
+    def test_ends_with_quit(self, monkeypatch):
+        cmd = self._captured_cmd(monkeypatch)["cmd"]
+        assert cmd[-1] == "+quit"
+
+    def test_passes_appid_to_both_request_and_print(self, monkeypatch):
+        cmd = self._captured_cmd(monkeypatch, app_id=1234)["cmd"]
+        assert cmd[cmd.index("+app_info_request") + 1] == "1234"
+        assert cmd[cmd.index("+app_info_print")   + 1] == "1234"
+
+    def test_timeout_kwarg_is_passed_to_subprocess(self, monkeypatch):
+        kw = self._captured_cmd(monkeypatch)["kw"]
+        assert "timeout" in kw
+        assert kw["timeout"] > 0
+
+
+class TestNoManifestDiagnostics:
+    """Failed seed runs must land a useful reason in fetch_status.error
+    AND log enough context that we do not need to re-run the workflow
+    to debug the shape of what PICS returned."""
+
+    def _run(self, monkeypatch, fake_stdout):
+        monkeypatch.setattr(steam_metadata, "run_steamcmd_app_info", lambda app_id, **kw: fake_stdout)
+        status_calls, log_calls = [], []
+        monkeypatch.setattr(steam_metadata, "upsert_fetch_status",
+            lambda app_id, status, depot_count, error=None: status_calls.append((app_id, status, depot_count, error)))
+        monkeypatch.setattr(steam_metadata, "upsert_depot_rows", lambda rows: 0)
+        monkeypatch.setattr(steam_metadata, "log", lambda msg: log_calls.append(msg))
+        status, n = steam_metadata.fetch_and_store(367520)
+        return status, n, status_calls, log_calls
+
+    def test_no_appinfo_block_logs_tail_and_reason(self, monkeypatch):
+        status, n, calls, logs = self._run(monkeypatch, "Loading Steam API...OK\n(no appinfo followed)\n")
+        assert (status, n) == ("no_public_manifest", 0)
+        assert calls[0][3] and "appinfo" in calls[0][3].lower()
+        # tail must be logged so a workflow log reader sees the stdout end
+        assert any("tail=" in m for m in logs)
+
+    def test_parsed_but_zero_rows_dumps_first_depot_shape(self, monkeypatch):
+        # Parse succeeds (appinfo block + digit-keyed depot present) but
+        # extract_depot_rows returns []. The dump MUST include the depot
+        # key list AND a JSON shape sample so a future PICS field-name
+        # mismatch is self-diagnosing.
+        text = '''
+"367520"
+{
+    "common" { "name" "Sample" }
+    "depots"
+    {
+        "10"
+        {
+            "MysteryField" "PICS may nest differently than we assume"
+        }
+    }
+}
+'''
+        status, n, calls, logs = self._run(monkeypatch, text)
+        assert (status, n) == ("no_public_manifest", 0)
+        assert calls[0][3] and "no OS-bound depot rows" in calls[0][3]
+        joined = " ".join(logs)
+        assert "sample_depot=10" in joined
+        assert "MysteryField"  in joined
+
+
 class TestFetchAndStoreOffline:
     def test_no_manifest_status_when_parse_yields_no_rows(self, monkeypatch):
         """fetch_and_store should mark the app as no_public_manifest when

--- a/tests/test_steam_metadata.py
+++ b/tests/test_steam_metadata.py
@@ -13,8 +13,14 @@ from scripts.pipeline import steam_metadata
 
 
 # A trimmed but realistic steamcmd `+app_info_print 367520` payload.
-# Real output is much larger; we keep only the fields the parser cares
-# about so the test text stays readable.
+# Shape mirrors what SteamKit / ValvePython/steam / patchforge parse:
+#   depots.<depotId>.config.oslist          -> which OS the depot ships
+#   depots.<depotId>.manifests.public.gid   -> current manifest id
+#   depots.branches.public.timeupdated      -> app-level last-update ts
+# Individual depots do not carry a per-depot timeupdated in real PICS
+# app_info output; the branch-level value is what SteamDB surfaces on
+# its Depot page's Last Update column. Our first seed run against
+# Hollow Knight taught us this the hard way (parser returned 0 rows).
 SAMPLE_APPINFO = '''\
 Loading Steam API...OK
 Waiting for user info...OK
@@ -40,7 +46,6 @@ AppID : 367520, change number : 12345678
                 "public"
                 {
                     "gid"          "9876543210"
-                    "timeupdated"  "1700000000"
                 }
             }
         }
@@ -56,7 +61,6 @@ AppID : 367520, change number : 12345678
                 "public"
                 {
                     "gid"          "9876543211"
-                    "timeupdated"  "1690000000"
                 }
             }
         }
@@ -72,7 +76,6 @@ AppID : 367520, change number : 12345678
                 "public"
                 {
                     "gid"          "9876543212"
-                    "timeupdated"  "1710000000"
                 }
             }
         }
@@ -84,8 +87,15 @@ AppID : 367520, change number : 12345678
                 "public"
                 {
                     "gid"          "9876543213"
-                    "timeupdated"  "1500000000"
                 }
+            }
+        }
+        "branches"
+        {
+            "public"
+            {
+                "buildid"      "12345678"
+                "timeupdated"  "1710000000"
             }
         }
     }
@@ -153,7 +163,11 @@ class TestExtractDepotRows:
         "10"
         {
             "config" { "oslist" "windows,linux" }
-            "manifests" { "public" { "timeupdated" "1234" } }
+            "manifests" { "public" { "gid" "111" } }
+        }
+        "branches"
+        {
+            "public" { "buildid" "1" "timeupdated" "1234" }
         }
     }
 }
@@ -163,7 +177,10 @@ class TestExtractDepotRows:
         assert sorted(r.os for r in rows) == ["linux", "windows"]
         assert all(r.last_updated_at == 1234 for r in rows)
 
-    def test_skips_depot_with_missing_or_zero_timestamp(self):
+    def test_skips_depot_when_no_branch_timestamp_and_no_manifest_timestamp(self):
+        # Neither the branch (missing) nor the per-depot manifest carry a
+        # timestamp -> nothing to record. Matches the earlier zero-ts
+        # skip but reframed for the new "branch-first" fallback order.
         text = '''
 "1"
 {
@@ -173,11 +190,7 @@ class TestExtractDepotRows:
         "10"
         {
             "config" { "oslist" "linux" }
-            "manifests" { "public" { "timeupdated" "0" } }
-        }
-        "11"
-        {
-            "config" { "oslist" "linux" }
+            "manifests" { "public" { "gid" "abc" } }
         }
     }
 }
@@ -185,6 +198,32 @@ class TestExtractDepotRows:
         parsed = steam_metadata.parse_app_info(text)
         rows = steam_metadata.extract_depot_rows(1, parsed)
         assert rows == []
+
+    def test_per_depot_manifest_timestamp_wins_over_branch(self):
+        # Rare shape: some apps carry a per-depot manifests.public
+        # .timeupdated. When present, we prefer it over the branch value.
+        text = '''
+"1"
+{
+    "common" { "name" "PerDepot" }
+    "depots"
+    {
+        "10"
+        {
+            "config" { "oslist" "linux" }
+            "manifests" { "public" { "gid" "abc" "timeupdated" "5000" } }
+        }
+        "branches"
+        {
+            "public" { "buildid" "1" "timeupdated" "1000" }
+        }
+    }
+}
+'''
+        parsed = steam_metadata.parse_app_info(text)
+        rows = steam_metadata.extract_depot_rows(1, parsed)
+        assert len(rows) == 1
+        assert rows[0].last_updated_at == 5000
 
     def test_unknown_oslist_lands_in_other_bucket(self):
         text = '''
@@ -195,7 +234,11 @@ class TestExtractDepotRows:
         "10"
         {
             "config" { "oslist" "chromeos" }
-            "manifests" { "public" { "timeupdated" "1000" } }
+            "manifests" { "public" { "gid" "abc" } }
+        }
+        "branches"
+        {
+            "public" { "buildid" "1" "timeupdated" "1000" }
         }
     }
 }


### PR DESCRIPTION
Both routes to 'when was this game last updated' in one PR.

## Path B: PICS depot dates (real fix)

Root cause of the still-open no_manifest miss on Hollow Knight seed: my parser was reading `depots.<id>.manifests.public.timeupdated` but real PICS puts that value on `depots.branches.public.timeupdated` instead. Discovered by reading patchforge, SteamKit, and ValvePython/steam source (couldn't test locally -- gevent won't build on Termux ARM).

Fix in extract_depot_rows:
- New _branch_timeupdated helper reads `depots.branches.<branch>.timeupdated` (default 'public')
- For each OS-tagged depot, use per-depot manifest timeupdated when present (rare) else the branch value
- Same normalization + OS aliasing as before

Loss of precision I want to name explicitly: every OS depot on a given app shares the branch timestamp. Per-depot manifest timestamps require a separate PICS call to each manifest header -- not doing that here. For per-OS 'the Linux build shipped later than Windows' precision we'd need a follow-up.

## Path A: ISteamNews fallback (public HTTP)

New `supabase/functions/steam-news/index.ts` proxies `ISteamNews/GetNewsForApp/v2/`. Metadata modal shows a new 'Last patch note' section (date + title + link), and the OS-table footer points at that date as the fallback signal when a specific OS row shows 'pending'. Covers apps the PICS pipeline has not cached yet.

## Hardening tests

- **TestRunnerCommandShape** (7 tests) pins the 7 steamcmd tokens PR #220 added: +login anonymous, +app_info_update 1, +app_info_request, +delay >=1, +app_info_print, +quit, subprocess.timeout kwarg.
- **TestNoManifestDiagnostics** (2 tests) pins the two failure-branch contracts: 'no appinfo block' -> reason + tail log; 'parsed but zero rows' -> reason + depot key list + JSON shape sample.
- Sample appinfo fixture rewritten to match real PICS shape (branches sibling of depot IDs, no per-manifest timeupdated). New test asserts per-depot manifest timestamp WINS when both present.

## Test plan

- [ ] `python -m pytest tests/test_steam_metadata.py --no-cov` -> 22/22 green
- [ ] After merge, deploy-functions.yml publishes `steam-news`
- [ ] Re-dispatch **Steam Metadata Fetch (depot dates)** with app_ids=367520
- [ ] Verify `steam_depot_updates` gains rows for 367520 (windows + mac + linux, all sharing the branch timestamp)
- [ ] Open Metadata modal for Hollow Knight, confirm OS table shows real dates AND 'Last patch note' section shows the recent 2026-03-27 patch entry