### PR TITLE
feat(pipeline): manifest observation history for real per-OS depot dates (closes #226)

### DIFF
--- a/app.html
+++ b/app.html
@@ -17,7 +17,7 @@
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/filters.css?v=4a590596">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/app/game-header.css?v=dbecc5e0">
+<link rel="stylesheet" href="css/app/game-header.css?v=68a12cde">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=6df19441">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">

--- a/app.html
+++ b/app.html
@@ -17,7 +17,7 @@
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/filters.css?v=4a590596">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/app/game-header.css?v=8018fb80">
+<link rel="stylesheet" href="css/app/game-header.css?v=dbecc5e0">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=6df19441">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">

--- a/confidence.html
+++ b/confidence.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=c550d77b">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/app/game-header.css?v=dbecc5e0">
+<link rel="stylesheet" href="css/app/game-header.css?v=68a12cde">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=6df19441">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">

--- a/confidence.html
+++ b/confidence.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=c550d77b">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/app/game-header.css?v=8018fb80">
+<link rel="stylesheet" href="css/app/game-header.css?v=dbecc5e0">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=6df19441">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">

--- a/css/app/game-header.css
+++ b/css/app/game-header.css
@@ -1357,6 +1357,11 @@
 /* Real depot dates from the #215 PICS cache -- render in mono so they
    line up under the "Last update" column heading. */
 .gm-depot-date { font-family: var(--mono); color: var(--text); }
+/* Italic + dimmer variant means the value fell back to the branch-level
+   PICS timestamp because the observation history (#226) has not recorded
+   a manifest_id change for this app yet. Both First seen and Last update
+   read the same value in that state -- tooltip explains. */
+.gm-depot-date--approx { font-style: italic; color: var(--muted); }
 .gm-plat-foot {
   padding-top: 6px !important;
   font-size: 0.68rem;

--- a/css/app/game-header.css
+++ b/css/app/game-header.css
@@ -441,12 +441,14 @@
 }
 [data-theme="light"] .game-os-chip--on { color: #256b25; }
 @media (max-width: 720px) {
-  /* Below the title area, above the grid, and full-width flex so all three
-     chips are visible without covering the title. */
+  /* Below the title area, above the grid. Left-align so the row starts
+     under the title instead of hugging the right edge -- overflow /
+     wrap looks intentional this way rather than crammed. */
   .game-os-strip {
     position: static;
     margin-bottom: 6px;
-    justify-content: flex-end;
+    justify-content: flex-start;
+    flex-wrap: wrap;
   }
 }
 .game-native-linux::before {

--- a/game-stats.html
+++ b/game-stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=c550d77b">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/app/game-header.css?v=dbecc5e0">
+<link rel="stylesheet" href="css/app/game-header.css?v=68a12cde">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=6df19441">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">

--- a/game-stats.html
+++ b/game-stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=c550d77b">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/app/game-header.css?v=8018fb80">
+<link rel="stylesheet" href="css/app/game-header.css?v=dbecc5e0">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=6df19441">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -288,31 +288,34 @@ async function _openMetadataModal(appId) {
     const row = (key, label) => {
       const on = !!p[key];
       const cached = dOs[key];
-      const firstFmt = fmtDate(cached?.first_seen);
-      const lastFmt  = fmtDate(cached?.last_updated);
-      let firstCell;
-      if (!on) firstCell = '<span class="gm-mute">not offered</span>';
-      else if (firstFmt) firstCell = `<span class="gm-depot-date" title="Earliest depot manifest seen in Steam PICS">${esc(firstFmt)}</span>`;
-      else firstCell = '<span class="gm-mute" title="Not cached yet -- pipeline #215 populates this nightly">pending</span>';
+      const lastFmt = fmtDate(cached?.last_updated);
+      let depotsCell;
       let lastCell;
-      if (!on) lastCell = '-';
-      else if (lastFmt) lastCell = `<span class="gm-depot-date" title="From Steam PICS (${cached.depots} depot${cached.depots === 1 ? '' : 's'} tracked)">${esc(lastFmt)}</span>`;
-      else lastCell = `<a class="gm-depot-link" href="https://steamdb.info/app/${esc(meta.appId)}/depots/" target="_blank" rel="noopener">SteamDB -&gt;</a>`;
+      if (!on) {
+        depotsCell = '<span class="gm-mute">not offered</span>';
+        lastCell   = '-';
+      } else if (lastFmt) {
+        depotsCell = `<span class="gm-mute">${cached.depots} tracked</span>`;
+        lastCell   = `<span class="gm-depot-date" title="Branch-level timeupdated from PICS -- every OS depot on a shared branch inherits this value. Per-OS 'First seen' requires observation history (#226).">${esc(lastFmt)}</span>`;
+      } else {
+        depotsCell = '<span class="gm-mute" title="Not cached yet -- pipeline #215 populates this nightly">pending</span>';
+        lastCell   = `<a class="gm-depot-link" href="https://steamdb.info/app/${esc(meta.appId)}/depots/" target="_blank" rel="noopener">SteamDB -&gt;</a>`;
+      }
       return `
         <tr>
           <td><span class="gm-plat${on ? ' gm-plat--on' : ''}">${esc(label)}</span></td>
-          <td>${firstCell}</td>
+          <td>${depotsCell}</td>
           <td>${lastCell}</td>
         </tr>`;
     };
     return `<table class="gm-plat-table">
-      <thead><tr><th>OS</th><th>First seen</th><th>Last update</th></tr></thead>
+      <thead><tr><th>OS</th><th>Depots</th><th>Last update</th></tr></thead>
       <tbody>${row('windows','Windows')}${row('mac','macOS')}${row('linux','Linux')}</tbody>
-      <tfoot><tr><td colspan="3" class="gm-plat-foot">Dates from Steam depot manifests (PICS). ${
+      <tfoot><tr><td colspan="3" class="gm-plat-foot">Last update is the branch-level timestamp from PICS -- every OS depot on the same branch shares one value. Per-OS 'first seen' needs observation history (#226). ${
         newsInfo?.found && newsInfo.newest_ts
-          ? `App-wide 'Last patch note' below (${esc(new Date(newsInfo.newest_ts * 1000).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }))}) is the public-API fallback when a specific OS row shows 'pending'.`
+          ? `App-wide 'Last patch note' (${esc(new Date(newsInfo.newest_ts * 1000).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }))}) below is the public-API fallback when a specific OS row shows 'pending'.`
           : ''
-      } Community report dates live in the game's report cards, not here.</td></tr></tfoot>
+      }</td></tr></tfoot>
     </table>`;
   };
   // System requirements: fold into one collapsible block per OS. Text is

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -280,38 +280,55 @@ async function _openMetadataModal(appId) {
       if (Number.isNaN(d.getTime())) return null;
       return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
     };
-    // First seen + Last update ONLY come from the steamcmd depot cache
-    // (steam_depot_updates via #215). We deliberately do NOT fall through
-    // to the app-wide release date -- that used to be shown here and
-    // confused viewers into thinking it was per-OS depot data, which it
-    // is not. Release date has its own row above the table.
+    // Two possible sources per OS (see supabase/functions/steam-depot-info):
+    //   source='history'         -> Phase 2 observation table (#226).
+    //     first_seen  = MIN(first_observed_at) over manifest_ids we have
+    //                  ever seen for this (app, os). Real per-OS tracking
+    //                  floor -- 'we started watching this on X'.
+    //     last_updated = MAX(first_observed_at) -- last time a new
+    //                  manifest_id was observed = last shipped build.
+    //   source='branch-fallback' -> only Phase 1 data; first_seen ==
+    //     last_updated because both read from the shared branch-level
+    //     PICS timestamp.
+    // Tooltip on the date cell tells the truth about which source the
+    // number came from so users are not misled by a fallback value.
     const row = (key, label) => {
       const on = !!p[key];
       const cached = dOs[key];
-      const lastFmt = fmtDate(cached?.last_updated);
-      let depotsCell;
-      let lastCell;
+      const firstFmt = fmtDate(cached?.first_seen);
+      const lastFmt  = fmtDate(cached?.last_updated);
+      const isHistory = cached?.source === 'history';
+      let depotsCell, firstCell, lastCell;
       if (!on) {
         depotsCell = '<span class="gm-mute">not offered</span>';
+        firstCell  = '-';
         lastCell   = '-';
-      } else if (lastFmt) {
-        depotsCell = `<span class="gm-mute">${cached.depots} tracked</span>`;
-        lastCell   = `<span class="gm-depot-date" title="Branch-level timeupdated from PICS -- every OS depot on a shared branch inherits this value. Per-OS 'First seen' requires observation history (#226).">${esc(lastFmt)}</span>`;
+      } else if (firstFmt && lastFmt) {
+        const depotCountLbl = `${cached.depots} tracked${isHistory && cached.manifests ? ` &middot; ${cached.manifests} manifest${cached.manifests === 1 ? '' : 's'} in history` : ''}`;
+        depotsCell = `<span class="gm-mute">${depotCountLbl}</span>`;
+        firstCell = isHistory
+          ? `<span class="gm-depot-date" title="Earliest date we observed a manifest for this OS depot. Not necessarily when the depot was created -- our observation window starts July 2026 (#226).">${esc(firstFmt)}</span>`
+          : `<span class="gm-depot-date gm-depot-date--approx" title="Branch-level PICS timestamp -- observation history not yet populated for this app. Once nightly runs record a manifest_id change we can show a real per-OS first_seen.">${esc(firstFmt)}</span>`;
+        lastCell = isHistory
+          ? `<span class="gm-depot-date" title="Most recent manifest_id observation -- proxy for 'this OS build shipped'. From steam_depot_manifest_history (#226).">${esc(lastFmt)}</span>`
+          : `<span class="gm-depot-date gm-depot-date--approx" title="Branch-level PICS timestamp -- same value across all OS depots on this branch until observation history is populated.">${esc(lastFmt)}</span>`;
       } else {
         depotsCell = '<span class="gm-mute" title="Not cached yet -- pipeline #215 populates this nightly">pending</span>';
+        firstCell  = '-';
         lastCell   = `<a class="gm-depot-link" href="https://steamdb.info/app/${esc(meta.appId)}/depots/" target="_blank" rel="noopener">SteamDB -&gt;</a>`;
       }
       return `
         <tr>
           <td><span class="gm-plat${on ? ' gm-plat--on' : ''}">${esc(label)}</span></td>
           <td>${depotsCell}</td>
+          <td>${firstCell}</td>
           <td>${lastCell}</td>
         </tr>`;
     };
     return `<table class="gm-plat-table">
-      <thead><tr><th>OS</th><th>Depots</th><th>Last update</th></tr></thead>
+      <thead><tr><th>OS</th><th>Depots</th><th>First seen</th><th>Last update</th></tr></thead>
       <tbody>${row('windows','Windows')}${row('mac','macOS')}${row('linux','Linux')}</tbody>
-      <tfoot><tr><td colspan="3" class="gm-plat-foot">Last update is the branch-level timestamp from PICS -- every OS depot on the same branch shares one value. Per-OS 'first seen' needs observation history (#226). ${
+      <tfoot><tr><td colspan="4" class="gm-plat-foot">'First seen' and 'Last update' come from our own manifest observation history (#226). Dates in italics are the pre-history branch-level timestamp (same value for both cells) until nightly runs record a manifest change. ${
         newsInfo?.found && newsInfo.newest_ts
           ? `App-wide 'Last patch note' (${esc(new Date(newsInfo.newest_ts * 1000).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }))}) below is the public-API fallback when a specific OS row shows 'pending'.`
           : ''

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=1b8ae722';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=003f23c0';
-import { renderGamePage } from './game-page.js?v=5a0c3324';
+import { renderGamePage } from './game-page.js?v=ab28f71b';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId, fetchDataWithProdFallback } from '../config.js?v=f9591262';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=c7e1268c';
 import { renderGameCard } from '../lib/card.js?v=5642a459';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=1b8ae722';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=003f23c0';
-import { renderGamePage } from './game-page.js?v=7c25e8fe';
+import { renderGamePage } from './game-page.js?v=5a0c3324';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId, fetchDataWithProdFallback } from '../config.js?v=f9591262';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=c7e1268c';
 import { renderGameCard } from '../lib/card.js?v=5642a459';

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,6 +1,6 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=7c25e8fe';
+import { renderGamePage } from './components/game-page.js?v=5a0c3324';
 import { renderHomePage } from './components/home.js?v=1aa3e1ab';
 import { renderSearchPage } from './components/search.js?v=598aaad1';
 

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,6 +1,6 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=5a0c3324';
+import { renderGamePage } from './components/game-page.js?v=ab28f71b';
 import { renderHomePage } from './components/home.js?v=1aa3e1ab';
 import { renderSearchPage } from './components/search.js?v=598aaad1';
 

--- a/scripts/pipeline/steam_metadata.py
+++ b/scripts/pipeline/steam_metadata.py
@@ -367,6 +367,46 @@ def upsert_depot_rows(rows: Iterable[DepotRow]) -> int:
     return len(payload)
 
 
+def upsert_manifest_history_rows(rows: Iterable[DepotRow]) -> int:
+    """Observation history for issue #226 (Phase 2 of the depot plan).
+
+    For each (app_id, depot_id, os, manifest_id) tuple we've never seen,
+    INSERT with first_observed_at = now(). For tuples we HAVE seen, bump
+    latest_observed_at to now(). When a game ships a build the manifest_id
+    changes for the affected depots -> a fresh row is inserted; the
+    previous row stays forever with its latest_observed_at frozen at the
+    time of the last observation, so we build a durable per-OS timeline.
+
+    Rows without a manifest_id are skipped -- the history is keyed on
+    manifest_id, and depots that PICS returned with no manifest are the
+    exact rows we cannot record change history for.
+    """
+    payload = [
+        {
+            "app_id":             r.app_id,
+            "depot_id":           r.depot_id,
+            "os":                 r.os,
+            "manifest_id":        r.manifest_id,
+            "latest_observed_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        }
+        for r in rows
+        if r.manifest_id  # skip depots that ship without a public manifest gid
+    ]
+    if not payload:
+        return 0
+    # on_conflict specifies our composite PK. Prefer: merge-duplicates means
+    # existing rows keep first_observed_at (never overwritten) and only
+    # latest_observed_at is bumped -- exactly the shape we want. The
+    # default column value 'now()' fires on INSERT only.
+    url = f"{_supabase_base()}/steam_depot_manifest_history?on_conflict=app_id,depot_id,os,manifest_id"
+    req = urllib.request.Request(
+        url, data=json.dumps(payload).encode(), method="POST",
+        headers=_supabase_headers(),
+    )
+    urllib.request.urlopen(req, timeout=30).read()
+    return len(payload)
+
+
 def upsert_fetch_status(app_id: int, status: str, depot_count: int, error: str | None = None) -> None:
     url = f"{_supabase_base()}/steam_depot_fetch_status?on_conflict=app_id"
     payload = [{
@@ -432,6 +472,15 @@ def fetch_and_store(app_id: int, sleep_between: float = 3.0) -> tuple[str, int]:
         upsert_fetch_status(app_id, "no_public_manifest", 0, "parsed appinfo but no OS-bound depot rows")
         return "no_public_manifest", 0
     n = upsert_depot_rows(rows)
+    # Feed the same rows into the manifest observation history so per-OS
+    # First seen / Last update become real dates. Failures here should
+    # NOT flip the status to error -- the primary depot_updates write is
+    # already durable; history is a strict enhancement. Log + continue.
+    try:
+        h = upsert_manifest_history_rows(rows)
+        log(f"steam-metadata: app={app_id} history rows upserted={h} source=depot-history")
+    except Exception as e:
+        log(f"steam-metadata: app={app_id} history upsert failed error={e}")
     upsert_fetch_status(app_id, "ok", n, None)
     log(f"steam-metadata: app={app_id} rows={n} source=steamcmd-pics")
     return "ok", n

--- a/submit.html
+++ b/submit.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=c550d77b">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/app/game-header.css?v=dbecc5e0">
+<link rel="stylesheet" href="css/app/game-header.css?v=68a12cde">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=6df19441">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">

--- a/submit.html
+++ b/submit.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=c550d77b">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/app/game-header.css?v=8018fb80">
+<link rel="stylesheet" href="css/app/game-header.css?v=dbecc5e0">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=6df19441">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">

--- a/supabase/functions/steam-depot-info/index.ts
+++ b/supabase/functions/steam-depot-info/index.ts
@@ -51,19 +51,37 @@ Deno.serve(async (req: Request) => {
     );
   }
   const supabase = createClient(supabaseUrl, supabaseKey);
-  const { data, error } = await supabase
-    .from("steam_depot_updates")
-    .select("app_id,os,depot_id,last_updated_at")
-    .eq("app_id", Number(appId));
 
-  if (error) {
-    console.error(`[steam-depot-info] appId=${appId} query error=${error.message}`);
+  // Two reads in parallel:
+  //   depot_updates   -> current per-depot state (last_updated_at is the
+  //                      branch-level timestamp; same across all OS depots
+  //                      for a given app on the same branch).
+  //   manifest_history -> Phase 2 observation table (#226). Every row is
+  //                      a (app, depot, os, manifest_id) tuple we've ever
+  //                      seen with first_observed_at + latest_observed_at.
+  //                      Per-OS First seen  = MIN(first_observed_at).
+  //                      Per-OS Last update = MAX(first_observed_at)
+  //                      (a fresh manifest_id observation means a build
+  //                      shipped for that OS).
+  const [depotRes, historyRes] = await Promise.all([
+    supabase
+      .from("steam_depot_updates")
+      .select("app_id,os,depot_id,last_updated_at")
+      .eq("app_id", Number(appId)),
+    supabase
+      .from("steam_depot_manifest_history")
+      .select("os,depot_id,manifest_id,first_observed_at,latest_observed_at")
+      .eq("app_id", Number(appId)),
+  ]);
+
+  if (depotRes.error) {
+    console.error(`[steam-depot-info] appId=${appId} depot query error=${depotRes.error.message}`);
     return Response.json(
-      { error: error.message, appId },
+      { error: depotRes.error.message, appId },
       { status: 502, headers: corsHeaders },
     );
   }
-  const rows = (data as Row[]) || [];
+  const rows = (depotRes.data as Row[]) || [];
   if (rows.length === 0) {
     console.log(`[steam-depot-info] appId=${appId} found=false source=cache-miss`);
     return Response.json(
@@ -71,28 +89,78 @@ Deno.serve(async (req: Request) => {
       { status: 200, headers: { ...corsHeaders, "Cache-Control": "public, max-age=600" } },
     );
   }
+  // History failure is non-fatal -- we can still return branch-level
+  // dates for both first_seen and last_updated as a degraded fallback,
+  // same shape as pre-#226. Log it so we notice.
+  const history = !historyRes.error && Array.isArray(historyRes.data)
+    ? (historyRes.data as {
+        os: string; depot_id: number; manifest_id: string;
+        first_observed_at: string; latest_observed_at: string;
+      }[])
+    : [];
+  if (historyRes.error) {
+    console.error(`[steam-depot-info] appId=${appId} history query error=${historyRes.error.message}`);
+  }
 
-  // Reduce to per-OS min / max timestamps + depot count.
-  type Bucket = { first: number; last: number; depots: Set<number> };
+  // Depot counts + branch fallback come from steam_depot_updates.
+  type Bucket = { branchTs: number; depots: Set<number> };
   const byOs = new Map<string, Bucket>();
   for (const row of rows) {
     const ts = Date.parse(row.last_updated_at);
     if (!Number.isFinite(ts)) continue;
     let b = byOs.get(row.os);
-    if (!b) { b = { first: ts, last: ts, depots: new Set() }; byOs.set(row.os, b); }
-    if (ts < b.first) b.first = ts;
-    if (ts > b.last)  b.last  = ts;
+    if (!b) { b = { branchTs: ts, depots: new Set() }; byOs.set(row.os, b); }
+    if (ts > b.branchTs) b.branchTs = ts;
     b.depots.add(row.depot_id);
   }
-  const os: Record<string, { first_seen: string; last_updated: string; depots: number }> = {};
-  for (const [key, b] of byOs.entries()) {
-    os[key] = {
-      first_seen:   new Date(b.first).toISOString(),
-      last_updated: new Date(b.last).toISOString(),
-      depots:       b.depots.size,
-    };
+  // Per-OS min / max of first_observed_at from history. Manifest_id
+  // changes are proxies for build changes; MIN across all rows is the
+  // per-OS 'we first tracked this OS depot' floor, MAX is the last
+  // time a new manifest_id was observed = the last time the OS build
+  // shipped.
+  type HistBucket = { minFirst: number; maxFirst: number; manifests: number };
+  const histByOs = new Map<string, HistBucket>();
+  for (const h of history) {
+    const ts = Date.parse(h.first_observed_at);
+    if (!Number.isFinite(ts)) continue;
+    let hb = histByOs.get(h.os);
+    if (!hb) { hb = { minFirst: ts, maxFirst: ts, manifests: 0 }; histByOs.set(h.os, hb); }
+    if (ts < hb.minFirst) hb.minFirst = ts;
+    if (ts > hb.maxFirst) hb.maxFirst = ts;
+    hb.manifests++;
   }
-  console.log(`[steam-depot-info] appId=${appId} found=true osCount=${Object.keys(os).length} source=cache`);
+  const os: Record<string, {
+    first_seen:   string;
+    last_updated: string;
+    depots:       number;
+    manifests:    number;   // # of distinct manifest_ids we have observed for this OS
+    source:       "history" | "branch-fallback";
+  }> = {};
+  for (const [key, b] of byOs.entries()) {
+    const hb = histByOs.get(key);
+    if (hb) {
+      os[key] = {
+        first_seen:   new Date(hb.minFirst).toISOString(),
+        last_updated: new Date(hb.maxFirst).toISOString(),
+        depots:       b.depots.size,
+        manifests:    hb.manifests,
+        source:       "history",
+      };
+    } else {
+      // No history yet (first observation from Phase 1 runs, or history
+      // upsert failed above). Fall back to the branch timestamp -- same
+      // value for both cells, same as pre-#226 UX.
+      os[key] = {
+        first_seen:   new Date(b.branchTs).toISOString(),
+        last_updated: new Date(b.branchTs).toISOString(),
+        depots:       b.depots.size,
+        manifests:    0,
+        source:       "branch-fallback",
+      };
+    }
+  }
+  const anyHist = [...Object.values(os)].some(v => v.source === "history");
+  console.log(`[steam-depot-info] appId=${appId} found=true osCount=${Object.keys(os).length} historyBacked=${anyHist} source=cache`);
   return Response.json(
     { appId, found: true, os },
     { status: 200, headers: { ...corsHeaders, "Cache-Control": "public, max-age=600" } },

--- a/supabase/migrations/20260707040000_steam_depot_manifest_history.sql
+++ b/supabase/migrations/20260707040000_steam_depot_manifest_history.sql
@@ -1,0 +1,69 @@
+-- Observation history for Steam depot manifests. Phase 2 of the plan
+-- documented in proton-pulse-web-wiki/Steam-Depot-Data.md (issue #226).
+--
+-- Motivation: PICS gives us ONE branch-level `timeupdated` shared by every
+-- OS depot on the branch, so per-OS 'First seen' and 'Last update' cannot
+-- come from a single-value schema. Real per-OS answers require observing
+-- how manifest_id changes over time and taking min / max of the
+-- first_observed_at column.
+--
+-- Model:
+--   - Row per unique (app_id, depot_id, os, manifest_id).
+--   - When the pipeline sees a manifest_id we've never recorded for that
+--     (app, depot, os) combo, INSERT (first_observed_at = now()).
+--   - When we see the same manifest_id again, UPDATE latest_observed_at.
+--   - When a game ships a new build the manifest_id changes for the
+--     affected depots -> a fresh row is inserted; the previous row stays
+--     forever (its latest_observed_at just stops advancing).
+--
+-- Aggregates the read-side edge function computes:
+--   - per-OS First seen  = MIN(first_observed_at) over all rows for
+--     (app_id, os). This is our observation floor -- for games whose
+--     depots existed before we started tracking, this reads as
+--     "tracked since <date>" rather than the true creation date.
+--   - per-OS Last update = MAX(first_observed_at). A new max means a
+--     new manifest_id was observed, i.e. a build for that OS shipped.
+--
+-- GDPR note: table holds only public Steam depot metadata (app id,
+-- depot id, OS name string, manifest gid, observation timestamps). No
+-- user identifier of any kind. admin_erase_user coverage is NOT required.
+
+create table if not exists public.steam_depot_manifest_history (
+  app_id              bigint      not null,
+  depot_id            bigint      not null,
+  os                  text        not null,
+  manifest_id         text        not null,
+  first_observed_at   timestamptz not null default now(),
+  latest_observed_at  timestamptz not null default now(),
+  primary key (app_id, depot_id, os, manifest_id)
+);
+
+comment on table  public.steam_depot_manifest_history is
+  'Observational history of Steam depot manifests per (app, depot, os). Populated by scripts/pipeline/steam_metadata.py; read by supabase/functions/steam-depot-info. #226.';
+comment on column public.steam_depot_manifest_history.first_observed_at is
+  'When the pipeline first saw this manifest_id for the (app, depot, os) tuple. Our observation floor -- not a true creation date.';
+comment on column public.steam_depot_manifest_history.latest_observed_at is
+  'When the pipeline last saw this manifest_id still active for the (app, depot, os). Advances on every re-observation of the same gid; a new gid means a new row.';
+
+-- Read hot paths: per-app aggregation and per-(app, os) filters.
+create index if not exists idx_steam_depot_manifest_history_app_os
+  on public.steam_depot_manifest_history (app_id, os);
+create index if not exists idx_steam_depot_manifest_history_first_observed
+  on public.steam_depot_manifest_history (first_observed_at desc);
+
+alter table public.steam_depot_manifest_history enable row level security;
+
+-- Public read (same as steam_depot_updates -- this is objective Steam data).
+-- Writes flow through the pipeline runner using the service role.
+do $$ begin
+  if not exists (
+    select 1 from pg_policies
+    where tablename  = 'steam_depot_manifest_history'
+      and policyname = 'anyone can read steam_depot_manifest_history'
+  ) then
+    create policy "anyone can read steam_depot_manifest_history"
+      on public.steam_depot_manifest_history for select
+      to anon, authenticated
+      using (true);
+  end if;
+end $$;

--- a/tests/test_steam_metadata.py
+++ b/tests/test_steam_metadata.py
@@ -395,3 +395,131 @@ class TestFetchAndStoreOffline:
         assert status_calls[0][0] == 1
         assert status_calls[0][1] == "error"
         assert "steamcmd missing" in status_calls[0][2]
+
+
+class TestManifestHistoryWriter:
+    """Phase 2 (#226) tests: the same rows that go into steam_depot_updates
+    must also be fed into steam_depot_manifest_history so per-OS First
+    seen / Last update stop being duplicative branch-level values.
+
+    Contract we lock down:
+      * upsert_manifest_history_rows drops depot rows without a manifest_id
+        (history is keyed on manifest_id; a row without it cannot carry
+        change history).
+      * The POST target uses the correct on_conflict PK.
+      * fetch_and_store calls the history writer AFTER upsert_depot_rows.
+      * A failing history write does NOT flip the outcome to 'error'; the
+        primary depot_updates write is durable and history is a strict
+        enhancement (per the module comment).
+    """
+
+    def _mkrow(self, os_key, manifest_id, depot_id=100, ts=1710000000):
+        return steam_metadata.DepotRow(
+            app_id=1, depot_id=depot_id, os=os_key,
+            name=None, manifest_id=manifest_id, last_updated_at=ts,
+        )
+
+    def test_skips_rows_without_manifest_id(self, monkeypatch):
+        captured = {}
+        def fake_urlopen(req, timeout=None):
+            captured["url"] = req.full_url
+            captured["body"] = req.data
+            class _R:
+                def read(self): return b""
+            return _R()
+        monkeypatch.setattr(steam_metadata.urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setenv("SUPABASE_URL", "https://test.supabase.co")
+        monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "srv")
+
+        rows = [
+            self._mkrow("linux",  None),                # dropped: no manifest_id
+            self._mkrow("windows", "abc"),
+            self._mkrow("mac",     ""),                 # dropped: empty manifest_id
+        ]
+        n = steam_metadata.upsert_manifest_history_rows(rows)
+        assert n == 1
+        import json as _j
+        body = _j.loads(captured["body"])
+        assert len(body) == 1
+        assert body[0]["os"] == "windows"
+        assert body[0]["manifest_id"] == "abc"
+
+    def test_upsert_url_uses_composite_pk_on_conflict(self, monkeypatch):
+        captured = {}
+        def fake_urlopen(req, timeout=None):
+            captured["url"] = req.full_url
+            class _R:
+                def read(self): return b""
+            return _R()
+        monkeypatch.setattr(steam_metadata.urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setenv("SUPABASE_URL", "https://test.supabase.co")
+        monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "srv")
+
+        steam_metadata.upsert_manifest_history_rows([self._mkrow("linux", "abc")])
+        # Composite PK matches the migration; anything else and Postgres
+        # rejects the upsert.
+        assert "steam_depot_manifest_history" in captured["url"]
+        assert "on_conflict=app_id,depot_id,os,manifest_id" in captured["url"]
+
+    def test_returns_zero_and_skips_post_when_all_rows_lack_manifest_id(self, monkeypatch):
+        calls = []
+        def fake_urlopen(req, timeout=None):
+            calls.append(req.full_url)
+            class _R:
+                def read(self): return b""
+            return _R()
+        monkeypatch.setattr(steam_metadata.urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setenv("SUPABASE_URL", "https://test.supabase.co")
+        monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "srv")
+
+        n = steam_metadata.upsert_manifest_history_rows([self._mkrow("linux", None)])
+        assert n == 0
+        assert calls == []  # no network call when payload is empty
+
+    def test_fetch_and_store_calls_history_writer_after_depot_upsert(self, monkeypatch):
+        # Verifies the sequencing: depot_updates first (the durable write),
+        # history second (the enhancement).
+        rows = [self._mkrow("linux", "abc", depot_id=42)]
+
+        order = []
+        parsed = {"depots": {"42": {"config": {"oslist": "linux"},
+                                    "manifests": {"public": {"gid": "abc"}}},
+                              "branches": {"public": {"timeupdated": "1710000000"}}}}
+        monkeypatch.setattr(steam_metadata, "run_steamcmd_app_info", lambda app_id, **kw: "dummy")
+        monkeypatch.setattr(steam_metadata, "parse_app_info", lambda text: parsed)
+        monkeypatch.setattr(steam_metadata, "extract_depot_rows", lambda app_id, p: rows)
+        monkeypatch.setattr(steam_metadata, "upsert_depot_rows",
+            lambda r: order.append("depot") or len(list(r)))
+        monkeypatch.setattr(steam_metadata, "upsert_manifest_history_rows",
+            lambda r: order.append("history") or len(list(r)))
+        monkeypatch.setattr(steam_metadata, "upsert_fetch_status",
+            lambda app_id, status, count, error=None: order.append(f"status={status}"))
+        monkeypatch.setattr(steam_metadata, "log", lambda msg: None)
+
+        status, n = steam_metadata.fetch_and_store(1)
+        assert status == "ok"
+        # depot write happens before history; final status flip last
+        assert order == ["depot", "history", "status=ok"]
+
+    def test_history_write_failure_does_not_flip_status_to_error(self, monkeypatch):
+        # Enhancement layer must never mask the durable primary write.
+        rows = [self._mkrow("linux", "abc")]
+        parsed = {"depots": {}}
+        monkeypatch.setattr(steam_metadata, "run_steamcmd_app_info", lambda app_id, **kw: "dummy")
+        monkeypatch.setattr(steam_metadata, "parse_app_info", lambda text: parsed)
+        monkeypatch.setattr(steam_metadata, "extract_depot_rows", lambda app_id, p: rows)
+        monkeypatch.setattr(steam_metadata, "upsert_depot_rows", lambda r: len(list(r)))
+        def boom(_):
+            raise RuntimeError("history table down")
+        monkeypatch.setattr(steam_metadata, "upsert_manifest_history_rows", boom)
+        status_calls = []
+        monkeypatch.setattr(steam_metadata, "upsert_fetch_status",
+            lambda app_id, status, count, error=None: status_calls.append((status, error)))
+        logs = []
+        monkeypatch.setattr(steam_metadata, "log", lambda msg: logs.append(msg))
+
+        status, n = steam_metadata.fetch_and_store(1)
+        assert status == "ok"
+        assert status_calls[-1][0] == "ok"
+        # But the failure must be logged so we can diagnose
+        assert any("history upsert failed" in m for m in logs)


### PR DESCRIPTION
Phase 2 of the depot data plan (proton-pulse-web-wiki/Steam-Depot-Data.md). Replaces the duplicative First seen == Last update problem with real per-OS values computed from a new observation table.

## What changes

- **New table `steam_depot_manifest_history`** (migration applied) — composite PK (app_id, depot_id, os, manifest_id), first_observed_at frozen on INSERT, latest_observed_at bumped on every re-observation. Public read RLS, no user data.

- **Pipeline (`steam_metadata.py`)** — new `upsert_manifest_history_rows()` fires after the durable depot_updates write. Rows without a manifest_id are skipped. History write failure keeps outcome 'ok' + logs — strict enhancement layer.

- **Edge fn (`steam-depot-info`)** — reads both tables in parallel. When history exists: `first_seen = MIN(first_observed_at)` and `last_updated = MAX(first_observed_at)` per OS. When history is empty for the app: falls back to Phase 1 branch timestamp. New `source: 'history' | 'branch-fallback'` field tells the client which path each OS took.

- **Metadata modal** — restores the First seen column (was retired for being duplicative). History-backed values render normal weight; fallback values italic + muted with tooltips explaining each source. Manifest count surfaces in the Depots column when history is populated.

## Tests

5 new Python tests in `TestManifestHistoryWriter`:
- drops rows without manifest_id
- upsert URL uses correct composite PK on_conflict  
- empty payload short-circuits (no network call)
- fetch_and_store sequences depot → history → status
- history write failure keeps outcome 'ok' + logs the failure

Total: Python 27 passed, JS 1492 passed.

## After merge

1. `deploy-functions.yml` publishes the updated `steam-depot-info` edge function
2. Dispatch `Steam Metadata Fetch (depot dates)` against 367520 → first history rows land
3. Modal for Hollow Knight shows italic fallback dates for all 3 OS rows (history has one observation per depot so MIN == MAX still; it only diverges when a manifest_id changes on a subsequent run)
4. Nightly runs from here forward will progressively diverge First seen from Last update as builds ship

## Test plan

- [ ] `python -m pytest tests/test_steam_metadata.py` → 27/27
- [ ] `make pre-push` → 1492 JS + no regressions
- [ ] After merge, re-dispatch seed → confirm rows appear in `steam_depot_manifest_history`
- [ ] Metadata modal shows the new columns with correct italic-fallback semantics on first observation