### PR TITLE
feat(admin): Depot Tracking panel (closes #230)

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=c550d77b">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/admin/admin.css?v=c883b5f7">
+<link rel="stylesheet" href="css/admin/admin.css?v=7e03c6fd">
 </head>
 <body>
 
@@ -44,6 +44,7 @@
           <option value="banned">Banned Users</option>
           <option value="boxart">Box Art Manager</option>
           <option value="api-explorer">API Explorer</option>
+          <option value="depot-tracking">Depot Tracking</option>
           <option value="all-reports">Reports</option>
         </select>
       </div>
@@ -306,6 +307,11 @@
         <div id="boxart-detail-content"></div>
       </section>
 
+      <!-- Depot Tracking: per-app Steam PICS pipeline status + manifest history. -->
+      <section id="tab-depot-tracking" class="admin-section" hidden>
+        <div id="depot-tracking-content"></div>
+      </section>
+
       <section id="tab-api-explorer" class="admin-section" hidden>
         <div id="api-explorer-content"></div>
       </section>
@@ -353,6 +359,6 @@
 <script src="js/lib/analytics.js?v=7855fb4c"></script>
 <script src="js/lib/topbar.js?v=46897460"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/admin/main.js?v=0bcda5eb"></script>
+<script type="module" src="js/admin/main.js?v=43db24b1"></script>
 </body>
 </html>

--- a/css/admin/admin.css
+++ b/css/admin/admin.css
@@ -1338,3 +1338,112 @@ pre.flag-raw-json {
   color: var(--text);
   background: rgba(46, 160, 67, 0.05);
 }
+
+/* Depot Tracking panel (#230). Aggregate cards + per-app expandable table. */
+.depot-tracking { display: flex; flex-direction: column; gap: 14px; }
+.depot-controls { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+.depot-agg {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 10px;
+}
+.depot-card {
+  border: 1px solid var(--border);
+  background: var(--s1);
+  padding: 10px 12px;
+  border-radius: 6px;
+  display: flex; flex-direction: column; gap: 2px;
+}
+.depot-card-label {
+  font-family: var(--mono);
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--muted);
+}
+.depot-card-value {
+  font-family: var(--mono);
+  font-size: 1.15rem;
+  color: var(--accent-hi);
+}
+.depot-card-sub { font-size: 0.7rem; color: var(--muted); }
+
+.depot-table th, .depot-table td { vertical-align: top; }
+.depot-row-error {
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  color: #ff8a80;
+  margin-top: 2px;
+}
+.depot-pill {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+  border: 1px solid var(--border2);
+}
+.depot-pill--ok   { color: #7ed37a; border-color: rgba(126,211,122,0.55); background: rgba(126,211,122,0.08); }
+.depot-pill--warn { color: #f5b041; border-color: rgba(245,176,65,0.55);  background: rgba(245,176,65,0.08); }
+.depot-pill--err  { color: #ff8a80; border-color: rgba(255,138,128,0.55); background: rgba(255,138,128,0.08); }
+
+.depot-os-chip {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 4px;
+  border: 1px solid var(--border2);
+  background: var(--s1);
+  font-family: var(--mono);
+  font-size: 0.68rem;
+  color: var(--muted);
+  margin-right: 4px;
+}
+.depot-os-chip--windows { color: #6ea8ff; border-color: rgba(110,168,255,0.55); background: rgba(110,168,255,0.08); }
+.depot-os-chip--mac     { color: #d0d0d0; border-color: var(--border); background: rgba(255,255,255,0.03); }
+.depot-os-chip--linux   { color: #7ed37a; border-color: rgba(126,211,122,0.55); background: rgba(126,211,122,0.08); }
+
+.admin-btn--small { padding: 2px 10px; font-size: 0.75rem; }
+
+.depot-detail { display: none; }
+.depot-detail--open { display: table-row; }
+.depot-detail > td {
+  background: rgba(255,255,255,0.02);
+  border-top: 1px solid var(--border);
+}
+.depot-detail-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+}
+@media (max-width: 720px) {
+  .depot-detail-grid { grid-template-columns: 1fr; }
+}
+.depot-detail-title {
+  font-family: var(--mono);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--muted);
+  margin-bottom: 6px;
+}
+.depot-inner-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.78rem;
+}
+.depot-inner-table th, .depot-inner-table td {
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+}
+.depot-inner-table th {
+  font-family: var(--mono);
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  font-weight: 600;
+}
+.depot-mono { font-family: var(--mono); font-size: 0.72rem; }
+.admin-loading, .admin-empty { text-align: center; color: var(--muted); padding: 18px 0; }

--- a/gh-pages-manifest.txt
+++ b/gh-pages-manifest.txt
@@ -91,6 +91,8 @@ js/admin/api/boxart.js
 js/admin/components/boxart.js
 js/admin/api/steam-explore.js
 js/admin/components/api-explorer.js
+js/admin/api/depotTracking.js
+js/admin/components/depotTracking.js
 js/admin/components/flagged.js
 js/admin/components/banned.js
 js/admin/components/users.js

--- a/js/admin/api/depotTracking.js
+++ b/js/admin/api/depotTracking.js
@@ -1,0 +1,158 @@
+// depotTracking (admin api): reads for the Depot Tracking admin panel (#230).
+// Pulls three public tables and aggregates them client-side into a single
+// per-app dossier so we don't have to open the Actions log or Supabase
+// dashboard to answer 'has the tracker seen X yet' style questions.
+//
+//   steam_depot_fetch_status    -> app-level ok / no_public_manifest / error
+//   steam_depot_updates         -> current per-depot state (OS, manifest_id)
+//   steam_depot_manifest_history -> observation history (first_seen, count)
+//
+// Reads use the anon key + public RLS policies -- no service role needed.
+// Writes (workflow dispatch, cache invalidation) are out of scope for the
+// MVP and will land as a separate signed-in-admin-only edge function in a
+// follow-up.
+
+import { SUPABASE_URL, SUPABASE_ANON_KEY } from '../config.js?v=ffed3d84';
+
+const REST = `${SUPABASE_URL}/rest/v1`;
+const HDR  = { apikey: SUPABASE_ANON_KEY, Accept: 'application/json' };
+
+/**
+ * Fetch the per-app status view. Returns an array sorted by fetched_at
+ * DESC so the most recently touched apps are on top. Fields:
+ *   { app_id, app_status, depot_count, fetched_at, error }
+ */
+export async function fetchDepotFetchStatus({ limit = 500 } = {}) {
+  const url = `${REST}/steam_depot_fetch_status?select=app_id,app_status,depot_count,fetched_at,error&order=fetched_at.desc&limit=${limit}`;
+  const r = await fetch(url, { headers: HDR });
+  if (!r.ok) throw new Error(`fetch status failed: HTTP ${r.status}`);
+  return r.json();
+}
+
+/**
+ * Fetch current per-depot state for a set of app_ids. Batched into
+ * chunks of 100 so a big status page does not trip PostgREST URL length
+ * limits. Returns { [app_id]: [{ os, depot_id, manifest_id,
+ * last_updated_at, name }, ...] }.
+ */
+export async function fetchDepotUpdatesForApps(appIds) {
+  const out = {};
+  if (!Array.isArray(appIds) || appIds.length === 0) return out;
+  const CHUNK = 100;
+  for (let i = 0; i < appIds.length; i += CHUNK) {
+    const chunk = appIds.slice(i, i + CHUNK);
+    const params = new URLSearchParams();
+    params.set('select', 'app_id,os,depot_id,manifest_id,last_updated_at,name');
+    params.append('app_id', `in.(${chunk.join(',')})`);
+    params.set('order', 'app_id.asc,os.asc');
+    params.set('limit', String(chunk.length * 10));
+    const r = await fetch(`${REST}/steam_depot_updates?${params}`, { headers: HDR });
+    if (!r.ok) continue;
+    const rows = await r.json();
+    for (const row of rows) {
+      const k = String(row.app_id);
+      if (!out[k]) out[k] = [];
+      out[k].push(row);
+    }
+  }
+  return out;
+}
+
+/**
+ * Fetch manifest history counts + newest observation per app in one
+ * paginated read. Returns { [app_id]: { manifestCount, newestFirstObserved,
+ * oldestFirstObserved, perOs: { linux: { count, newestFirstObserved,
+ * oldestFirstObserved }, ... } } }. Aggregation is client-side because
+ * PostgREST does not have GROUP BY unless we ship a view or RPC.
+ */
+export async function fetchManifestHistoryForApps(appIds) {
+  const out = {};
+  if (!Array.isArray(appIds) || appIds.length === 0) return out;
+  const CHUNK = 100;
+  for (let i = 0; i < appIds.length; i += CHUNK) {
+    const chunk = appIds.slice(i, i + CHUNK);
+    const params = new URLSearchParams();
+    params.set('select', 'app_id,os,first_observed_at,latest_observed_at');
+    params.append('app_id', `in.(${chunk.join(',')})`);
+    params.set('limit', '2000');
+    const r = await fetch(`${REST}/steam_depot_manifest_history?${params}`, { headers: HDR });
+    if (!r.ok) continue;
+    const rows = await r.json();
+    for (const row of rows) {
+      const k = String(row.app_id);
+      if (!out[k]) out[k] = { manifestCount: 0, newestFirstObserved: null, oldestFirstObserved: null, perOs: {} };
+      const bucket = out[k];
+      bucket.manifestCount++;
+      const ts = row.first_observed_at;
+      if (!bucket.newestFirstObserved || ts > bucket.newestFirstObserved) bucket.newestFirstObserved = ts;
+      if (!bucket.oldestFirstObserved || ts < bucket.oldestFirstObserved) bucket.oldestFirstObserved = ts;
+      const os = row.os || 'unknown';
+      if (!bucket.perOs[os]) bucket.perOs[os] = { count: 0, newestFirstObserved: null, oldestFirstObserved: null };
+      const ob = bucket.perOs[os];
+      ob.count++;
+      if (!ob.newestFirstObserved || ts > ob.newestFirstObserved) ob.newestFirstObserved = ts;
+      if (!ob.oldestFirstObserved || ts < ob.oldestFirstObserved) ob.oldestFirstObserved = ts;
+    }
+  }
+  return out;
+}
+
+/**
+ * One-shot loader for the panel: fetches status + hydrates each row with
+ * depots + history. Returns { apps: [{ ...status, depots: [...],
+ * history: {...} }], aggregate: { total, ok, noManifest, error, newest,
+ * updatedIn24h, updatedIn7d, updatedIn30d } }.
+ */
+export async function fetchDepotTrackingDossier({ limit = 500 } = {}) {
+  const status = await fetchDepotFetchStatus({ limit });
+  const appIds = status.map(s => s.app_id);
+  const [depots, history] = await Promise.all([
+    fetchDepotUpdatesForApps(appIds),
+    fetchManifestHistoryForApps(appIds),
+  ]);
+  const apps = status.map(s => ({
+    ...s,
+    depots:  depots[String(s.app_id)]  || [],
+    history: history[String(s.app_id)] || null,
+  }));
+  return {
+    apps,
+    aggregate: summarizeApps(apps),
+  };
+}
+
+/**
+ * Pure aggregation over hydrated app rows. Broken out so the tests do
+ * not need a live Supabase to exercise the summary math.
+ */
+export function summarizeApps(apps) {
+  const s = {
+    total: apps.length,
+    ok: 0,
+    noManifest: 0,
+    error: 0,
+    newest: null,
+    updatedIn24h: 0,
+    updatedIn7d:  0,
+    updatedIn30d: 0,
+  };
+  if (!apps.length) return s;
+  const now = Date.now();
+  const DAY = 86400 * 1000;
+  for (const a of apps) {
+    if (a.app_status === 'ok') s.ok++;
+    else if (a.app_status === 'no_public_manifest') s.noManifest++;
+    else s.error++;
+    if (a.fetched_at && (!s.newest || a.fetched_at > s.newest)) s.newest = a.fetched_at;
+    const changeTs = a.history?.newestFirstObserved || null;
+    if (changeTs) {
+      const diff = now - Date.parse(changeTs);
+      if (Number.isFinite(diff)) {
+        if (diff <= 1 * DAY)  s.updatedIn24h++;
+        if (diff <= 7 * DAY)  s.updatedIn7d++;
+        if (diff <= 30 * DAY) s.updatedIn30d++;
+      }
+    }
+  }
+  return s;
+}

--- a/js/admin/components/admins.js
+++ b/js/admin/components/admins.js
@@ -1,7 +1,7 @@
 // admins (components) for the admin page.
 
 import { escapeHtml, fmtDateTime } from '../utils.js?v=2668b2f0';
-import { PERMISSION_LABELS, effectivePermissions, resolveRoleLabel, permissionsToAdd } from '../permissions.js?v=12b82ef4';
+import { PERMISSION_LABELS, effectivePermissions, resolveRoleLabel, permissionsToAdd } from '../permissions.js?v=e2aa69ae';
 
 // Role <select> for a row or the add form. `uuid` is 'new' for the add form.
 function roleSelectHtml(label, uuid) {

--- a/js/admin/components/depotTracking.js
+++ b/js/admin/components/depotTracking.js
@@ -1,0 +1,206 @@
+// depotTracking (admin component): renders the Depot Tracking admin panel
+// (#230). Aggregate cards + per-app table with expand-to-see-details. Read
+// only for the MVP; workflow-dispatch + cache invalidation actions land in
+// a follow-up so the UI can ship without a new signed-in-admin edge fn.
+
+import { fetchDepotTrackingDossier, summarizeApps } from '../api/depotTracking.js?v=4b0f8cc0';
+
+function esc(s) {
+  return String(s == null ? '' : s).replace(/[<>&"]/g, c =>
+    ({ '<': '&lt;', '>': '&gt;', '&': '&amp;', '"': '&quot;' }[c]));
+}
+
+function fmtDate(iso) {
+  if (!iso) return '-';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '-';
+  return d.toLocaleString('en-US', { year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+}
+
+function relTime(iso) {
+  if (!iso) return '';
+  const diff = Date.now() - Date.parse(iso);
+  if (!Number.isFinite(diff) || diff < 0) return '';
+  const min = Math.round(diff / 60000);
+  if (min < 60)  return `${min}m ago`;
+  const h = Math.round(min / 60);
+  if (h < 48)    return `${h}h ago`;
+  const d = Math.round(h / 24);
+  return `${d}d ago`;
+}
+
+function statusPill(status) {
+  const cls = status === 'ok' ? 'ok' : status === 'no_public_manifest' ? 'warn' : 'err';
+  const label = status === 'no_public_manifest' ? 'no manifest' : status;
+  return `<span class="depot-pill depot-pill--${cls}">${esc(label || 'unknown')}</span>`;
+}
+
+/**
+ * Render the panel into the given host element. Idempotent: re-renders on
+ * search input + a manual Refresh button. Not paginated for the MVP --
+ * fetchDepotTrackingDossier caps at 500 apps which is fine while our
+ * tracked set is small.
+ */
+export async function renderDepotTracking(host) {
+  if (!host) return;
+  host.innerHTML = `
+    <div class="depot-tracking">
+      <div class="depot-controls">
+        <input type="text" id="depot-search" class="admin-input admin-input--wide" placeholder="Filter by app id or status...">
+        <button type="button" id="depot-refresh" class="admin-btn">Refresh</button>
+      </div>
+      <div class="depot-agg" id="depot-agg"></div>
+      <div class="admin-table-scroll">
+        <table class="admin-table depot-table">
+          <thead>
+            <tr>
+              <th>App ID</th>
+              <th>Status</th>
+              <th>Depots</th>
+              <th>OSes</th>
+              <th>Fetched</th>
+              <th>Latest observation</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody id="depot-tbody">
+            <tr><td colspan="7" class="admin-loading">Loading...</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>`;
+
+  let dossier = null;
+
+  async function load() {
+    const tbody = host.querySelector('#depot-tbody');
+    if (tbody) tbody.innerHTML = `<tr><td colspan="7" class="admin-loading">Loading...</td></tr>`;
+    try {
+      dossier = await fetchDepotTrackingDossier();
+      applyFilter(host.querySelector('#depot-search')?.value || '');
+    } catch (e) {
+      if (tbody) tbody.innerHTML = `<tr><td colspan="7" class="admin-error">${esc(e.message || e)}</td></tr>`;
+    }
+  }
+
+  function applyFilter(query) {
+    if (!dossier) return;
+    const q = query.trim().toLowerCase();
+    const rows = dossier.apps.filter(a => {
+      if (!q) return true;
+      if (String(a.app_id).includes(q)) return true;
+      if ((a.app_status || '').toLowerCase().includes(q)) return true;
+      return false;
+    });
+    renderAggregate(host.querySelector('#depot-agg'), rows.length === dossier.apps.length
+      ? dossier.aggregate
+      : summarizeApps(rows));
+    renderRows(host.querySelector('#depot-tbody'), rows);
+  }
+
+  host.querySelector('#depot-refresh')?.addEventListener('click', load);
+  host.querySelector('#depot-search')?.addEventListener('input', (e) => applyFilter(e.target.value));
+
+  await load();
+}
+
+function renderAggregate(el, agg) {
+  if (!el) return;
+  const card = (label, value, sub = '') => `
+    <div class="depot-card">
+      <div class="depot-card-label">${esc(label)}</div>
+      <div class="depot-card-value">${esc(String(value))}</div>
+      ${sub ? `<div class="depot-card-sub">${esc(sub)}</div>` : ''}
+    </div>`;
+  el.innerHTML = [
+    card('Total tracked',   agg.total),
+    card('OK',              agg.ok),
+    card('No manifest',     agg.noManifest),
+    card('Errors',          agg.error),
+    card('Newest fetch',    fmtDate(agg.newest), relTime(agg.newest)),
+    card('Manifests changed 24h', agg.updatedIn24h),
+    card('Changed 7d',      agg.updatedIn7d),
+    card('Changed 30d',     agg.updatedIn30d),
+  ].join('');
+}
+
+function renderRows(tbody, rows) {
+  if (!tbody) return;
+  if (rows.length === 0) {
+    tbody.innerHTML = `<tr><td colspan="7" class="admin-empty">No apps match the current filter.</td></tr>`;
+    return;
+  }
+  tbody.innerHTML = rows.map(a => renderRow(a)).join('');
+  // Wire per-row expand toggles. Delegated because innerHTML replacement
+  // wipes any per-element listeners we could have attached above.
+  tbody.querySelectorAll('[data-depot-toggle]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const target = tbody.querySelector(`[data-depot-detail="${btn.dataset.depotToggle}"]`);
+      if (!target) return;
+      const open = target.classList.toggle('depot-detail--open');
+      btn.textContent = open ? 'Hide' : 'Details';
+    });
+  });
+}
+
+function renderRow(a) {
+  const oses = [...new Set((a.depots || []).map(d => d.os))].sort();
+  const osChips = oses.length
+    ? oses.map(o => `<span class="depot-os-chip depot-os-chip--${esc(o)}">${esc(o)}</span>`).join(' ')
+    : '<span class="admin-muted">-</span>';
+  const historyPart = a.history?.newestFirstObserved
+    ? `${fmtDate(a.history.newestFirstObserved)} <span class="admin-muted">(${relTime(a.history.newestFirstObserved)})</span>`
+    : '<span class="admin-muted">no history yet</span>';
+  const key = `app-${a.app_id}`;
+  return `
+    <tr class="depot-row">
+      <td><a href="app.html#/app/${esc(String(a.app_id))}" target="_blank" rel="noopener">${esc(String(a.app_id))}</a></td>
+      <td>${statusPill(a.app_status)}${a.error ? `<div class="depot-row-error" title="${esc(a.error)}">${esc(a.error.slice(0, 80))}${a.error.length > 80 ? '...' : ''}</div>` : ''}</td>
+      <td>${a.depot_count ?? (a.depots || []).length}</td>
+      <td>${osChips}</td>
+      <td>${fmtDate(a.fetched_at)} <span class="admin-muted">(${relTime(a.fetched_at)})</span></td>
+      <td>${historyPart}</td>
+      <td><button type="button" class="admin-btn admin-btn--small" data-depot-toggle="${esc(key)}">Details</button></td>
+    </tr>
+    <tr class="depot-detail" data-depot-detail="${esc(key)}">
+      <td colspan="7">
+        ${renderDetail(a)}
+      </td>
+    </tr>`;
+}
+
+function renderDetail(a) {
+  const depots = a.depots || [];
+  if (depots.length === 0) return '<div class="admin-muted">No depot rows recorded.</div>';
+  const depotRows = depots.map(d => `
+    <tr>
+      <td>${esc(d.os)}</td>
+      <td>${esc(String(d.depot_id))}</td>
+      <td class="depot-mono">${esc(d.manifest_id || '-')}</td>
+      <td>${fmtDate(d.last_updated_at)}</td>
+    </tr>`).join('');
+  const perOs = a.history?.perOs || {};
+  const historyRows = Object.entries(perOs).map(([os, h]) => `
+    <tr>
+      <td>${esc(os)}</td>
+      <td>${h.count}</td>
+      <td>${fmtDate(h.oldestFirstObserved)}</td>
+      <td>${fmtDate(h.newestFirstObserved)}</td>
+    </tr>`).join('');
+  return `
+    <div class="depot-detail-grid">
+      <div>
+        <div class="depot-detail-title">Current depots</div>
+        <table class="depot-inner-table">
+          <thead><tr><th>OS</th><th>Depot</th><th>Manifest</th><th>Last update</th></tr></thead>
+          <tbody>${depotRows}</tbody>
+        </table>
+      </div>
+      <div>
+        <div class="depot-detail-title">Manifest history per OS</div>
+        ${historyRows
+          ? `<table class="depot-inner-table"><thead><tr><th>OS</th><th>Count</th><th>First observed</th><th>Latest observation</th></tr></thead><tbody>${historyRows}</tbody></table>`
+          : '<div class="admin-muted">No history rows yet. Nightly runs will populate this once a manifest_id changes.</div>'}
+      </div>
+    </div>`;
+}

--- a/js/admin/main.js
+++ b/js/admin/main.js
@@ -1,6 +1,6 @@
 import { SupaAuth, SUPABASE_URL } from './config.js?v=ffed3d84';
 import { supabaseHeaders, escapeHtml } from './utils.js?v=2668b2f0';
-import { effectivePermissions, hasPermission, canSeeTab, resolveRoleLabel, PERMISSION_LABELS, presetFor, addPermission, removePermission } from './permissions.js?v=12b82ef4';
+import { effectivePermissions, hasPermission, canSeeTab, resolveRoleLabel, PERMISSION_LABELS, presetFor, addPermission, removePermission } from './permissions.js?v=e2aa69ae';
 import { fetchFlaggedReports, updateFlagStatus, deleteFlaggedReport, fetchFlagReportContent, findPulseConfigId, shadowBanReport, releaseReportContent, deleteReportContent, suppressMirrorReport, unsuppressMirrorReport, fetchReportState } from './api/flagged.js?v=9359a45e';
 import { renderFlagged, renderFlagDetail } from './components/flagged.js?v=5e2c6b60';
 import { fetchBannedUsers, banUser, unbanUser } from './api/banned.js?v=0d6ec118';
@@ -17,6 +17,7 @@ import { renderUserDetail } from './components/userDetail.js?v=5ff164c0';
 import { fetchAnalytics } from './api/analytics.js?v=a1c14331';
 import { renderAnalytics } from './components/analytics.js?v=e538dd08';
 import { renderCacheStatus } from './components/cache-status.js?v=0c6c0cb7';
+import { renderDepotTracking } from './components/depotTracking.js?v=8ce33fc6';
 import { renderBoxartAdmin, renderBoxartAdminDetail } from './components/boxart.js?v=bd0825b6';
 import { renderApiExplorer } from './components/api-explorer.js?v=1d2d1835';
 import { renderAllReports, updateAllReportsRow, renderAllReportsDetail } from './components/allReports.js?v=99d5c1f5';
@@ -455,6 +456,10 @@ const TAB_LOADERS = {
   analytics: loadAnalytics,
   boxart: () => renderBoxartAdmin().catch(e => console.error('[boxart]', e)),
   'api-explorer': () => renderApiExplorer(),
+  'depot-tracking': () => {
+    const host = document.getElementById('depot-tracking-content');
+    if (host) renderDepotTracking(host).catch(e => console.error('[depot-tracking]', e));
+  },
 };
 
 // Activate a tab, load its data, and reflect it in the URL as ?tab=<name> so a

--- a/js/admin/permissions.js
+++ b/js/admin/permissions.js
@@ -31,6 +31,7 @@ export const TAB_PERMISSIONS = {
   analytics:      ['view_analytics'],
   boxart:         ['view_analytics'],
   'api-explorer': ['view_analytics'],
+  'depot-tracking': ['view_analytics'],
 };
 
 // Effective permissions for an admin. super_admin short-circuits to all.

--- a/tests/depotTracking.test.js
+++ b/tests/depotTracking.test.js
@@ -1,0 +1,186 @@
+/**
+ * Tests for js/admin/api/depotTracking.js.
+ *
+ * The reads and the pure summarizeApps aggregation are the interesting
+ * bits; the render fn is a source-shape smoke test (kept minimal).
+ */
+
+// depotTracking imports SUPABASE_URL from js/admin/config.js. Stub that
+// out before requiring the module.
+jest.mock('../js/admin/config.js', () => ({
+  SUPABASE_URL:      'https://test.supabase.co',
+  SUPABASE_ANON_KEY: 'test-anon',
+}), { virtual: true });
+
+const {
+  fetchDepotFetchStatus,
+  fetchDepotUpdatesForApps,
+  fetchManifestHistoryForApps,
+  fetchDepotTrackingDossier,
+  summarizeApps,
+} = require('../js/admin/api/depotTracking.js');
+
+function stubFetchByUrl(routes) {
+  return jest.fn(async (url) => {
+    for (const [prefix, payload] of Object.entries(routes)) {
+      if (url.includes(prefix)) {
+        return {
+          ok: true, status: 200,
+          json: async () => (typeof payload === 'function' ? payload(url) : payload),
+        };
+      }
+    }
+    // Unknown URL -> HTTP 500 so it's obviously a test miss
+    return { ok: false, status: 500, json: async () => ({}) };
+  });
+}
+
+afterEach(() => { delete global.fetch; });
+
+describe('summarizeApps (pure)', () => {
+  const now = 1_700_000_000_000; // fixed reference so 24h/7d/30d math is deterministic
+  const iso = (offsetDays) => new Date(now - offsetDays * 86400_000).toISOString();
+
+  beforeEach(() => { jest.spyOn(Date, 'now').mockReturnValue(now); });
+  afterEach(()  => Date.now.mockRestore?.());
+
+  test('empty input yields all zeros', () => {
+    expect(summarizeApps([])).toEqual({
+      total: 0, ok: 0, noManifest: 0, error: 0,
+      newest: null, updatedIn24h: 0, updatedIn7d: 0, updatedIn30d: 0,
+    });
+  });
+
+  test('counts status buckets independently', () => {
+    const s = summarizeApps([
+      { app_status: 'ok', fetched_at: iso(1), history: null },
+      { app_status: 'ok', fetched_at: iso(2), history: null },
+      { app_status: 'no_public_manifest', fetched_at: iso(3), history: null },
+      { app_status: 'error', fetched_at: iso(4), history: null },
+    ]);
+    expect(s.total).toBe(4);
+    expect(s.ok).toBe(2);
+    expect(s.noManifest).toBe(1);
+    expect(s.error).toBe(1);
+  });
+
+  test('newest fetch is the max of fetched_at across the batch', () => {
+    const s = summarizeApps([
+      { app_status: 'ok', fetched_at: iso(3), history: null },
+      { app_status: 'ok', fetched_at: iso(1), history: null },
+      { app_status: 'ok', fetched_at: iso(5), history: null },
+    ]);
+    expect(s.newest).toBe(iso(1));
+  });
+
+  test('manifest-change windows count history observations by age', () => {
+    const s = summarizeApps([
+      { app_status: 'ok', fetched_at: iso(0), history: { newestFirstObserved: iso(0.5) } },  // in all three windows
+      { app_status: 'ok', fetched_at: iso(0), history: { newestFirstObserved: iso(2)  } },   // 7d + 30d only
+      { app_status: 'ok', fetched_at: iso(0), history: { newestFirstObserved: iso(10) } },   // 30d only
+      { app_status: 'ok', fetched_at: iso(0), history: { newestFirstObserved: iso(45) } },   // none
+      { app_status: 'ok', fetched_at: iso(0), history: null },                                // none (no history)
+    ]);
+    expect(s.updatedIn24h).toBe(1);
+    expect(s.updatedIn7d).toBe(2);
+    expect(s.updatedIn30d).toBe(3);
+  });
+});
+
+describe('fetchDepotFetchStatus', () => {
+  test('hits the correct REST URL and returns rows', async () => {
+    global.fetch = stubFetchByUrl({
+      '/rest/v1/steam_depot_fetch_status': [{ app_id: 1, app_status: 'ok', depot_count: 3, fetched_at: '2026-07-08', error: null }],
+    });
+    const rows = await fetchDepotFetchStatus();
+    expect(Array.isArray(rows)).toBe(true);
+    expect(rows[0].app_id).toBe(1);
+    const url = global.fetch.mock.calls[0][0];
+    expect(url).toContain('steam_depot_fetch_status');
+    expect(url).toContain('order=fetched_at.desc');
+    expect(url).toContain('select=app_id,app_status,depot_count,fetched_at,error');
+  });
+});
+
+describe('fetchDepotUpdatesForApps', () => {
+  test('empty input short-circuits to {}', async () => {
+    global.fetch = jest.fn();
+    const out = await fetchDepotUpdatesForApps([]);
+    expect(out).toEqual({});
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('groups rows by app_id', async () => {
+    global.fetch = stubFetchByUrl({
+      '/rest/v1/steam_depot_updates': [
+        { app_id: 1, os: 'windows', depot_id: 11, manifest_id: 'a', last_updated_at: '2026-07-07T00:00:00Z', name: null },
+        { app_id: 1, os: 'linux',   depot_id: 12, manifest_id: 'b', last_updated_at: '2026-07-07T00:00:00Z', name: null },
+        { app_id: 2, os: 'windows', depot_id: 21, manifest_id: 'c', last_updated_at: '2026-07-07T00:00:00Z', name: null },
+      ],
+    });
+    const out = await fetchDepotUpdatesForApps([1, 2]);
+    expect(Object.keys(out).sort()).toEqual(['1', '2']);
+    expect(out['1']).toHaveLength(2);
+    expect(out['2']).toHaveLength(1);
+  });
+
+  test('chunks large lists into 100-app requests', async () => {
+    global.fetch = stubFetchByUrl({ '/rest/v1/steam_depot_updates': [] });
+    const ids = Array.from({ length: 205 }, (_, i) => i + 1);
+    await fetchDepotUpdatesForApps(ids);
+    // 205 ids / 100 per chunk = ceil(2.05) = 3 requests
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('fetchManifestHistoryForApps', () => {
+  test('aggregates per-OS min / max first_observed_at + count', async () => {
+    global.fetch = stubFetchByUrl({
+      '/rest/v1/steam_depot_manifest_history': [
+        { app_id: 1, os: 'linux',   first_observed_at: '2026-07-01T00:00:00Z', latest_observed_at: '2026-07-08T00:00:00Z' },
+        { app_id: 1, os: 'linux',   first_observed_at: '2026-07-05T00:00:00Z', latest_observed_at: '2026-07-08T00:00:00Z' },
+        { app_id: 1, os: 'windows', first_observed_at: '2026-07-03T00:00:00Z', latest_observed_at: '2026-07-08T00:00:00Z' },
+      ],
+    });
+    const out = await fetchManifestHistoryForApps([1]);
+    const one = out['1'];
+    expect(one.manifestCount).toBe(3);
+    expect(one.oldestFirstObserved).toBe('2026-07-01T00:00:00Z');
+    expect(one.newestFirstObserved).toBe('2026-07-05T00:00:00Z');
+    expect(one.perOs.linux.count).toBe(2);
+    expect(one.perOs.linux.oldestFirstObserved).toBe('2026-07-01T00:00:00Z');
+    expect(one.perOs.linux.newestFirstObserved).toBe('2026-07-05T00:00:00Z');
+    expect(one.perOs.windows.count).toBe(1);
+  });
+});
+
+describe('fetchDepotTrackingDossier', () => {
+  test('joins the three reads into a per-app dossier + summary', async () => {
+    global.fetch = stubFetchByUrl({
+      '/rest/v1/steam_depot_fetch_status': [
+        { app_id: 1, app_status: 'ok', depot_count: 2, fetched_at: '2026-07-08T00:00:00Z', error: null },
+        { app_id: 2, app_status: 'error', depot_count: 0, fetched_at: '2026-07-07T00:00:00Z', error: 'boom' },
+      ],
+      '/rest/v1/steam_depot_updates': [
+        { app_id: 1, os: 'linux', depot_id: 11, manifest_id: 'a', last_updated_at: '2026-07-07T00:00:00Z', name: null },
+      ],
+      '/rest/v1/steam_depot_manifest_history': [
+        { app_id: 1, os: 'linux', first_observed_at: '2026-07-06T00:00:00Z', latest_observed_at: '2026-07-08T00:00:00Z' },
+      ],
+    });
+    const dossier = await fetchDepotTrackingDossier();
+    expect(dossier.apps).toHaveLength(2);
+    // Order preserved from status query
+    expect(dossier.apps[0].app_id).toBe(1);
+    expect(dossier.apps[0].depots).toHaveLength(1);
+    expect(dossier.apps[0].history.manifestCount).toBe(1);
+    // App 2 has no depot / history rows but still appears
+    expect(dossier.apps[1].app_id).toBe(2);
+    expect(dossier.apps[1].depots).toEqual([]);
+    expect(dossier.apps[1].history).toBeNull();
+    // Aggregate reflects the two rows
+    expect(dossier.aggregate.total).toBe(2);
+    expect(dossier.aggregate.ok).toBe(1);
+    expect(dossier.aggregate.error).toBe(1);
+  });
+});


### PR DESCRIPTION
Read-only admin panel that surfaces the Steam PICS pipeline health in one place so we do not have to open the Actions log or Supabase dashboard.

## What ships

- Tab entry in admin.html + main.js loader + view_analytics permission gate (same as boxart / api-explorer)
- js/admin/api/depotTracking.js — three anon-key REST reads joined into a per-app dossier, chunked at 100 apps per request
- js/admin/components/depotTracking.js — aggregate cards + per-app expandable table with free-text filter over app_id + status
- CSS additions matching the existing admin look
- 10 tests covering pure summarizeApps math + REST fetches + dossier join

Aggregate cards:
- Total tracked / OK / No manifest / Errors
- Newest fetch (with relative time)
- Manifests changed 24h / 7d / 30d

Each row expands to show:
- Current depots (OS, manifest_id, last_updated_at)
- Manifest history per OS (count, oldest / newest first_observed_at)

## Scope

MVP is read-only. Actions (workflow_dispatch against a single app id, force re-fetch, delete cached history) require a new signed-in-admin edge function and will land as a follow-up.

## Test plan

- [ ] make pre-push -> 1502 passed
- [ ] After merge, visit /admin.html?tab=depot-tracking as a view_analytics admin
- [ ] Confirm Hollow Knight (367520) row appears with status=ok, 3 depots, all three OS chips lit, expand shows current manifest_ids + per-OS history row (linux/mac/windows count=1)