### PR TITLE
Pipeline: validate Steam app IDs and detect redirects

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -316,6 +316,7 @@ jobs:
           cp gh-pages-data/game-images-cache.json /tmp/protondb-output/ 2>/dev/null || true
           cp gh-pages-data/nonsteam-images-cache.json /tmp/protondb-output/ 2>/dev/null || true
           cp gh-pages-data/release-years-cache.json /tmp/protondb-output/ 2>/dev/null || true
+          cp gh-pages-data/app-id-validation-cache.json /tmp/protondb-output/ 2>/dev/null || true
 
       - name: Restore pipeline cache
         uses: actions/cache/restore@v4
@@ -496,7 +497,7 @@ jobs:
           git add data/ data-index.html coverage.html search-index.json scoring-info.json form-schema.json badges/
           # add optional pipeline outputs (skip silently if a fresh checkout
           # didn't have them yet, e.g. first run after introducing the file)
-          for f in coverage-summary.json stats.json recent-reports.json game-images.json game-images-skip.json game-images-cache.json nonsteam-images-cache.json release-years-cache.json gog-catalog-cache.json epic-catalog-cache.json most_played.json deck-status.json proton-versions.json steam-catalog.json hardware-suggestions.json nonsteam-images.json data-versions.json search-index-steam-extended.json; do
+          for f in coverage-summary.json stats.json recent-reports.json game-images.json game-images-skip.json game-images-cache.json nonsteam-images-cache.json release-years-cache.json gog-catalog-cache.json epic-catalog-cache.json most_played.json deck-status.json proton-versions.json steam-catalog.json hardware-suggestions.json nonsteam-images.json data-versions.json search-index-steam-extended.json app-id-redirects.json app-id-validation-cache.json; do
             [ -f "$f" ] && git add "$f"
           done
           while IFS= read -r path; do
@@ -560,7 +561,7 @@ jobs:
           curl -sL https://raw.githubusercontent.com/mdeguzis/decky-proton-pulse/main/src/data/scoring-info.json -o scoring-info.json
           curl -sL https://raw.githubusercontent.com/mdeguzis/decky-proton-pulse/main/src/data/form-schema.json -o form-schema.json
           git add data/ data-index.html coverage.html search-index.json scoring-info.json form-schema.json
-          for f in coverage-summary.json stats.json recent-reports.json game-images.json game-images-skip.json game-images-cache.json nonsteam-images-cache.json release-years-cache.json gog-catalog-cache.json epic-catalog-cache.json most_played.json deck-status.json proton-versions.json steam-catalog.json hardware-suggestions.json nonsteam-images.json data-versions.json search-index-steam-extended.json; do
+          for f in coverage-summary.json stats.json recent-reports.json game-images.json game-images-skip.json game-images-cache.json nonsteam-images-cache.json release-years-cache.json gog-catalog-cache.json epic-catalog-cache.json most_played.json deck-status.json proton-versions.json steam-catalog.json hardware-suggestions.json nonsteam-images.json data-versions.json search-index-steam-extended.json app-id-redirects.json app-id-validation-cache.json; do
             [ -f "$f" ] && git add "$f"
           done
           while IFS= read -r path; do
@@ -826,7 +827,7 @@ jobs:
           git add data/ data-index.html coverage.html search-index.json scoring-info.json form-schema.json badges/
           # add optional pipeline outputs (skip silently if a fresh checkout
           # didn't have them yet, e.g. first run after introducing the file)
-          for f in coverage-summary.json stats.json recent-reports.json game-images.json game-images-skip.json game-images-cache.json nonsteam-images-cache.json release-years-cache.json gog-catalog-cache.json epic-catalog-cache.json most_played.json deck-status.json proton-versions.json steam-catalog.json hardware-suggestions.json nonsteam-images.json data-versions.json search-index-steam-extended.json; do
+          for f in coverage-summary.json stats.json recent-reports.json game-images.json game-images-skip.json game-images-cache.json nonsteam-images-cache.json release-years-cache.json gog-catalog-cache.json epic-catalog-cache.json most_played.json deck-status.json proton-versions.json steam-catalog.json hardware-suggestions.json nonsteam-images.json data-versions.json search-index-steam-extended.json app-id-redirects.json app-id-validation-cache.json; do
             [ -f "$f" ] && git add "$f"
           done
           while IFS= read -r path; do
@@ -1048,7 +1049,7 @@ jobs:
           git add data/ data-index.html coverage.html search-index.json scoring-info.json form-schema.json badges/
           # add optional pipeline outputs (skip silently if a fresh checkout
           # didn't have them yet, e.g. first run after introducing the file)
-          for f in coverage-summary.json stats.json recent-reports.json game-images.json game-images-skip.json game-images-cache.json nonsteam-images-cache.json release-years-cache.json gog-catalog-cache.json epic-catalog-cache.json most_played.json deck-status.json proton-versions.json steam-catalog.json hardware-suggestions.json nonsteam-images.json data-versions.json search-index-steam-extended.json; do
+          for f in coverage-summary.json stats.json recent-reports.json game-images.json game-images-skip.json game-images-cache.json nonsteam-images-cache.json release-years-cache.json gog-catalog-cache.json epic-catalog-cache.json most_played.json deck-status.json proton-versions.json steam-catalog.json hardware-suggestions.json nonsteam-images.json data-versions.json search-index-steam-extended.json app-id-redirects.json app-id-validation-cache.json; do
             [ -f "$f" ] && git add "$f"
           done
           while IFS= read -r path; do

--- a/app.html
+++ b/app.html
@@ -17,7 +17,7 @@
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/filters.css?v=4a590596">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/app/game-header.css?v=dbecc5e0">
+<link rel="stylesheet" href="css/app/game-header.css?v=68a12cde">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=6df19441">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">

--- a/confidence.html
+++ b/confidence.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=c550d77b">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/app/game-header.css?v=dbecc5e0">
+<link rel="stylesheet" href="css/app/game-header.css?v=68a12cde">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=6df19441">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">

--- a/css/app/game-header.css
+++ b/css/app/game-header.css
@@ -1357,6 +1357,11 @@
 /* Real depot dates from the #215 PICS cache -- render in mono so they
    line up under the "Last update" column heading. */
 .gm-depot-date { font-family: var(--mono); color: var(--text); }
+/* Italic + dimmer variant means the value fell back to the branch-level
+   PICS timestamp because the observation history (#226) has not recorded
+   a manifest_id change for this app yet. Both First seen and Last update
+   read the same value in that state -- tooltip explains. */
+.gm-depot-date--approx { font-style: italic; color: var(--muted); }
 .gm-plat-foot {
   padding-top: 6px !important;
   font-size: 0.68rem;

--- a/game-stats.html
+++ b/game-stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=c550d77b">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/app/game-header.css?v=dbecc5e0">
+<link rel="stylesheet" href="css/app/game-header.css?v=68a12cde">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=6df19441">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -280,38 +280,55 @@ async function _openMetadataModal(appId) {
       if (Number.isNaN(d.getTime())) return null;
       return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
     };
-    // First seen + Last update ONLY come from the steamcmd depot cache
-    // (steam_depot_updates via #215). We deliberately do NOT fall through
-    // to the app-wide release date -- that used to be shown here and
-    // confused viewers into thinking it was per-OS depot data, which it
-    // is not. Release date has its own row above the table.
+    // Two possible sources per OS (see supabase/functions/steam-depot-info):
+    //   source='history'         -> Phase 2 observation table (#226).
+    //     first_seen  = MIN(first_observed_at) over manifest_ids we have
+    //                  ever seen for this (app, os). Real per-OS tracking
+    //                  floor -- 'we started watching this on X'.
+    //     last_updated = MAX(first_observed_at) -- last time a new
+    //                  manifest_id was observed = last shipped build.
+    //   source='branch-fallback' -> only Phase 1 data; first_seen ==
+    //     last_updated because both read from the shared branch-level
+    //     PICS timestamp.
+    // Tooltip on the date cell tells the truth about which source the
+    // number came from so users are not misled by a fallback value.
     const row = (key, label) => {
       const on = !!p[key];
       const cached = dOs[key];
-      const lastFmt = fmtDate(cached?.last_updated);
-      let depotsCell;
-      let lastCell;
+      const firstFmt = fmtDate(cached?.first_seen);
+      const lastFmt  = fmtDate(cached?.last_updated);
+      const isHistory = cached?.source === 'history';
+      let depotsCell, firstCell, lastCell;
       if (!on) {
         depotsCell = '<span class="gm-mute">not offered</span>';
+        firstCell  = '-';
         lastCell   = '-';
-      } else if (lastFmt) {
-        depotsCell = `<span class="gm-mute">${cached.depots} tracked</span>`;
-        lastCell   = `<span class="gm-depot-date" title="Branch-level timeupdated from PICS -- every OS depot on a shared branch inherits this value. Per-OS 'First seen' requires observation history (#226).">${esc(lastFmt)}</span>`;
+      } else if (firstFmt && lastFmt) {
+        const depotCountLbl = `${cached.depots} tracked${isHistory && cached.manifests ? ` &middot; ${cached.manifests} manifest${cached.manifests === 1 ? '' : 's'} in history` : ''}`;
+        depotsCell = `<span class="gm-mute">${depotCountLbl}</span>`;
+        firstCell = isHistory
+          ? `<span class="gm-depot-date" title="Earliest date we observed a manifest for this OS depot. Not necessarily when the depot was created -- our observation window starts July 2026 (#226).">${esc(firstFmt)}</span>`
+          : `<span class="gm-depot-date gm-depot-date--approx" title="Branch-level PICS timestamp -- observation history not yet populated for this app. Once nightly runs record a manifest_id change we can show a real per-OS first_seen.">${esc(firstFmt)}</span>`;
+        lastCell = isHistory
+          ? `<span class="gm-depot-date" title="Most recent manifest_id observation -- proxy for 'this OS build shipped'. From steam_depot_manifest_history (#226).">${esc(lastFmt)}</span>`
+          : `<span class="gm-depot-date gm-depot-date--approx" title="Branch-level PICS timestamp -- same value across all OS depots on this branch until observation history is populated.">${esc(lastFmt)}</span>`;
       } else {
         depotsCell = '<span class="gm-mute" title="Not cached yet -- pipeline #215 populates this nightly">pending</span>';
+        firstCell  = '-';
         lastCell   = `<a class="gm-depot-link" href="https://steamdb.info/app/${esc(meta.appId)}/depots/" target="_blank" rel="noopener">SteamDB -&gt;</a>`;
       }
       return `
         <tr>
           <td><span class="gm-plat${on ? ' gm-plat--on' : ''}">${esc(label)}</span></td>
           <td>${depotsCell}</td>
+          <td>${firstCell}</td>
           <td>${lastCell}</td>
         </tr>`;
     };
     return `<table class="gm-plat-table">
-      <thead><tr><th>OS</th><th>Depots</th><th>Last update</th></tr></thead>
+      <thead><tr><th>OS</th><th>Depots</th><th>First seen</th><th>Last update</th></tr></thead>
       <tbody>${row('windows','Windows')}${row('mac','macOS')}${row('linux','Linux')}</tbody>
-      <tfoot><tr><td colspan="3" class="gm-plat-foot">Last update is the branch-level timestamp from PICS -- every OS depot on the same branch shares one value. Per-OS 'first seen' needs observation history (#226). ${
+      <tfoot><tr><td colspan="4" class="gm-plat-foot">'First seen' and 'Last update' come from our own manifest observation history (#226). Dates in italics are the pre-history branch-level timestamp (same value for both cells) until nightly runs record a manifest change. ${
         newsInfo?.found && newsInfo.newest_ts
           ? `App-wide 'Last patch note' (${esc(new Date(newsInfo.newest_ts * 1000).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }))}) below is the public-API fallback when a specific OS row shows 'pending'.`
           : ''

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=1b8ae722';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=003f23c0';
-import { renderGamePage } from './game-page.js?v=5a0c3324';
+import { renderGamePage } from './game-page.js?v=ab28f71b';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId, fetchDataWithProdFallback } from '../config.js?v=f9591262';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=c7e1268c';
 import { renderGameCard } from '../lib/card.js?v=5642a459';

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,6 +1,6 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=5a0c3324';
+import { renderGamePage } from './components/game-page.js?v=ab28f71b';
 import { renderHomePage } from './components/home.js?v=1aa3e1ab';
 import { renderSearchPage } from './components/search.js?v=598aaad1';
 

--- a/scripts/pipeline/finalize.py
+++ b/scripts/pipeline/finalize.py
@@ -54,6 +54,7 @@ from .release_years import enrich_search_index_with_release_years
 from .pulse import merge_pulse_into_data_dir
 from .state import read_pipeline_state
 from .stats import write_stats_json
+from .validate_app_ids import validate_steam_app_ids
 
 
 def log_summary(
@@ -1780,6 +1781,7 @@ def finalize_output(output_dir, skip_probe: bool = False):
     # appdetails. Flag them in search-index.json column 7 so the frontend can
     # render a DELISTED chip without re-fetching anything client-side.
     enrich_search_index_with_delisted(output_path)
+    validate_steam_app_ids(output_dir)
     # Issue #134: emit the extended Steam index AFTER the primary index has
     # been finalized (release-year + delisted enrichment runs first), so the
     # primary id set we read back is the final one.

--- a/scripts/pipeline/steam_metadata.py
+++ b/scripts/pipeline/steam_metadata.py
@@ -367,6 +367,46 @@ def upsert_depot_rows(rows: Iterable[DepotRow]) -> int:
     return len(payload)
 
 
+def upsert_manifest_history_rows(rows: Iterable[DepotRow]) -> int:
+    """Observation history for issue #226 (Phase 2 of the depot plan).
+
+    For each (app_id, depot_id, os, manifest_id) tuple we've never seen,
+    INSERT with first_observed_at = now(). For tuples we HAVE seen, bump
+    latest_observed_at to now(). When a game ships a build the manifest_id
+    changes for the affected depots -> a fresh row is inserted; the
+    previous row stays forever with its latest_observed_at frozen at the
+    time of the last observation, so we build a durable per-OS timeline.
+
+    Rows without a manifest_id are skipped -- the history is keyed on
+    manifest_id, and depots that PICS returned with no manifest are the
+    exact rows we cannot record change history for.
+    """
+    payload = [
+        {
+            "app_id":             r.app_id,
+            "depot_id":           r.depot_id,
+            "os":                 r.os,
+            "manifest_id":        r.manifest_id,
+            "latest_observed_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        }
+        for r in rows
+        if r.manifest_id  # skip depots that ship without a public manifest gid
+    ]
+    if not payload:
+        return 0
+    # on_conflict specifies our composite PK. Prefer: merge-duplicates means
+    # existing rows keep first_observed_at (never overwritten) and only
+    # latest_observed_at is bumped -- exactly the shape we want. The
+    # default column value 'now()' fires on INSERT only.
+    url = f"{_supabase_base()}/steam_depot_manifest_history?on_conflict=app_id,depot_id,os,manifest_id"
+    req = urllib.request.Request(
+        url, data=json.dumps(payload).encode(), method="POST",
+        headers=_supabase_headers(),
+    )
+    urllib.request.urlopen(req, timeout=30).read()
+    return len(payload)
+
+
 def upsert_fetch_status(app_id: int, status: str, depot_count: int, error: str | None = None) -> None:
     url = f"{_supabase_base()}/steam_depot_fetch_status?on_conflict=app_id"
     payload = [{
@@ -432,6 +472,15 @@ def fetch_and_store(app_id: int, sleep_between: float = 3.0) -> tuple[str, int]:
         upsert_fetch_status(app_id, "no_public_manifest", 0, "parsed appinfo but no OS-bound depot rows")
         return "no_public_manifest", 0
     n = upsert_depot_rows(rows)
+    # Feed the same rows into the manifest observation history so per-OS
+    # First seen / Last update become real dates. Failures here should
+    # NOT flip the status to error -- the primary depot_updates write is
+    # already durable; history is a strict enhancement. Log + continue.
+    try:
+        h = upsert_manifest_history_rows(rows)
+        log(f"steam-metadata: app={app_id} history rows upserted={h} source=depot-history")
+    except Exception as e:
+        log(f"steam-metadata: app={app_id} history upsert failed error={e}")
     upsert_fetch_status(app_id, "ok", n, None)
     log(f"steam-metadata: app={app_id} rows={n} source=steamcmd-pics")
     return "ok", n

--- a/scripts/pipeline/validate_app_ids.py
+++ b/scripts/pipeline/validate_app_ids.py
@@ -1,0 +1,171 @@
+"""Validate Steam app IDs by following store page redirects.
+
+Detects:
+  - Dead app IDs that redirect to the Steam homepage (removed/invalid)
+  - Replaced app IDs that redirect to a different app (superseded entries)
+  - Valid app IDs that resolve to their own store page
+
+Output: app-id-redirects.json
+  { "<original_id>": { "status": "replaced", "replaced_by": "<new_id>" },
+    "<original_id>": { "status": "dead", "final_url": "..." },
+    ... }
+
+Only entries with problems are written (valid IDs are omitted to keep the file
+small). The frontend and admin panel can use this to fix links and surface
+warnings. A persistent cache (app-id-validation-cache.json) avoids re-probing
+IDs that have already been checked.
+"""
+
+import json
+import re
+import time
+import urllib.request
+import urllib.error
+from datetime import date, timedelta
+from pathlib import Path
+
+from .common import log
+
+STEAM_STORE_URL = "https://store.steampowered.com/app/{app_id}/"
+PROBE_CAP = 200
+STALE_DAYS = 90
+BATCH_DELAY = 0.35
+
+
+def _follow_redirects(app_id: str) -> dict:
+    """Follow redirects for a Steam store page and return the resolution."""
+    url = STEAM_STORE_URL.format(app_id=app_id)
+    try:
+        req = urllib.request.Request(
+            url,
+            headers={
+                "User-Agent": "Mozilla/5.0 (compatible; ProtonPulse/1.0)",
+                "Cookie": "birthtime=0; wants_mature_content=1",
+            },
+        )
+        opener = urllib.request.build_opener(urllib.request.HTTPRedirectHandler)
+        resp = opener.open(req, timeout=15)
+        final_url = resp.url
+        resp.close()
+
+        if f"/app/{app_id}" in final_url:
+            return {"status": "valid"}
+
+        app_match = re.search(r"/app/(\d+)", final_url)
+        if app_match:
+            new_id = app_match.group(1)
+            if new_id != app_id:
+                return {"status": "replaced", "replaced_by": new_id, "final_url": final_url}
+
+        if "/app/" not in final_url:
+            return {"status": "dead", "final_url": final_url}
+
+        return {"status": "valid"}
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return {"status": "dead", "final_url": url, "http_status": 404}
+        return {"status": "error", "http_status": e.code}
+    except Exception as exc:
+        return {"status": "error", "error": str(exc)}
+
+
+def _load_cache(output_dir: Path) -> dict:
+    cache_path = output_dir / "app-id-validation-cache.json"
+    if cache_path.exists():
+        try:
+            return json.loads(cache_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            log(f"[validate-appids] WARN: could not load cache: {exc}")
+    return {}
+
+
+def _save_cache(output_dir: Path, cache: dict) -> None:
+    cache_path = output_dir / "app-id-validation-cache.json"
+    cache_path.write_text(json.dumps(cache, separators=(",", ":")), encoding="utf-8")
+
+
+def _is_stale(entry: dict) -> bool:
+    probed = entry.get("probed_at", "")
+    if not probed:
+        return True
+    try:
+        probed_date = date.fromisoformat(probed)
+        return (date.today() - probed_date) > timedelta(days=STALE_DAYS)
+    except ValueError:
+        return True
+
+
+def validate_steam_app_ids(output_dir: str) -> dict:
+    """Validate Steam app IDs from the search index. Returns the redirect map."""
+    output_path = Path(output_dir)
+    search_index_path = output_path / "search-index.json"
+    if not search_index_path.exists():
+        log("[validate-appids] No search-index.json found, skipping")
+        return {}
+
+    index = json.loads(search_index_path.read_text(encoding="utf-8"))
+    steam_ids = []
+    for row in index:
+        if not isinstance(row, list) or len(row) < 6:
+            continue
+        app_id = str(row[0])
+        app_type = row[5] if len(row) > 5 else "steam"
+        if app_type == "steam" and app_id.isdigit():
+            steam_ids.append(app_id)
+
+    cache = _load_cache(output_path)
+    today = date.today().isoformat()
+
+    to_probe = []
+    for app_id in steam_ids:
+        entry = cache.get(app_id)
+        if entry is None or _is_stale(entry):
+            to_probe.append(app_id)
+
+    if not to_probe:
+        log("[validate-appids] All app IDs cached and fresh, nothing to probe")
+    else:
+        capped = to_probe[:PROBE_CAP]
+        log(f"[validate-appids] Probing {len(capped)}/{len(to_probe)} uncached/stale Steam app IDs")
+
+        probed = 0
+        for app_id in capped:
+            result = _follow_redirects(app_id)
+            result["probed_at"] = today
+            cache[app_id] = result
+            probed += 1
+            if probed % 50 == 0:
+                log(f"[validate-appids]   ...{probed}/{len(capped)} probed")
+            if result.get("status") == "error":
+                log(f"[validate-appids] WARN: error probing {app_id}: {result}")
+            time.sleep(BATCH_DELAY)
+
+        _save_cache(output_path, cache)
+        log(f"[validate-appids] Probed {probed} app IDs, cache now has {len(cache)} entries")
+
+    redirects = {}
+    for app_id, entry in cache.items():
+        status = entry.get("status")
+        if status == "replaced":
+            redirects[app_id] = {
+                "status": "replaced",
+                "replaced_by": entry["replaced_by"],
+                "final_url": entry.get("final_url", ""),
+            }
+        elif status == "dead":
+            redirects[app_id] = {
+                "status": "dead",
+                "final_url": entry.get("final_url", ""),
+            }
+
+    redirect_path = output_path / "app-id-redirects.json"
+    redirect_path.write_text(
+        json.dumps(redirects, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    replaced_count = sum(1 for v in redirects.values() if v["status"] == "replaced")
+    dead_count = sum(1 for v in redirects.values() if v["status"] == "dead")
+    log(f"[validate-appids] Results: {replaced_count} replaced, {dead_count} dead, written to app-id-redirects.json")
+
+    return redirects

--- a/scripts/pipeline/validate_app_ids.py
+++ b/scripts/pipeline/validate_app_ids.py
@@ -33,34 +33,43 @@ BATCH_DELAY = 0.35
 
 
 def _follow_redirects(app_id: str) -> dict:
-    """Follow redirects for a Steam store page and return the resolution."""
+    """Follow redirects for a Steam store page and return the resolution.
+
+    Steam categorization comes from the final path segment after urllib
+    resolves 3xx redirects transparently:
+      - `/app/<same_id>/...` -> valid
+      - `/app/<different_id>/...` -> replaced (superseded appid)
+      - no `/app/<digits>/` -> dead (redirected to homepage or elsewhere)
+    """
     url = STEAM_STORE_URL.format(app_id=app_id)
     try:
         req = urllib.request.Request(
             url,
             headers={
+                # Age-gate bypass cookies -- mature titles otherwise redirect
+                # to /agecheck/ instead of the store page.
                 "User-Agent": "Mozilla/5.0 (compatible; ProtonPulse/1.0)",
                 "Cookie": "birthtime=0; wants_mature_content=1",
             },
         )
-        opener = urllib.request.build_opener(urllib.request.HTTPRedirectHandler)
-        resp = opener.open(req, timeout=15)
+        # urlopen() already follows 3xx via the default opener; no need for
+        # a custom HTTPRedirectHandler.
+        resp = urllib.request.urlopen(req, timeout=15)
         final_url = resp.url
         resp.close()
 
-        if f"/app/{app_id}" in final_url:
-            return {"status": "valid"}
-
+        # Compare IDs exactly against the extracted numeric segment. A naive
+        # substring check like `f"/app/{app_id}" in final_url` false-positives
+        # when the redirect target's ID starts with app_id -- e.g. app_id=26
+        # redirected to /app/2670/ would look "valid" but is actually replaced.
         app_match = re.search(r"/app/(\d+)", final_url)
         if app_match:
             new_id = app_match.group(1)
-            if new_id != app_id:
-                return {"status": "replaced", "replaced_by": new_id, "final_url": final_url}
+            if new_id == app_id:
+                return {"status": "valid"}
+            return {"status": "replaced", "replaced_by": new_id, "final_url": final_url}
 
-        if "/app/" not in final_url:
-            return {"status": "dead", "final_url": final_url}
-
-        return {"status": "valid"}
+        return {"status": "dead", "final_url": final_url}
     except urllib.error.HTTPError as e:
         if e.code == 404:
             return {"status": "dead", "final_url": url, "http_status": 404}

--- a/submit.html
+++ b/submit.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=c550d77b">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/app/game-header.css?v=dbecc5e0">
+<link rel="stylesheet" href="css/app/game-header.css?v=68a12cde">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=6df19441">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">

--- a/supabase/functions/steam-depot-info/index.ts
+++ b/supabase/functions/steam-depot-info/index.ts
@@ -51,19 +51,37 @@ Deno.serve(async (req: Request) => {
     );
   }
   const supabase = createClient(supabaseUrl, supabaseKey);
-  const { data, error } = await supabase
-    .from("steam_depot_updates")
-    .select("app_id,os,depot_id,last_updated_at")
-    .eq("app_id", Number(appId));
 
-  if (error) {
-    console.error(`[steam-depot-info] appId=${appId} query error=${error.message}`);
+  // Two reads in parallel:
+  //   depot_updates   -> current per-depot state (last_updated_at is the
+  //                      branch-level timestamp; same across all OS depots
+  //                      for a given app on the same branch).
+  //   manifest_history -> Phase 2 observation table (#226). Every row is
+  //                      a (app, depot, os, manifest_id) tuple we've ever
+  //                      seen with first_observed_at + latest_observed_at.
+  //                      Per-OS First seen  = MIN(first_observed_at).
+  //                      Per-OS Last update = MAX(first_observed_at)
+  //                      (a fresh manifest_id observation means a build
+  //                      shipped for that OS).
+  const [depotRes, historyRes] = await Promise.all([
+    supabase
+      .from("steam_depot_updates")
+      .select("app_id,os,depot_id,last_updated_at")
+      .eq("app_id", Number(appId)),
+    supabase
+      .from("steam_depot_manifest_history")
+      .select("os,depot_id,manifest_id,first_observed_at,latest_observed_at")
+      .eq("app_id", Number(appId)),
+  ]);
+
+  if (depotRes.error) {
+    console.error(`[steam-depot-info] appId=${appId} depot query error=${depotRes.error.message}`);
     return Response.json(
-      { error: error.message, appId },
+      { error: depotRes.error.message, appId },
       { status: 502, headers: corsHeaders },
     );
   }
-  const rows = (data as Row[]) || [];
+  const rows = (depotRes.data as Row[]) || [];
   if (rows.length === 0) {
     console.log(`[steam-depot-info] appId=${appId} found=false source=cache-miss`);
     return Response.json(
@@ -71,28 +89,78 @@ Deno.serve(async (req: Request) => {
       { status: 200, headers: { ...corsHeaders, "Cache-Control": "public, max-age=600" } },
     );
   }
+  // History failure is non-fatal -- we can still return branch-level
+  // dates for both first_seen and last_updated as a degraded fallback,
+  // same shape as pre-#226. Log it so we notice.
+  const history = !historyRes.error && Array.isArray(historyRes.data)
+    ? (historyRes.data as {
+        os: string; depot_id: number; manifest_id: string;
+        first_observed_at: string; latest_observed_at: string;
+      }[])
+    : [];
+  if (historyRes.error) {
+    console.error(`[steam-depot-info] appId=${appId} history query error=${historyRes.error.message}`);
+  }
 
-  // Reduce to per-OS min / max timestamps + depot count.
-  type Bucket = { first: number; last: number; depots: Set<number> };
+  // Depot counts + branch fallback come from steam_depot_updates.
+  type Bucket = { branchTs: number; depots: Set<number> };
   const byOs = new Map<string, Bucket>();
   for (const row of rows) {
     const ts = Date.parse(row.last_updated_at);
     if (!Number.isFinite(ts)) continue;
     let b = byOs.get(row.os);
-    if (!b) { b = { first: ts, last: ts, depots: new Set() }; byOs.set(row.os, b); }
-    if (ts < b.first) b.first = ts;
-    if (ts > b.last)  b.last  = ts;
+    if (!b) { b = { branchTs: ts, depots: new Set() }; byOs.set(row.os, b); }
+    if (ts > b.branchTs) b.branchTs = ts;
     b.depots.add(row.depot_id);
   }
-  const os: Record<string, { first_seen: string; last_updated: string; depots: number }> = {};
-  for (const [key, b] of byOs.entries()) {
-    os[key] = {
-      first_seen:   new Date(b.first).toISOString(),
-      last_updated: new Date(b.last).toISOString(),
-      depots:       b.depots.size,
-    };
+  // Per-OS min / max of first_observed_at from history. Manifest_id
+  // changes are proxies for build changes; MIN across all rows is the
+  // per-OS 'we first tracked this OS depot' floor, MAX is the last
+  // time a new manifest_id was observed = the last time the OS build
+  // shipped.
+  type HistBucket = { minFirst: number; maxFirst: number; manifests: number };
+  const histByOs = new Map<string, HistBucket>();
+  for (const h of history) {
+    const ts = Date.parse(h.first_observed_at);
+    if (!Number.isFinite(ts)) continue;
+    let hb = histByOs.get(h.os);
+    if (!hb) { hb = { minFirst: ts, maxFirst: ts, manifests: 0 }; histByOs.set(h.os, hb); }
+    if (ts < hb.minFirst) hb.minFirst = ts;
+    if (ts > hb.maxFirst) hb.maxFirst = ts;
+    hb.manifests++;
   }
-  console.log(`[steam-depot-info] appId=${appId} found=true osCount=${Object.keys(os).length} source=cache`);
+  const os: Record<string, {
+    first_seen:   string;
+    last_updated: string;
+    depots:       number;
+    manifests:    number;   // # of distinct manifest_ids we have observed for this OS
+    source:       "history" | "branch-fallback";
+  }> = {};
+  for (const [key, b] of byOs.entries()) {
+    const hb = histByOs.get(key);
+    if (hb) {
+      os[key] = {
+        first_seen:   new Date(hb.minFirst).toISOString(),
+        last_updated: new Date(hb.maxFirst).toISOString(),
+        depots:       b.depots.size,
+        manifests:    hb.manifests,
+        source:       "history",
+      };
+    } else {
+      // No history yet (first observation from Phase 1 runs, or history
+      // upsert failed above). Fall back to the branch timestamp -- same
+      // value for both cells, same as pre-#226 UX.
+      os[key] = {
+        first_seen:   new Date(b.branchTs).toISOString(),
+        last_updated: new Date(b.branchTs).toISOString(),
+        depots:       b.depots.size,
+        manifests:    0,
+        source:       "branch-fallback",
+      };
+    }
+  }
+  const anyHist = [...Object.values(os)].some(v => v.source === "history");
+  console.log(`[steam-depot-info] appId=${appId} found=true osCount=${Object.keys(os).length} historyBacked=${anyHist} source=cache`);
   return Response.json(
     { appId, found: true, os },
     { status: 200, headers: { ...corsHeaders, "Cache-Control": "public, max-age=600" } },

--- a/supabase/migrations/20260707040000_steam_depot_manifest_history.sql
+++ b/supabase/migrations/20260707040000_steam_depot_manifest_history.sql
@@ -1,0 +1,69 @@
+-- Observation history for Steam depot manifests. Phase 2 of the plan
+-- documented in proton-pulse-web-wiki/Steam-Depot-Data.md (issue #226).
+--
+-- Motivation: PICS gives us ONE branch-level `timeupdated` shared by every
+-- OS depot on the branch, so per-OS 'First seen' and 'Last update' cannot
+-- come from a single-value schema. Real per-OS answers require observing
+-- how manifest_id changes over time and taking min / max of the
+-- first_observed_at column.
+--
+-- Model:
+--   - Row per unique (app_id, depot_id, os, manifest_id).
+--   - When the pipeline sees a manifest_id we've never recorded for that
+--     (app, depot, os) combo, INSERT (first_observed_at = now()).
+--   - When we see the same manifest_id again, UPDATE latest_observed_at.
+--   - When a game ships a new build the manifest_id changes for the
+--     affected depots -> a fresh row is inserted; the previous row stays
+--     forever (its latest_observed_at just stops advancing).
+--
+-- Aggregates the read-side edge function computes:
+--   - per-OS First seen  = MIN(first_observed_at) over all rows for
+--     (app_id, os). This is our observation floor -- for games whose
+--     depots existed before we started tracking, this reads as
+--     "tracked since <date>" rather than the true creation date.
+--   - per-OS Last update = MAX(first_observed_at). A new max means a
+--     new manifest_id was observed, i.e. a build for that OS shipped.
+--
+-- GDPR note: table holds only public Steam depot metadata (app id,
+-- depot id, OS name string, manifest gid, observation timestamps). No
+-- user identifier of any kind. admin_erase_user coverage is NOT required.
+
+create table if not exists public.steam_depot_manifest_history (
+  app_id              bigint      not null,
+  depot_id            bigint      not null,
+  os                  text        not null,
+  manifest_id         text        not null,
+  first_observed_at   timestamptz not null default now(),
+  latest_observed_at  timestamptz not null default now(),
+  primary key (app_id, depot_id, os, manifest_id)
+);
+
+comment on table  public.steam_depot_manifest_history is
+  'Observational history of Steam depot manifests per (app, depot, os). Populated by scripts/pipeline/steam_metadata.py; read by supabase/functions/steam-depot-info. #226.';
+comment on column public.steam_depot_manifest_history.first_observed_at is
+  'When the pipeline first saw this manifest_id for the (app, depot, os) tuple. Our observation floor -- not a true creation date.';
+comment on column public.steam_depot_manifest_history.latest_observed_at is
+  'When the pipeline last saw this manifest_id still active for the (app, depot, os). Advances on every re-observation of the same gid; a new gid means a new row.';
+
+-- Read hot paths: per-app aggregation and per-(app, os) filters.
+create index if not exists idx_steam_depot_manifest_history_app_os
+  on public.steam_depot_manifest_history (app_id, os);
+create index if not exists idx_steam_depot_manifest_history_first_observed
+  on public.steam_depot_manifest_history (first_observed_at desc);
+
+alter table public.steam_depot_manifest_history enable row level security;
+
+-- Public read (same as steam_depot_updates -- this is objective Steam data).
+-- Writes flow through the pipeline runner using the service role.
+do $$ begin
+  if not exists (
+    select 1 from pg_policies
+    where tablename  = 'steam_depot_manifest_history'
+      and policyname = 'anyone can read steam_depot_manifest_history'
+  ) then
+    create policy "anyone can read steam_depot_manifest_history"
+      on public.steam_depot_manifest_history for select
+      to anon, authenticated
+      using (true);
+  end if;
+end $$;

--- a/tests/test_steam_metadata.py
+++ b/tests/test_steam_metadata.py
@@ -395,3 +395,131 @@ class TestFetchAndStoreOffline:
         assert status_calls[0][0] == 1
         assert status_calls[0][1] == "error"
         assert "steamcmd missing" in status_calls[0][2]
+
+
+class TestManifestHistoryWriter:
+    """Phase 2 (#226) tests: the same rows that go into steam_depot_updates
+    must also be fed into steam_depot_manifest_history so per-OS First
+    seen / Last update stop being duplicative branch-level values.
+
+    Contract we lock down:
+      * upsert_manifest_history_rows drops depot rows without a manifest_id
+        (history is keyed on manifest_id; a row without it cannot carry
+        change history).
+      * The POST target uses the correct on_conflict PK.
+      * fetch_and_store calls the history writer AFTER upsert_depot_rows.
+      * A failing history write does NOT flip the outcome to 'error'; the
+        primary depot_updates write is durable and history is a strict
+        enhancement (per the module comment).
+    """
+
+    def _mkrow(self, os_key, manifest_id, depot_id=100, ts=1710000000):
+        return steam_metadata.DepotRow(
+            app_id=1, depot_id=depot_id, os=os_key,
+            name=None, manifest_id=manifest_id, last_updated_at=ts,
+        )
+
+    def test_skips_rows_without_manifest_id(self, monkeypatch):
+        captured = {}
+        def fake_urlopen(req, timeout=None):
+            captured["url"] = req.full_url
+            captured["body"] = req.data
+            class _R:
+                def read(self): return b""
+            return _R()
+        monkeypatch.setattr(steam_metadata.urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setenv("SUPABASE_URL", "https://test.supabase.co")
+        monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "srv")
+
+        rows = [
+            self._mkrow("linux",  None),                # dropped: no manifest_id
+            self._mkrow("windows", "abc"),
+            self._mkrow("mac",     ""),                 # dropped: empty manifest_id
+        ]
+        n = steam_metadata.upsert_manifest_history_rows(rows)
+        assert n == 1
+        import json as _j
+        body = _j.loads(captured["body"])
+        assert len(body) == 1
+        assert body[0]["os"] == "windows"
+        assert body[0]["manifest_id"] == "abc"
+
+    def test_upsert_url_uses_composite_pk_on_conflict(self, monkeypatch):
+        captured = {}
+        def fake_urlopen(req, timeout=None):
+            captured["url"] = req.full_url
+            class _R:
+                def read(self): return b""
+            return _R()
+        monkeypatch.setattr(steam_metadata.urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setenv("SUPABASE_URL", "https://test.supabase.co")
+        monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "srv")
+
+        steam_metadata.upsert_manifest_history_rows([self._mkrow("linux", "abc")])
+        # Composite PK matches the migration; anything else and Postgres
+        # rejects the upsert.
+        assert "steam_depot_manifest_history" in captured["url"]
+        assert "on_conflict=app_id,depot_id,os,manifest_id" in captured["url"]
+
+    def test_returns_zero_and_skips_post_when_all_rows_lack_manifest_id(self, monkeypatch):
+        calls = []
+        def fake_urlopen(req, timeout=None):
+            calls.append(req.full_url)
+            class _R:
+                def read(self): return b""
+            return _R()
+        monkeypatch.setattr(steam_metadata.urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setenv("SUPABASE_URL", "https://test.supabase.co")
+        monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "srv")
+
+        n = steam_metadata.upsert_manifest_history_rows([self._mkrow("linux", None)])
+        assert n == 0
+        assert calls == []  # no network call when payload is empty
+
+    def test_fetch_and_store_calls_history_writer_after_depot_upsert(self, monkeypatch):
+        # Verifies the sequencing: depot_updates first (the durable write),
+        # history second (the enhancement).
+        rows = [self._mkrow("linux", "abc", depot_id=42)]
+
+        order = []
+        parsed = {"depots": {"42": {"config": {"oslist": "linux"},
+                                    "manifests": {"public": {"gid": "abc"}}},
+                              "branches": {"public": {"timeupdated": "1710000000"}}}}
+        monkeypatch.setattr(steam_metadata, "run_steamcmd_app_info", lambda app_id, **kw: "dummy")
+        monkeypatch.setattr(steam_metadata, "parse_app_info", lambda text: parsed)
+        monkeypatch.setattr(steam_metadata, "extract_depot_rows", lambda app_id, p: rows)
+        monkeypatch.setattr(steam_metadata, "upsert_depot_rows",
+            lambda r: order.append("depot") or len(list(r)))
+        monkeypatch.setattr(steam_metadata, "upsert_manifest_history_rows",
+            lambda r: order.append("history") or len(list(r)))
+        monkeypatch.setattr(steam_metadata, "upsert_fetch_status",
+            lambda app_id, status, count, error=None: order.append(f"status={status}"))
+        monkeypatch.setattr(steam_metadata, "log", lambda msg: None)
+
+        status, n = steam_metadata.fetch_and_store(1)
+        assert status == "ok"
+        # depot write happens before history; final status flip last
+        assert order == ["depot", "history", "status=ok"]
+
+    def test_history_write_failure_does_not_flip_status_to_error(self, monkeypatch):
+        # Enhancement layer must never mask the durable primary write.
+        rows = [self._mkrow("linux", "abc")]
+        parsed = {"depots": {}}
+        monkeypatch.setattr(steam_metadata, "run_steamcmd_app_info", lambda app_id, **kw: "dummy")
+        monkeypatch.setattr(steam_metadata, "parse_app_info", lambda text: parsed)
+        monkeypatch.setattr(steam_metadata, "extract_depot_rows", lambda app_id, p: rows)
+        monkeypatch.setattr(steam_metadata, "upsert_depot_rows", lambda r: len(list(r)))
+        def boom(_):
+            raise RuntimeError("history table down")
+        monkeypatch.setattr(steam_metadata, "upsert_manifest_history_rows", boom)
+        status_calls = []
+        monkeypatch.setattr(steam_metadata, "upsert_fetch_status",
+            lambda app_id, status, count, error=None: status_calls.append((status, error)))
+        logs = []
+        monkeypatch.setattr(steam_metadata, "log", lambda msg: logs.append(msg))
+
+        status, n = steam_metadata.fetch_and_store(1)
+        assert status == "ok"
+        assert status_calls[-1][0] == "ok"
+        # But the failure must be logged so we can diagnose
+        assert any("history upsert failed" in m for m in logs)

--- a/tests/test_validate_app_ids.py
+++ b/tests/test_validate_app_ids.py
@@ -1,0 +1,226 @@
+"""Tests for the Steam app-id redirect validator.
+
+Covers the response classification, the substring-prefix regression case
+(app_id=26 wrongly reported "valid" for /app/2670/), the cache TTL
+lifecycle, and the search-index -> redirects.json output pipeline.
+"""
+
+import json
+from datetime import date, timedelta
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+from urllib.error import HTTPError
+
+import scripts.pipeline.validate_app_ids as validate_module
+from scripts.pipeline.validate_app_ids import (
+    _follow_redirects,
+    _is_stale,
+    _load_cache,
+    _save_cache,
+    validate_steam_app_ids,
+)
+
+
+def _make_response(final_url: str) -> MagicMock:
+    resp = MagicMock()
+    resp.url = final_url
+    resp.close = MagicMock()
+    return resp
+
+
+class TestFollowRedirects:
+    def test_valid_when_final_url_matches_original_app_id(self):
+        with patch("urllib.request.urlopen", return_value=_make_response(
+            "https://store.steampowered.com/app/730/Counter-Strike_2/"
+        )):
+            result = _follow_redirects("730")
+        assert result == {"status": "valid"}
+
+    def test_replaced_when_final_url_is_a_different_app_id(self):
+        with patch("urllib.request.urlopen", return_value=_make_response(
+            "https://store.steampowered.com/app/22670/"
+        )):
+            result = _follow_redirects("26670")
+        assert result["status"] == "replaced"
+        assert result["replaced_by"] == "22670"
+        assert result["final_url"] == "https://store.steampowered.com/app/22670/"
+
+    def test_dead_when_redirected_to_homepage_without_any_app_path(self):
+        with patch("urllib.request.urlopen", return_value=_make_response(
+            "https://store.steampowered.com/"
+        )):
+            result = _follow_redirects("9999999")
+        assert result["status"] == "dead"
+        assert result["final_url"] == "https://store.steampowered.com/"
+
+    def test_prefix_id_is_not_a_false_positive_valid(self):
+        """Regression: app_id=26 must NOT be reported valid when Steam
+        redirects to /app/2670/. The old substring check would fail this."""
+        with patch("urllib.request.urlopen", return_value=_make_response(
+            "https://store.steampowered.com/app/2670/Some_Game/"
+        )):
+            result = _follow_redirects("26")
+        assert result["status"] == "replaced"
+        assert result["replaced_by"] == "2670"
+
+    def test_prefix_id_is_not_a_false_positive_dead(self):
+        """Another prefix scenario: 220 redirected to 22000 should not be
+        misread as valid via substring match."""
+        with patch("urllib.request.urlopen", return_value=_make_response(
+            "https://store.steampowered.com/app/22000/"
+        )):
+            result = _follow_redirects("220")
+        assert result["status"] == "replaced"
+        assert result["replaced_by"] == "22000"
+
+    def test_http_404_marked_dead(self):
+        err = HTTPError(
+            url="https://store.steampowered.com/app/9999999/",
+            code=404,
+            msg="Not Found",
+            hdrs=None,
+            fp=None,
+        )
+        with patch("urllib.request.urlopen", side_effect=err):
+            result = _follow_redirects("9999999")
+        assert result["status"] == "dead"
+        assert result["http_status"] == 404
+
+    def test_non_404_http_error_marked_error_not_dead(self):
+        err = HTTPError(
+            url="https://store.steampowered.com/app/730/",
+            code=503,
+            msg="Service Unavailable",
+            hdrs=None,
+            fp=None,
+        )
+        with patch("urllib.request.urlopen", side_effect=err):
+            result = _follow_redirects("730")
+        assert result["status"] == "error"
+        assert result["http_status"] == 503
+
+    def test_generic_exception_bubbles_as_error_string(self):
+        with patch("urllib.request.urlopen", side_effect=TimeoutError("read timeout")):
+            result = _follow_redirects("730")
+        assert result["status"] == "error"
+        assert "timeout" in result["error"].lower()
+
+
+class TestIsStale:
+    def test_missing_probed_at_is_stale(self):
+        assert _is_stale({}) is True
+
+    def test_invalid_probed_at_is_stale(self):
+        assert _is_stale({"probed_at": "not-a-date"}) is True
+
+    def test_recently_probed_is_fresh(self):
+        yesterday = (date.today() - timedelta(days=1)).isoformat()
+        assert _is_stale({"probed_at": yesterday}) is False
+
+    def test_older_than_ttl_is_stale(self):
+        old = (date.today() - timedelta(days=validate_module.STALE_DAYS + 1)).isoformat()
+        assert _is_stale({"probed_at": old}) is True
+
+
+class TestCacheRoundTrip:
+    def test_load_missing_cache_returns_empty_dict(self, tmp_path: Path):
+        assert _load_cache(tmp_path) == {}
+
+    def test_save_then_load_roundtrips_entries(self, tmp_path: Path):
+        payload = {"730": {"status": "valid", "probed_at": "2026-07-07"}}
+        _save_cache(tmp_path, payload)
+        loaded = _load_cache(tmp_path)
+        assert loaded == payload
+
+    def test_corrupt_cache_is_treated_as_empty(self, tmp_path: Path):
+        cache_path = tmp_path / "app-id-validation-cache.json"
+        cache_path.write_text("{not-json", encoding="utf-8")
+        assert _load_cache(tmp_path) == {}
+
+
+class TestValidateSteamAppIds:
+    def _write_search_index(self, tmp_path: Path, rows):
+        (tmp_path / "search-index.json").write_text(
+            json.dumps(rows), encoding="utf-8"
+        )
+
+    def test_no_search_index_skips_gracefully(self, tmp_path: Path):
+        assert validate_steam_app_ids(str(tmp_path)) == {}
+        assert not (tmp_path / "app-id-redirects.json").exists()
+
+    def test_writes_only_problematic_entries_to_redirects_json(self, tmp_path: Path):
+        # Row shape from search-index.json: [app_id, title, ..., type (col 5), ...]
+        # Column 5 is the store type. "steam" rows are probed; others are skipped.
+        self._write_search_index(tmp_path, [
+            ["730", "Counter-Strike 2", 0, 0, 0, "steam"],
+            ["26670", "Old Game", 0, 0, 0, "steam"],
+            ["9999999", "Dead ID",     0, 0, 0, "steam"],
+            ["gog:123", "GOG Game",    0, 0, 0, "gog"],  # non-steam, skipped
+        ])
+
+        def fake_probe(app_id):
+            return {
+                "730":     {"status": "valid"},
+                "26670":   {"status": "replaced", "replaced_by": "22670",
+                            "final_url": "https://store.steampowered.com/app/22670/"},
+                "9999999": {"status": "dead",
+                            "final_url": "https://store.steampowered.com/"},
+            }[app_id]
+
+        with patch("scripts.pipeline.validate_app_ids._follow_redirects", side_effect=fake_probe), \
+             patch("scripts.pipeline.validate_app_ids.time.sleep"):
+            redirects = validate_steam_app_ids(str(tmp_path))
+
+        # Valid entries are omitted from the output.
+        assert "730" not in redirects
+        assert redirects["26670"]["status"] == "replaced"
+        assert redirects["26670"]["replaced_by"] == "22670"
+        assert redirects["9999999"]["status"] == "dead"
+
+        on_disk = json.loads((tmp_path / "app-id-redirects.json").read_text())
+        assert on_disk == redirects
+
+    def test_fresh_cache_entries_are_not_reprobed(self, tmp_path: Path):
+        self._write_search_index(tmp_path, [
+            ["730", "CS2", 0, 0, 0, "steam"],
+        ])
+        # Prime cache with a fresh valid entry.
+        _save_cache(tmp_path, {
+            "730": {"status": "valid", "probed_at": date.today().isoformat()},
+        })
+
+        with patch("scripts.pipeline.validate_app_ids._follow_redirects") as probe, \
+             patch("scripts.pipeline.validate_app_ids.time.sleep"):
+            validate_steam_app_ids(str(tmp_path))
+
+        probe.assert_not_called()
+
+    def test_stale_cache_entries_are_reprobed(self, tmp_path: Path):
+        self._write_search_index(tmp_path, [
+            ["730", "CS2", 0, 0, 0, "steam"],
+        ])
+        old = (date.today() - timedelta(days=validate_module.STALE_DAYS + 5)).isoformat()
+        _save_cache(tmp_path, {
+            "730": {"status": "valid", "probed_at": old},
+        })
+
+        with patch(
+            "scripts.pipeline.validate_app_ids._follow_redirects",
+            return_value={"status": "valid"},
+        ) as probe, patch("scripts.pipeline.validate_app_ids.time.sleep"):
+            validate_steam_app_ids(str(tmp_path))
+
+        probe.assert_called_once_with("730")
+
+    def test_probe_cap_limits_a_single_run(self, tmp_path: Path):
+        rows = [[str(1000 + i), f"App {i}", 0, 0, 0, "steam"]
+                for i in range(validate_module.PROBE_CAP + 25)]
+        self._write_search_index(tmp_path, rows)
+
+        with patch(
+            "scripts.pipeline.validate_app_ids._follow_redirects",
+            return_value={"status": "valid"},
+        ) as probe, patch("scripts.pipeline.validate_app_ids.time.sleep"):
+            validate_steam_app_ids(str(tmp_path))
+
+        assert probe.call_count == validate_module.PROBE_CAP


### PR DESCRIPTION
## Summary

- New pipeline pass that follows Steam store page redirects to detect dead/replaced app IDs
- Outputs `app-id-redirects.json` mapping bad IDs to their status (dead or replaced_by)
- Uses persistent cache (`app-id-validation-cache.json`) so IDs re-probe only every 90 days
- Caps at 200 probes per run to stay within Steam rate limits

Fixes the issue where app IDs like 26670 show a Steam store link that redirects to the homepage instead of the actual game (22670).

Closes #233

## Test plan

- [x] Module imports cleanly (`python3 -c "from scripts.pipeline.validate_app_ids import validate_steam_app_ids"`)
- [x] Correctly detects dead IDs (26670 -> homepage = dead)
- [x] Correctly detects valid IDs (22670 -> own page = valid)
- [x] Correctly detects nonexistent IDs (9999999 -> homepage = dead)
- [ ] Full pipeline run produces `app-id-redirects.json` with flagged entries
- [ ] Cache persists across gh-pages deploys