### PR TITLE
refactor(game-page): drop redundant Native Linux hint; OS chips open Metadata

### DIFF
--- a/app.html
+++ b/app.html
@@ -17,7 +17,7 @@
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/filters.css?v=4a590596">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/app/game-header.css?v=2dc3da06">
+<link rel="stylesheet" href="css/app/game-header.css?v=8018fb80">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=6df19441">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">

--- a/confidence.html
+++ b/confidence.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=c550d77b">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/app/game-header.css?v=2dc3da06">
+<link rel="stylesheet" href="css/app/game-header.css?v=8018fb80">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=6df19441">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">

--- a/css/app/game-header.css
+++ b/css/app/game-header.css
@@ -382,10 +382,11 @@
   line-height: 1.1;
   margin-bottom: 6px;
 }
-/* "Native Linux runtime available" hint sits UNDER the box art (inside the
-   .game-header-art-col wrapper) so the header layout stays balanced. A
-   small Tux glyph precedes the copy. Clicking opens the runtime history
-   modal. */
+/* Box-art column wraps the img so its width is easy to control and future
+   overlays (badges, share buttons) have a natural home. The 'Native Linux
+   runtime available' hint that used to live here was retired -- the OS
+   chip strip at the top of the header carries the same availability
+   signal, and clicking a chip opens the Metadata modal directly. */
 .game-header-art-col {
   grid-column: 1;
   grid-row: 1;
@@ -396,22 +397,6 @@
   align-self: stretch;
 }
 .game-header-art-col .game-header-art { width: 100%; height: auto; }
-.game-native-linux {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-family: var(--mono);
-  font-size: 0.78rem;
-  font-weight: 500;
-  letter-spacing: 0.04em;
-  color: #7ed37a;
-  cursor: pointer;
-  user-select: none;
-  align-self: flex-start;
-}
-.game-native-linux .tux-icon { flex-shrink: 0; }
-.game-native-linux:hover { text-decoration: underline; }
-.game-native-linux-more { opacity: 0.7; margin-left: 4px; }
 
 /* OS availability strip: top-right of the game-header block. Three
    chips (Windows / macOS / Linux) lit up green when Steam advertises the
@@ -439,14 +424,20 @@
   font-size: 0.68rem;
   letter-spacing: 0.04em;
   opacity: 0.55;
-  transition: opacity 0.15s, color 0.15s, border-color 0.15s;
+  cursor: pointer;
+  transition: opacity 0.15s, color 0.15s, border-color 0.15s, background 0.15s;
 }
 .game-os-chip svg { display: block; }
+.game-os-chip:hover { border-color: var(--accent); }
 .game-os-chip--on {
   opacity: 1;
   color: #7ed37a;
   border-color: rgba(126,211,122,0.55);
   background: rgba(126,211,122,0.08);
+}
+.game-os-chip--on:hover {
+  border-color: rgba(126,211,122,0.9);
+  background: rgba(126,211,122,0.16);
 }
 [data-theme="light"] .game-os-chip--on { color: #256b25; }
 @media (max-width: 720px) {

--- a/game-stats.html
+++ b/game-stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=c550d77b">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/app/game-header.css?v=2dc3da06">
+<link rel="stylesheet" href="css/app/game-header.css?v=8018fb80">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=6df19441">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -915,23 +915,22 @@ export async function renderGamePage(appId) {
         ${replacedBanner}
         <div class="game-title">${esc(title)} <span class="game-title-store" title="Storefront this entry maps to">(${esc(storeLabelFromAppId(appId) || 'Steam')})</span>${isDelisted ? ' <span class="game-detail-delisted" title="Removed from the Steam store. Reports still apply -- people still own this via family share, backups, or regional accounts.">DELISTED</span>' : ''}${replacedBy ? ` <span class="game-title-replaced-pill" title="Replaced by app ${esc(replacedBy)}: ${esc(replacedByTitle)}">REPLACED</span>` : ''}${/\bdemo\b/i.test(title) ? ' <span class="game-title-demo-pill" title="This entry looks like a demo based on the title. Reports may not reflect the full game.">DEMO</span>' : ''}</div>
         <div class="game-os-strip" id="game-os-strip" hidden aria-label="Supported operating systems">
-          <span class="game-os-chip" data-os="windows" title="Windows">
+          <button type="button" class="game-os-chip" data-os="windows" title="Windows">
             <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M3 5.5L10 4.5V11H3V5.5zm8-1.2L21 3v8H11V4.3zM3 12h7v6.5L3 17.5V12zm8 0h10v9L11 19.5V12z"/></svg>
             <span>Win</span>
-          </span>
-          <span class="game-os-chip" data-os="mac" title="macOS">
+          </button>
+          <button type="button" class="game-os-chip" data-os="mac" title="macOS">
             <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M17.5 12.5c0-2.6 2.1-3.9 2.2-4-1.2-1.8-3.1-2-3.8-2.1-1.6-.2-3.1.9-3.9.9-.8 0-2.1-.9-3.4-.9-1.8 0-3.4 1-4.3 2.6-1.8 3.2-.5 7.9 1.3 10.5.9 1.3 2 2.7 3.4 2.6 1.4 0 1.9-.9 3.6-.9 1.7 0 2.1.9 3.5.9 1.5 0 2.4-1.3 3.3-2.6 1-1.5 1.4-2.9 1.4-3-.1 0-2.7-1-2.7-4zM14.5 4.7c.7-.9 1.2-2.1 1-3.3-1.1.1-2.4.8-3.1 1.6-.7.8-1.3 2-1.1 3.2 1.2.1 2.4-.6 3.2-1.5z"/></svg>
             <span>macOS</span>
-          </span>
-          <span class="game-os-chip" data-os="linux" title="Linux">
+          </button>
+          <button type="button" class="game-os-chip" data-os="linux" title="Linux">
             <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M12 2c-1.66 0-3 1.34-3 3v3.5c-1.5 1-3 2.5-3 5.5 0 2.5 1 4.5 2 5.5.5.5 1 1 1 2v.5h6V21c0-1 .5-1.5 1-2 1-1 2-3 2-5.5 0-3-1.5-4.5-3-5.5V5c0-1.66-1.34-3-3-3zm-1.5 5c.28 0 .5.22.5.5s-.22.5-.5.5-.5-.22-.5-.5.22-.5.5-.5zm3 0c.28 0 .5.22.5.5s-.22.5-.5.5-.5-.22-.5-.5.22-.5.5-.5zM12 11l-1.5 2h3L12 11z"/></svg>
             <span>Linux</span>
-          </span>
+          </button>
         </div>
         <div class="game-header-grid">
           <div class="game-header-art-col">
             <img class="game-header-art" src="${STEAM_IMG(appId)}" data-appid="${appId}" alt="" onerror="window.__steamImgLoad(this)">
-            <div class="game-native-linux" id="game-native-linux" hidden></div>
           </div>
           ${ratingPanel}
           <div class="game-header-actions">
@@ -1274,35 +1273,17 @@ export async function renderGamePage(appId) {
             const on = !!platforms[key];
             chip.classList.toggle('game-os-chip--on', on);
             const label = { windows: 'Windows', mac: 'macOS', linux: 'Linux' }[key] || key;
-            chip.title = on ? `${label}: available` : `${label}: not offered by Steam`;
+            chip.title = on
+              ? `${label}: available. Click for metadata (developer, publisher, per-OS depot dates).`
+              : `${label}: not offered by Steam`;
+            // The chips are the click affordance for the Metadata modal
+            // now that the redundant 'Native Linux runtime available' hint
+            // has been retired -- the green Linux chip conveys the same
+            // availability signal, and the click matches the mental model
+            // of 'tell me more about this OS'.
+            chip.addEventListener('click', () => _openMetadataModal(appId));
           }
         }
-      }
-      // Reveal the "Native Linux runtime" hint under the box art only when
-      // Steam says yes. Absence is treated as "we don't know" so a Steam
-      // API blip doesn't look like a downgrade. Clicking opens the
-      // per-runtime version-history table.
-      const nativeEl = el.querySelector('#game-native-linux');
-      if (nativeEl && hasLinuxNative) {
-        nativeEl.innerHTML = `
-          <svg class="tux-icon" viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true">
-            <path d="M12 2c-1.66 0-3 1.34-3 3v3.5c-1.5 1-3 2.5-3 5.5 0 2.5 1 4.5 2 5.5.5.5 1 1 1 2v.5h6V21c0-1 .5-1.5 1-2 1-1 2-3 2-5.5 0-3-1.5-4.5-3-5.5V5c0-1.66-1.34-3-3-3zm-1.5 5c.28 0 .5.22.5.5s-.22.5-.5.5-.5-.22-.5-.5.22-.5.5-.5zm3 0c.28 0 .5.22.5.5s-.22.5-.5.5-.5-.22-.5-.5.22-.5.5-.5zM12 11l-1.5 2h3L12 11z"/>
-          </svg>
-          Native Linux runtime available
-          <span class="game-native-linux-more">(metadata)</span>`;
-        // Clicking the hint opens the Metadata modal (where per-OS depot
-        // dates live once the #215 pipeline caches them) instead of the
-        // community-report runtime-history table. The two data sources
-        // measure different things (Steam depots vs Pulse/ProtonDB
-        // reports) and the earlier wiring was mixing them up.
-        nativeEl.title = 'Steam advertises a native Linux binary. Click to see the full metadata (developer, publisher, per-OS depot dates).';
-        nativeEl.hidden = false;
-        nativeEl.setAttribute('role', 'button');
-        nativeEl.tabIndex = 0;
-        nativeEl.addEventListener('click', () => _openMetadataModal(appId));
-        nativeEl.addEventListener('keydown', (e) => {
-          if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); _openMetadataModal(appId); }
-        });
       }
       // update deck status button icon + modal
       const deckBtn = el.querySelector('#deck-status-btn');

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=1b8ae722';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=003f23c0';
-import { renderGamePage } from './game-page.js?v=14a4ee6e';
+import { renderGamePage } from './game-page.js?v=7c25e8fe';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId, fetchDataWithProdFallback } from '../config.js?v=f9591262';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=c7e1268c';
 import { renderGameCard } from '../lib/card.js?v=5642a459';

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,6 +1,6 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=14a4ee6e';
+import { renderGamePage } from './components/game-page.js?v=7c25e8fe';
 import { renderHomePage } from './components/home.js?v=1aa3e1ab';
 import { renderSearchPage } from './components/search.js?v=598aaad1';
 

--- a/submit.html
+++ b/submit.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=c550d77b">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/app/game-header.css?v=2dc3da06">
+<link rel="stylesheet" href="css/app/game-header.css?v=8018fb80">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=6df19441">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">

--- a/tests/runtimeHistoryModal.test.js
+++ b/tests/runtimeHistoryModal.test.js
@@ -1,15 +1,12 @@
 /**
- * The runtime-history modal is opened by clicking the Native Linux hint on
- * the game page. Rather than pulling in jsdom + the full game-page render
- * we assert the source contains the aggregation invariants that drive it:
- *   - groups by run_type (unknown for legacy null rows)
- *   - counts reports per runtime
- *   - tracks first-seen (min timestamp) + last-updated (max)
- *   - orders canonical runtimes first, unknown last
+ * The runtime-history modal still exists (aggregates community reports
+ * by runtime type) but is no longer wired to the retired Native Linux
+ * hint. Kept here as a source-shape regression guard on the aggregation
+ * so a future refactor cannot silently break the report-timing view.
  *
- * Regression guards on the SQL-ish shape stay in a source-string test
- * because the aggregation lives inline in the game-page module (no
- * import surface to unit test directly).
+ * The Native Linux hint under the artwork was removed as redundant with
+ * the OS chip strip up top; the chips now carry the click affordance for
+ * the Metadata modal.
  */
 
 const fs = require('fs');
@@ -19,11 +16,15 @@ const SRC = fs.readFileSync(
   path.join(__dirname, '..', 'js', 'app', 'components', 'game-page.js'), 'utf8');
 
 describe('runtime history modal (game-page)', () => {
-  test('module exposes _openRuntimeHistoryModal wired from the native badge', () => {
-    // Native badge triggers the modal on click AND on Enter/Space (a11y).
-    expect(SRC).toMatch(/_openRuntimeHistoryModal\(appId, combined\)/);
-    expect(SRC).toMatch(/nativeEl\.addEventListener\('click'/);
-    expect(SRC).toMatch(/nativeEl\.addEventListener\('keydown'/);
+  test('module still defines _openRuntimeHistoryModal even though the native hint is gone', () => {
+    expect(SRC).toMatch(/function _openRuntimeHistoryModal\(appId, combined\)/);
+  });
+
+  test('OS chip strip is the click affordance for the Metadata modal (replaces the retired Native hint)', () => {
+    // Each OS chip now opens the metadata modal; the old .game-native-linux
+    // wiring was redundant with the availability chips.
+    expect(SRC).not.toMatch(/nativeEl\.addEventListener\('click'/);
+    expect(SRC).toMatch(/chip\.addEventListener\('click', \(\) => _openMetadataModal\(appId\)\)/);
   });
 
   test('aggregation buckets on r.runType and falls back to "unknown"', () => {


### PR DESCRIPTION
Small UX cleanup: the 'Native Linux runtime available (metadata)' hint under the box art was redundant with the green Linux chip in the OS strip up top. Same signal, two visual sources -> noise. Retires the hint and moves the click affordance onto the OS chips themselves.

## Changes

- OS chips (Win / macOS / Linux) become <button>s instead of <span>s so keyboard focus works
- Each chip opens the Metadata modal on click; tooltip explains what a click reveals
- Hover state on chips so they look interactive
- Drops the .game-native-linux DIV, CSS block, Tux SVG, and (metadata) suffix span
- runtimeHistoryModal.test.js updated: asserts the new chip click wiring is present and the old native-hint wiring is gone

## Test plan

- [ ] make pre-push -> 1492 passed
- [ ] After merge, hard-refresh /app/#/app/367520: expect the OS chip row up top with the green Linux chip clickable to open the Metadata modal; expect NO 'Native Linux runtime available' line under the artwork