### PR TITLE
Promote staging to main: #219 (ProtonDB aggregates), #221 (Steam library API Explorer), Runtime Type rename + validator fixes

### DIFF
--- a/.github/actions/back-comment-run/action.yml
+++ b/.github/actions/back-comment-run/action.yml
@@ -1,0 +1,70 @@
+name: 'Back-comment run summary on issue'
+description: |
+  When a workflow_dispatch was targeted at a specific GitHub issue, post a
+  short summary comment (run URL + conclusion) back on that issue so bug
+  reports and enrichment requests get a paper trail. No-op if issue_id is
+  empty, so every workflow can call this unconditionally.
+
+  Part of #218: standardize workflow_dispatch inputs so any pipeline
+  workflow can be scoped to a target-app / target-issue with a one-click
+  dispatch.
+
+inputs:
+  issue_id:
+    description: 'GitHub issue number to comment on. Empty = skip.'
+    required: false
+    default: ''
+  status:
+    description: 'success | failure | cancelled | started'
+    required: true
+  workflow_name:
+    description: 'Human-friendly workflow name (e.g. "steam-metadata-fetch")'
+    required: true
+  app_ids:
+    description: 'Optional context: the app_ids the dispatch ran against'
+    required: false
+    default: ''
+  dry_run:
+    description: 'Optional context: whether the run was dry-run'
+    required: false
+    default: 'false'
+  notes:
+    description: 'Optional extra body text (e.g. counts, failures)'
+    required: false
+    default: ''
+  repo:
+    description: 'owner/name of the repo the issue lives in'
+    required: false
+    default: ${{ github.repository }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Post run summary to issue
+      if: inputs.issue_id != ''
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        ISSUE_ID: ${{ inputs.issue_id }}
+        STATUS: ${{ inputs.status }}
+        WORKFLOW: ${{ inputs.workflow_name }}
+        APP_IDS: ${{ inputs.app_ids }}
+        DRY_RUN: ${{ inputs.dry_run }}
+        NOTES: ${{ inputs.notes }}
+        REPO: ${{ inputs.repo }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: |
+        set -euo pipefail
+        emoji="?"
+        case "$STATUS" in
+          success)   emoji="OK"      ;;
+          failure)   emoji="FAIL"    ;;
+          cancelled) emoji="CANCEL"  ;;
+          started)   emoji="STARTED" ;;
+        esac
+        body="[$emoji] \`$WORKFLOW\` dispatched via #$ISSUE_ID"$'\n\n'
+        body+="Run: $RUN_URL"$'\n'
+        if [ -n "$APP_IDS" ]; then body+="App IDs: \`$APP_IDS\`"$'\n'; fi
+        if [ "$DRY_RUN" = "true" ]; then body+="Dry run: yes (no writes)"$'\n'; fi
+        if [ -n "$NOTES" ]; then body+=$'\n'"$NOTES"$'\n'; fi
+        gh issue comment "$ISSUE_ID" --repo "$REPO" --body "$body"

--- a/.github/scripts/moderate-content.mjs
+++ b/.github/scripts/moderate-content.mjs
@@ -11,7 +11,8 @@
  * Optional env vars:
  *   OPENAI_API_KEY  - enables semantic layer; wordlist-only if absent
  *   LOOKBACK_HOURS  - scan window in hours (default: 5)
- *   APP_ID          - restrict to a single Steam app ID
+ *   APP_IDS         - restrict to a comma-separated list of Steam app IDs (#218 standard)
+ *   APP_ID          - legacy singular alias for APP_IDS; still honored for backcompat
  *   DRY_RUN         - "true" to log without writing to Supabase
  */
 
@@ -19,7 +20,10 @@ const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 const OPENAI_KEY   = process.env.OPENAI_API_KEY;
 const LOOKBACK_H   = parseInt(process.env.LOOKBACK_HOURS ?? '5', 10);
-const APP_ID       = process.env.APP_ID ?? '';
+// #218: standard env is APP_IDS (comma-separated). Fall back to the legacy
+// APP_ID (singular) so an old dispatch from a saved link keeps working.
+const APP_IDS      = (process.env.APP_IDS || process.env.APP_ID || '')
+  .split(',').map((s) => s.trim()).filter(Boolean);
 const DRY_RUN      = process.env.DRY_RUN === 'true';
 
 if (!SUPABASE_URL || !SUPABASE_KEY) {
@@ -207,7 +211,9 @@ async function fetchRecentRows() {
     + `&or=(created_at.gte.${since},updated_at.gte.${since})`
     + `&is_hidden=eq.false`
     + `&order=id.asc`
-    + (APP_ID ? `&app_id=eq.${APP_ID}` : '');
+    + (APP_IDS.length === 1 ? `&app_id=eq.${encodeURIComponent(APP_IDS[0])}`
+       : APP_IDS.length > 1 ? `&app_id=in.(${APP_IDS.map(encodeURIComponent).join(',')})`
+       : '');
 
   log(`Supabase fetch request`, { url: url.replace(SUPABASE_URL, '<SUPABASE_URL>'), since });
 
@@ -274,7 +280,7 @@ function extractTextFields(row) {
 async function main() {
   log(`Moderation scan starting`, {
     lookbackHours: LOOKBACK_H,
-    appId: APP_ID || 'all',
+    appIds: APP_IDS.length ? APP_IDS : 'all',
     dryRun: DRY_RUN,
     openai: !!OPENAI_KEY,
   });
@@ -361,7 +367,7 @@ async function main() {
       `| Rows scanned | ${scanned} |`,
       `| Rows flagged | ${flaggedCount} |`,
       `| Lookback | ${LOOKBACK_H}h |`,
-      `| App ID filter | ${APP_ID || 'all'} |`,
+      `| App ID filter | ${APP_IDS.length ? APP_IDS.join(', ') : 'all'} |`,
       `| Dry run | ${DRY_RUN} |`,
       `| Layers | wordlist${OPENAI_KEY ? ' + openai' : ' only'} |`,
     ];

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -20,6 +20,15 @@ on:
           - user_configs
           - author_avatars
           - site
+      # Standardized inputs (#218). backup doesn't take app_ids.
+      issue_id:
+        description: "GitHub issue to comment run summary back on (leave blank to skip)"
+        required: false
+        default: ""
+      dry_run:
+        description: "Produce backup artifacts locally but skip the upload to the backup repo"
+        type: boolean
+        default: false
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -28,6 +37,9 @@ jobs:
   backup:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    permissions:
+      contents: read
+      issues: write
     # For workflow_run triggers, only run if the upstream workflow succeeded.
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
 
@@ -75,6 +87,7 @@ jobs:
           fi
 
       - name: Publish release and update backups.jsonl
+        if: inputs.dry_run != true
         env:
           GH_TOKEN: ${{ secrets.BACKUP_REPO_TOKEN }}
           BACKUP_REPO_TOKEN: ${{ secrets.BACKUP_REPO_TOKEN }}
@@ -169,3 +182,12 @@ jobs:
           git add latest/ backups.jsonl
           git commit -m "backup (${TRIGGER}): ${DATE} [${TAG}]"
           git push
+
+      - name: Back-comment run summary on issue
+        if: always()
+        uses: ./.github/actions/back-comment-run
+        with:
+          issue_id: ${{ inputs.issue_id }}
+          status: ${{ job.status }}
+          workflow_name: backup
+          dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/content-moderation.yml
+++ b/.github/workflows/content-moderation.yml
@@ -12,8 +12,8 @@ on:
         description: "Scan rows updated within this many hours (default: 5 for scheduled, 25 for manual)"
         required: false
         default: "5"
-      app_id:
-        description: "Restrict scan to a single Steam app ID (leave blank for all)"
+      app_ids:
+        description: "Restrict scan to a comma-separated list of Steam app IDs (leave blank for all)"
         required: false
         default: ""
       dry_run:
@@ -21,6 +21,11 @@ on:
         required: false
         default: false
         type: boolean
+      # Standardized input (#218): back-comment the run summary on an issue.
+      issue_id:
+        description: "GitHub issue to comment run summary back on (leave blank to skip)"
+        required: false
+        default: ""
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -29,6 +34,9 @@ jobs:
   moderate:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    permissions:
+      contents: read
+      issues: write
 
     steps:
       - name: Checkout
@@ -61,6 +69,18 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           LOOKBACK_HOURS: ${{ steps.lookback.outputs.hours }}
-          APP_ID: ${{ inputs.app_id || '' }}
+          # APP_IDS is comma-separated. Legacy scripts read APP_ID (singular);
+          # the moderation script now honors both -- prefer APP_IDS when set.
+          APP_IDS: ${{ inputs.app_ids || '' }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: node .github/scripts/moderate-content.mjs
+
+      - name: Back-comment run summary on issue
+        if: always()
+        uses: ./.github/actions/back-comment-run
+        with:
+          issue_id: ${{ inputs.issue_id }}
+          status: ${{ job.status }}
+          workflow_name: content-moderation
+          app_ids: ${{ inputs.app_ids }}
+          dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/steam-metadata-fetch.yml
+++ b/.github/workflows/steam-metadata-fetch.yml
@@ -26,6 +26,15 @@ on:
         description: 'Seconds to sleep between apps (rate limit courtesy)'
         required: false
         default: '3'
+      # Standardized inputs (#218).
+      issue_id:
+        description: 'GitHub issue to comment run summary back on (leave blank to skip)'
+        required: false
+        default: ''
+      dry_run:
+        description: 'Fetch depot data but skip the Supabase write'
+        type: boolean
+        default: false
   schedule:
     - cron: '0 9 * * *'
 
@@ -33,6 +42,9 @@ jobs:
   fetch:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
+    permissions:
+      contents: read
+      issues: write
     env:
       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
@@ -63,5 +75,17 @@ jobs:
           fi
 
       - name: Fetch depot dates
+        env:
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: |
           python -m scripts.pipeline.steam_metadata $(echo "${{ steps.apps.outputs.list }}" | tr ',' ' ')
+
+      - name: Back-comment run summary on issue
+        if: always()
+        uses: ./.github/actions/back-comment-run
+        with:
+          issue_id: ${{ inputs.issue_id }}
+          status: ${{ job.status }}
+          workflow_name: steam-metadata-fetch
+          app_ids: ${{ steps.apps.outputs.list }}
+          dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -316,6 +316,7 @@ jobs:
           cp gh-pages-data/game-images-cache.json /tmp/protondb-output/ 2>/dev/null || true
           cp gh-pages-data/nonsteam-images-cache.json /tmp/protondb-output/ 2>/dev/null || true
           cp gh-pages-data/release-years-cache.json /tmp/protondb-output/ 2>/dev/null || true
+          cp gh-pages-data/app-id-validation-cache.json /tmp/protondb-output/ 2>/dev/null || true
 
       - name: Restore pipeline cache
         uses: actions/cache/restore@v4
@@ -496,7 +497,7 @@ jobs:
           git add data/ data-index.html coverage.html search-index.json scoring-info.json form-schema.json badges/
           # add optional pipeline outputs (skip silently if a fresh checkout
           # didn't have them yet, e.g. first run after introducing the file)
-          for f in coverage-summary.json stats.json recent-reports.json game-images.json game-images-skip.json game-images-cache.json nonsteam-images-cache.json release-years-cache.json gog-catalog-cache.json epic-catalog-cache.json most_played.json deck-status.json proton-versions.json steam-catalog.json hardware-suggestions.json nonsteam-images.json data-versions.json search-index-steam-extended.json; do
+          for f in coverage-summary.json stats.json recent-reports.json game-images.json game-images-skip.json game-images-cache.json nonsteam-images-cache.json release-years-cache.json gog-catalog-cache.json epic-catalog-cache.json most_played.json deck-status.json proton-versions.json steam-catalog.json hardware-suggestions.json nonsteam-images.json data-versions.json search-index-steam-extended.json app-id-redirects.json app-id-validation-cache.json; do
             [ -f "$f" ] && git add "$f"
           done
           while IFS= read -r path; do
@@ -560,7 +561,7 @@ jobs:
           curl -sL https://raw.githubusercontent.com/mdeguzis/decky-proton-pulse/main/src/data/scoring-info.json -o scoring-info.json
           curl -sL https://raw.githubusercontent.com/mdeguzis/decky-proton-pulse/main/src/data/form-schema.json -o form-schema.json
           git add data/ data-index.html coverage.html search-index.json scoring-info.json form-schema.json
-          for f in coverage-summary.json stats.json recent-reports.json game-images.json game-images-skip.json game-images-cache.json nonsteam-images-cache.json release-years-cache.json gog-catalog-cache.json epic-catalog-cache.json most_played.json deck-status.json proton-versions.json steam-catalog.json hardware-suggestions.json nonsteam-images.json data-versions.json search-index-steam-extended.json; do
+          for f in coverage-summary.json stats.json recent-reports.json game-images.json game-images-skip.json game-images-cache.json nonsteam-images-cache.json release-years-cache.json gog-catalog-cache.json epic-catalog-cache.json most_played.json deck-status.json proton-versions.json steam-catalog.json hardware-suggestions.json nonsteam-images.json data-versions.json search-index-steam-extended.json app-id-redirects.json app-id-validation-cache.json; do
             [ -f "$f" ] && git add "$f"
           done
           while IFS= read -r path; do
@@ -826,7 +827,7 @@ jobs:
           git add data/ data-index.html coverage.html search-index.json scoring-info.json form-schema.json badges/
           # add optional pipeline outputs (skip silently if a fresh checkout
           # didn't have them yet, e.g. first run after introducing the file)
-          for f in coverage-summary.json stats.json recent-reports.json game-images.json game-images-skip.json game-images-cache.json nonsteam-images-cache.json release-years-cache.json gog-catalog-cache.json epic-catalog-cache.json most_played.json deck-status.json proton-versions.json steam-catalog.json hardware-suggestions.json nonsteam-images.json data-versions.json search-index-steam-extended.json; do
+          for f in coverage-summary.json stats.json recent-reports.json game-images.json game-images-skip.json game-images-cache.json nonsteam-images-cache.json release-years-cache.json gog-catalog-cache.json epic-catalog-cache.json most_played.json deck-status.json proton-versions.json steam-catalog.json hardware-suggestions.json nonsteam-images.json data-versions.json search-index-steam-extended.json app-id-redirects.json app-id-validation-cache.json; do
             [ -f "$f" ] && git add "$f"
           done
           while IFS= read -r path; do
@@ -1048,7 +1049,7 @@ jobs:
           git add data/ data-index.html coverage.html search-index.json scoring-info.json form-schema.json badges/
           # add optional pipeline outputs (skip silently if a fresh checkout
           # didn't have them yet, e.g. first run after introducing the file)
-          for f in coverage-summary.json stats.json recent-reports.json game-images.json game-images-skip.json game-images-cache.json nonsteam-images-cache.json release-years-cache.json gog-catalog-cache.json epic-catalog-cache.json most_played.json deck-status.json proton-versions.json steam-catalog.json hardware-suggestions.json nonsteam-images.json data-versions.json search-index-steam-extended.json; do
+          for f in coverage-summary.json stats.json recent-reports.json game-images.json game-images-skip.json game-images-cache.json nonsteam-images-cache.json release-years-cache.json gog-catalog-cache.json epic-catalog-cache.json most_played.json deck-status.json proton-versions.json steam-catalog.json hardware-suggestions.json nonsteam-images.json data-versions.json search-index-steam-extended.json app-id-redirects.json app-id-validation-cache.json; do
             [ -f "$f" ] && git add "$f"
           done
           while IFS= read -r path; do

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -53,6 +53,18 @@ on:
         required: false
         default: false
         type: boolean
+      # Standardized inputs (#218). `backfill_app_ids` is the domain-specific
+      # name for this workflow's app-id list, so we don't rename it -- but
+      # every workflow now accepts issue_id + dry_run for a common back-comment
+      # + preview-only story.
+      issue_id:
+        description: "GitHub issue to comment run summary back on (leave blank to skip)"
+        required: false
+        default: ""
+      dry_run:
+        description: "Preview: run stages that read but skip commits + Supabase writes (best-effort per stage)"
+        type: boolean
+        default: false
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -1064,7 +1076,13 @@ jobs:
     needs: [build, probe-chunks, finalize, targeted-backfill, coverage-backfill]
     runs-on: ubuntu-24.04
     if: always()
+    permissions:
+      contents: read
+      issues: write
     steps:
+      # Needed by the back-comment composite action.
+      - uses: actions/checkout@v4
+
       - name: Summary
         run: |
           echo "### Build Site Data" >> "$GITHUB_STEP_SUMMARY"
@@ -1096,6 +1114,19 @@ jobs:
             echo "| Probe chunks | ${{ needs.probe-chunks.result }} |" >> "$GITHUB_STEP_SUMMARY"
             echo "| Finalize + Deploy | ${{ needs.finalize.result }} |" >> "$GITHUB_STEP_SUMMARY"
           fi
+
+      # #218: back-comment on the target issue if the dispatch specified one.
+      # Runs BEFORE the fail step so a failed run still posts a summary before
+      # the job flips red.
+      - name: Back-comment run summary on issue
+        if: always()
+        uses: ./.github/actions/back-comment-run
+        with:
+          issue_id: ${{ inputs.issue_id }}
+          status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
+          workflow_name: update-data
+          app_ids: ${{ inputs.backfill_app_ids }}
+          dry_run: ${{ inputs.dry_run }}
 
       - name: Fail if any job failed
         if: contains(needs.*.result, 'failure')

--- a/.github/workflows/update-epic-catalog.yml
+++ b/.github/workflows/update-epic-catalog.yml
@@ -9,12 +9,24 @@ on:
         description: "Force re-fetch even if cache is fresh"
         type: boolean
         default: false
+      # Standardized inputs (#218). Every dispatchable workflow accepts these
+      # so a bug report can be spot-fixed with a one-click dispatch that
+      # comments the run summary back on the issue.
+      issue_id:
+        description: "GitHub issue to comment run summary back on (leave blank to skip)"
+        required: false
+        default: ""
+      dry_run:
+        description: "Skip cache writes; log what would change"
+        type: boolean
+        default: false
 
 jobs:
   update-epic-catalog:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      issues: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -46,6 +58,7 @@ jobs:
           FORCE_REFRESH: ${{ inputs.force_refresh }}
 
       - name: Commit catalog cache to gh-pages
+        if: inputs.dry_run != true
         run: |
           cd gh-pages-data
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -55,3 +68,12 @@ jobs:
           git add epic-catalog-cache.json
           git diff --cached --quiet && echo "Cache unchanged, nothing to commit" || git commit -m "chore: refresh Epic catalog cache $(date +%F)"
           git push origin gh-pages
+
+      - name: Back-comment run summary on issue
+        if: always()
+        uses: ./.github/actions/back-comment-run
+        with:
+          issue_id: ${{ inputs.issue_id }}
+          status: ${{ job.status }}
+          workflow_name: update-epic-catalog
+          dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/update-gog-catalog.yml
+++ b/.github/workflows/update-gog-catalog.yml
@@ -9,12 +9,22 @@ on:
         description: "Force re-fetch even if cache is fresh"
         type: boolean
         default: false
+      # Standardized inputs (#218).
+      issue_id:
+        description: "GitHub issue to comment run summary back on (leave blank to skip)"
+        required: false
+        default: ""
+      dry_run:
+        description: "Skip cache writes; log what would change"
+        type: boolean
+        default: false
 
 jobs:
   update-gog-catalog:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      issues: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -46,6 +56,7 @@ jobs:
           FORCE_REFRESH: ${{ inputs.force_refresh }}
 
       - name: Commit catalog cache to gh-pages
+        if: inputs.dry_run != true
         run: |
           cd gh-pages-data
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -55,3 +66,12 @@ jobs:
           git add gog-catalog-cache.json
           git diff --cached --quiet && echo "Cache unchanged, nothing to commit" || git commit -m "chore: refresh GOG catalog cache $(date +%F)"
           git push origin gh-pages
+
+      - name: Back-comment run summary on issue
+        if: always()
+        uses: ./.github/actions/back-comment-run
+        with:
+          issue_id: ${{ inputs.issue_id }}
+          status: ${{ job.status }}
+          workflow_name: update-gog-catalog
+          dry_run: ${{ inputs.dry_run }}

--- a/admin.html
+++ b/admin.html
@@ -353,6 +353,6 @@
 <script src="js/lib/analytics.js?v=7855fb4c"></script>
 <script src="js/lib/topbar.js?v=46897460"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/admin/main.js?v=0bcda5eb"></script>
+<script type="module" src="js/admin/main.js?v=fed3f6e2"></script>
 </body>
 </html>

--- a/admin.html
+++ b/admin.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=c550d77b">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/admin/admin.css?v=c883b5f7">
+<link rel="stylesheet" href="css/admin/admin.css?v=e3e828e2">
 </head>
 <body>
 
@@ -44,6 +44,7 @@
           <option value="banned">Banned Users</option>
           <option value="boxart">Box Art Manager</option>
           <option value="api-explorer">API Explorer</option>
+          <option value="games">Game Manager</option>
           <option value="all-reports">Reports</option>
         </select>
       </div>
@@ -310,6 +311,10 @@
         <div id="api-explorer-content"></div>
       </section>
 
+      <section id="tab-games" class="admin-section" hidden>
+        <div id="game-manager-content"></div>
+      </section>
+
       <!-- Shared boxart chrome (modal + file picker). Used by both the
            list view and the detail view so a single instance handles
            set-url and upload actions from either place. -->
@@ -353,6 +358,6 @@
 <script src="js/lib/analytics.js?v=7855fb4c"></script>
 <script src="js/lib/topbar.js?v=46897460"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/admin/main.js?v=fed3f6e2"></script>
+<script type="module" src="js/admin/main.js?v=eb4d8a33"></script>
 </body>
 </html>

--- a/app.html
+++ b/app.html
@@ -17,7 +17,7 @@
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/filters.css?v=4a590596">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/app/game-header.css?v=dbecc5e0">
+<link rel="stylesheet" href="css/app/game-header.css?v=eeae198f">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=6df19441">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">

--- a/app.html
+++ b/app.html
@@ -17,7 +17,7 @@
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/filters.css?v=4a590596">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/app/game-header.css?v=8dc8f5f9">
+<link rel="stylesheet" href="css/app/game-header.css?v=9d16d085">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=6df19441">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">

--- a/app.html
+++ b/app.html
@@ -17,7 +17,7 @@
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/filters.css?v=4a590596">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/app/game-header.css?v=9d16d085">
+<link rel="stylesheet" href="css/app/game-header.css?v=bfb9d9a1">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=6df19441">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">

--- a/app.html
+++ b/app.html
@@ -17,7 +17,7 @@
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/filters.css?v=4a590596">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/app/game-header.css?v=eeae198f">
+<link rel="stylesheet" href="css/app/game-header.css?v=8dc8f5f9">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=6df19441">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">

--- a/confidence.html
+++ b/confidence.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=c550d77b">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/app/game-header.css?v=dbecc5e0">
+<link rel="stylesheet" href="css/app/game-header.css?v=eeae198f">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=6df19441">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">

--- a/confidence.html
+++ b/confidence.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=c550d77b">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/app/game-header.css?v=8dc8f5f9">
+<link rel="stylesheet" href="css/app/game-header.css?v=9d16d085">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=6df19441">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">

--- a/confidence.html
+++ b/confidence.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=c550d77b">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/app/game-header.css?v=9d16d085">
+<link rel="stylesheet" href="css/app/game-header.css?v=bfb9d9a1">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=6df19441">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">

--- a/confidence.html
+++ b/confidence.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=c550d77b">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/app/game-header.css?v=eeae198f">
+<link rel="stylesheet" href="css/app/game-header.css?v=8dc8f5f9">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=6df19441">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">

--- a/css/admin/admin.css
+++ b/css/admin/admin.css
@@ -1338,3 +1338,31 @@ pre.flag-raw-json {
   color: var(--text);
   background: rgba(46, 160, 67, 0.05);
 }
+
+/* Game Manager (#234): three stacked cards -- hides, remaps, pipeline
+   suspects. Each has a form + table. Kept minimal because the panel's
+   MVP is intentionally lean. */
+.gm-card { margin-bottom: 20px; }
+.gm-form {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+  margin: 8px 0 12px;
+}
+.gm-form .gm-form-id     { flex: 0 1 200px; min-width: 0; }
+.gm-form .gm-form-reason { flex: 1 1 260px; min-width: 0; }
+.gm-table { width: 100%; }
+.gm-table code { font-family: var(--mono); font-size: 0.82em; }
+.gm-suspect-status {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-size: 0.72rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-family: var(--mono);
+}
+.gm-suspect-status--replaced { background: rgba(217, 179, 92, 0.15);  color: #d9b35c; border: 1px solid rgba(217, 179, 92, 0.3); }
+.gm-suspect-status--dead     { background: rgba(200, 80, 80, 0.15);   color: #c85050; border: 1px solid rgba(200, 80, 80, 0.3); }
+.gm-suspect-status--unknown  { background: rgba(140, 140, 140, 0.15); color: #a0a0a0; border: 1px solid rgba(140, 140, 140, 0.3); }

--- a/css/app/game-header.css
+++ b/css/app/game-header.css
@@ -1369,6 +1369,31 @@
 /* Real depot dates from the #215 PICS cache -- render in mono so they
    line up under the "Last update" column heading. */
 .gm-depot-date { font-family: var(--mono); color: var(--text); }
+/* Steam-style brown package icon that deep-links to the per-game
+   depots.json we publish under /data/{appId}/depots.json (#237).
+   Sits inline in the row so admins / curious viewers can jump straight
+   to the raw file the modal was built from. */
+.gm-depot-file {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  margin-left: 6px;
+  border-radius: 4px;
+  background: rgba(120, 76, 40, 0.14);
+  border: 1px solid rgba(160, 106, 60, 0.35);
+  color: #b07040;
+  text-decoration: none;
+  vertical-align: middle;
+  transition: background 0.12s, border-color 0.12s;
+}
+.gm-depot-file:hover {
+  background: rgba(160, 106, 60, 0.24);
+  border-color: rgba(200, 140, 80, 0.6);
+  text-decoration: none;
+}
+.gm-depot-file svg { width: 14px; height: 14px; }
 .gm-plat-foot {
   padding-top: 6px !important;
   font-size: 0.68rem;

--- a/css/app/game-header.css
+++ b/css/app/game-header.css
@@ -314,6 +314,9 @@
 .grp-bar-fill { position: absolute; inset: 0 auto 0 0; border-radius: 5px; }
 .grp-bar-count { text-align: right; color: var(--text); font-variant-numeric: tabular-nums; }
 .grp-bars-note { font-size: 0.76rem; color: var(--muted); align-self: center; }
+/* Attribution when live total > mirror sample: sits under the bar stack,
+   text-aligned left, tighter spacing than the main empty-note variant. */
+.grp-bars-note--sample { margin-top: 6px; text-align: left; align-self: stretch; line-height: 1.35; }
 .grp-foot {
   border-top: 1px solid var(--border);
   padding-top: 10px;

--- a/css/app/game-header.css
+++ b/css/app/game-header.css
@@ -314,9 +314,18 @@
 .grp-bar-fill { position: absolute; inset: 0 auto 0 0; border-radius: 5px; }
 .grp-bar-count { text-align: right; color: var(--text); font-variant-numeric: tabular-nums; }
 .grp-bars-note { font-size: 0.76rem; color: var(--muted); align-self: center; }
-/* Attribution when live total > mirror sample: sits under the bar stack,
-   text-aligned left, tighter spacing than the main empty-note variant. */
-.grp-bars-note--sample { margin-top: 6px; text-align: left; align-self: stretch; line-height: 1.35; }
+/* One-line ProtonDB rating + count, sits above the 5-bar stack. Same visual
+   weight as the bar row so it reads as part of the same block, not a note. */
+.grp-bars-note--live {
+  align-self: stretch;
+  text-align: left;
+  margin-bottom: 4px;
+  padding-bottom: 4px;
+  border-bottom: 1px dashed var(--border);
+  font-size: 0.8rem;
+  color: var(--text);
+}
+.grp-bars-note--live strong { color: var(--strong); font-weight: 600; }
 .grp-foot {
   border-top: 1px solid var(--border);
   padding-top: 10px;

--- a/css/app/game-header.css
+++ b/css/app/game-header.css
@@ -1394,6 +1394,14 @@
   text-decoration: none;
 }
 .gm-depot-file svg { width: 14px; height: 14px; }
+/* Depots column is icon-only after #237 v2, so keep it narrow: right-aligned,
+   fixed width so long dates in other columns don't shove it around. */
+.gm-plat-table .gm-plat-depots,
+.gm-plat-table .gm-plat-depots-th {
+  width: 40px;
+  text-align: right;
+  padding-right: 6px;
+}
 .gm-plat-foot {
   padding-top: 6px !important;
   font-size: 0.68rem;

--- a/game-stats.html
+++ b/game-stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=c550d77b">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/app/game-header.css?v=dbecc5e0">
+<link rel="stylesheet" href="css/app/game-header.css?v=eeae198f">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=6df19441">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">

--- a/game-stats.html
+++ b/game-stats.html
@@ -316,6 +316,56 @@ h1 {
   font-family: var(--mono);
   color: var(--muted);
 }
+/* ProtonDB live summary block shown on the error state when we have aggregate
+   data for a game but no individual reports mirrored yet (#219). */
+.gs-live-summary {
+  margin: 20px auto 0;
+  max-width: 620px;
+  padding: 18px 20px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.03);
+  text-align: left;
+}
+.gs-live-summary-head {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+  font-family: var(--mono);
+  font-size: 0.9rem;
+  color: var(--text);
+}
+.gs-live-summary-tier {
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  font-size: 0.78rem;
+}
+.gs-live-summary-tier-platinum { background: rgba(148, 172, 190, 0.15); color: #c8d4e0; }
+.gs-live-summary-tier-gold     { background: rgba(217, 179, 92, 0.15);  color: #d9b35c; }
+.gs-live-summary-tier-silver   { background: rgba(143, 160, 176, 0.15); color: #8fa0b0; }
+.gs-live-summary-tier-bronze   { background: rgba(176, 112, 64, 0.15);  color: #b07040; }
+.gs-live-summary-tier-borked   { background: rgba(200, 80, 80, 0.15);   color: #c85050; }
+.gs-live-summary-total { color: var(--text); }
+.gs-live-summary-conf {
+  font-size: 0.78rem;
+  color: var(--muted);
+  padding: 3px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+.gs-live-summary-note {
+  margin: 10px 0 0;
+  font-family: var(--font-body);
+  font-size: 0.86rem;
+  line-height: 1.45;
+  color: var(--muted);
+  text-align: left;
+}
+.gs-live-summary-note a { color: var(--accent); }
+.gs-live-summary-note a:hover { color: var(--accent-hi); text-decoration: underline; }
 </style>
 </head>
 <body>
@@ -345,7 +395,7 @@ h1 {
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script src="js/lib/analytics.js?v=7855fb4c"></script>
-<script type="module" src="js/game-stats/main.js?v=d1b893a7"></script>
+<script type="module" src="js/game-stats/main.js?v=13085c16"></script>
 
 </body>
 </html>

--- a/game-stats.html
+++ b/game-stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=c550d77b">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/app/game-header.css?v=8dc8f5f9">
+<link rel="stylesheet" href="css/app/game-header.css?v=9d16d085">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=6df19441">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">

--- a/game-stats.html
+++ b/game-stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=c550d77b">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/app/game-header.css?v=9d16d085">
+<link rel="stylesheet" href="css/app/game-header.css?v=bfb9d9a1">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=6df19441">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">

--- a/game-stats.html
+++ b/game-stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=c550d77b">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/app/game-header.css?v=eeae198f">
+<link rel="stylesheet" href="css/app/game-header.css?v=8dc8f5f9">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=6df19441">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">

--- a/gh-pages-manifest.txt
+++ b/gh-pages-manifest.txt
@@ -90,6 +90,7 @@ js/admin/api/analytics.js
 js/admin/api/boxart.js
 js/admin/components/boxart.js
 js/admin/api/steam-explore.js
+js/admin/api/steam-library-lookup.js
 js/admin/components/api-explorer.js
 js/admin/components/flagged.js
 js/admin/components/banned.js

--- a/gh-pages-manifest.txt
+++ b/gh-pages-manifest.txt
@@ -91,7 +91,9 @@ js/admin/api/boxart.js
 js/admin/components/boxart.js
 js/admin/api/steam-explore.js
 js/admin/api/steam-library-lookup.js
+js/admin/api/gameManager.js
 js/admin/components/api-explorer.js
+js/admin/components/gameManager.js
 js/admin/components/flagged.js
 js/admin/components/banned.js
 js/admin/components/users.js

--- a/js/admin/api/gameManager.js
+++ b/js/admin/api/gameManager.js
@@ -1,0 +1,167 @@
+// Admin API client for the Game Manager panel (#234).
+//
+// Two tables: game_hides (blacklist) and game_remaps (from_app_id -> to_app_id).
+// Both keyed on app_id TEXT so they work for Steam numeric ids and the
+// prefixed non-Steam ids (`gog:123`, `epic:MyGame`).
+//
+// RLS gates every write on manage_games (super_admin gets it too). We still
+// send the Authorization header so the RLS check has an authenticated caller.
+
+import { SupaAuth, SUPABASE_URL, SUPABASE_ANON_KEY } from '../config.js?v=ffed3d84';
+import { supabaseHeaders } from '../utils.js?v=2668b2f0';
+
+const SB = `${SUPABASE_URL}/rest/v1`;
+
+async function _authedHeaders() {
+  const session = await SupaAuth.getSession().catch(() => null);
+  return supabaseHeaders(session);
+}
+
+// ── game_hides ─────────────────────────────────────────────────────────
+
+/**
+ * List every game hide, newest first. Returns an array of
+ * { app_id, reason, hidden_by, hidden_at } rows (empty on error).
+ */
+export async function listGameHides() {
+  try {
+    const headers = await _authedHeaders();
+    const res = await fetch(
+      `${SB}/game_hides?select=app_id,reason,hidden_by,hidden_at&order=hidden_at.desc`,
+      { headers, cache: 'no-store' },
+    );
+    if (!res.ok) return [];
+    return await res.json();
+  } catch { return []; }
+}
+
+/**
+ * Add or update a hide entry. `reason` is required (RLS + panel enforce it).
+ * Uses Prefer: resolution=merge-duplicates so a re-hide with a new reason
+ * updates in place instead of failing on the primary key.
+ */
+export async function upsertGameHide(appId, reason) {
+  if (!appId || !reason?.trim()) {
+    return { ok: false, error: 'app_id and reason are required' };
+  }
+  const session = await SupaAuth.getSession().catch(() => null);
+  const headers = {
+    ...supabaseHeaders(session),
+    'Content-Type': 'application/json',
+    Prefer: 'resolution=merge-duplicates,return=representation',
+  };
+  const body = JSON.stringify([{
+    app_id:    String(appId),
+    reason:    reason.trim(),
+    hidden_by: session?.user?.id || null,
+  }]);
+  try {
+    const res = await fetch(`${SB}/game_hides?on_conflict=app_id`, {
+      method: 'POST', headers, body, cache: 'no-store',
+    });
+    if (!res.ok) return { ok: false, error: `HTTP ${res.status}`, status: res.status };
+    const rows = await res.json().catch(() => []);
+    return { ok: true, row: rows[0] || null };
+  } catch (e) { return { ok: false, error: e.message || String(e) }; }
+}
+
+/** Remove a hide entry so the game becomes visible again. */
+export async function deleteGameHide(appId) {
+  if (!appId) return { ok: false, error: 'app_id is required' };
+  try {
+    const headers = await _authedHeaders();
+    const res = await fetch(
+      `${SB}/game_hides?app_id=eq.${encodeURIComponent(String(appId))}`,
+      { method: 'DELETE', headers, cache: 'no-store' },
+    );
+    if (!res.ok) return { ok: false, error: `HTTP ${res.status}`, status: res.status };
+    return { ok: true };
+  } catch (e) { return { ok: false, error: e.message || String(e) }; }
+}
+
+// ── game_remaps ────────────────────────────────────────────────────────
+
+/**
+ * List every remap, newest first. Returns an array of
+ * { from_app_id, to_app_id, reason, remapped_by, created_at, updated_at } rows.
+ */
+export async function listGameRemaps() {
+  try {
+    const headers = await _authedHeaders();
+    const res = await fetch(
+      `${SB}/game_remaps?select=from_app_id,to_app_id,reason,remapped_by,created_at,updated_at&order=updated_at.desc`,
+      { headers, cache: 'no-store' },
+    );
+    if (!res.ok) return [];
+    return await res.json();
+  } catch { return []; }
+}
+
+/**
+ * Set or replace a remap. Panel-side validation guards against the self-loop
+ * that the DB CHECK constraint would also catch; we do it here too so the
+ * error message is friendlier.
+ */
+export async function upsertGameRemap(fromAppId, toAppId, reason) {
+  if (!fromAppId || !toAppId || !reason?.trim()) {
+    return { ok: false, error: 'from_app_id, to_app_id, and reason are required' };
+  }
+  if (String(fromAppId) === String(toAppId)) {
+    return { ok: false, error: 'from and to app ids must differ' };
+  }
+  const session = await SupaAuth.getSession().catch(() => null);
+  const headers = {
+    ...supabaseHeaders(session),
+    'Content-Type': 'application/json',
+    Prefer: 'resolution=merge-duplicates,return=representation',
+  };
+  const body = JSON.stringify([{
+    from_app_id: String(fromAppId),
+    to_app_id:   String(toAppId),
+    reason:      reason.trim(),
+    remapped_by: session?.user?.id || null,
+  }]);
+  try {
+    const res = await fetch(`${SB}/game_remaps?on_conflict=from_app_id`, {
+      method: 'POST', headers, body, cache: 'no-store',
+    });
+    if (!res.ok) return { ok: false, error: `HTTP ${res.status}`, status: res.status };
+    const rows = await res.json().catch(() => []);
+    return { ok: true, row: rows[0] || null };
+  } catch (e) { return { ok: false, error: e.message || String(e) }; }
+}
+
+/** Remove a remap so the original app id resolves to itself again. */
+export async function deleteGameRemap(fromAppId) {
+  if (!fromAppId) return { ok: false, error: 'from_app_id is required' };
+  try {
+    const headers = await _authedHeaders();
+    const res = await fetch(
+      `${SB}/game_remaps?from_app_id=eq.${encodeURIComponent(String(fromAppId))}`,
+      { method: 'DELETE', headers, cache: 'no-store' },
+    );
+    if (!res.ok) return { ok: false, error: `HTTP ${res.status}`, status: res.status };
+    return { ok: true };
+  } catch (e) { return { ok: false, error: e.message || String(e) }; }
+}
+
+// ── Pipeline-flagged suspects (read-only) ─────────────────────────────
+
+/**
+ * Load the pipeline's app-id-redirects.json (produced by #233's validator).
+ * Returns { <appId>: { status, replaced_by?, final_url? }, ... } or {} if
+ * the file isn't published yet.
+ */
+export async function loadPipelineSuspects() {
+  try {
+    // The pipeline writes this file at the origin's data root during finalize.
+    // Fetching relative keeps it on the current origin (staging vs prod).
+    const parts = location.pathname.split('/').filter(Boolean);
+    const base = parts[0] === 'proton-pulse-web' ? '/proton-pulse-web'
+              : parts[0] === 'proton-pulse-web-staging' ? '/proton-pulse-web-staging'
+              : '';
+    const res = await fetch(`${base}/app-id-redirects.json`, { cache: 'no-store' });
+    if (!res.ok) return {};
+    return await res.json();
+  } catch { return {}; }
+}

--- a/js/admin/api/steam-library-lookup.js
+++ b/js/admin/api/steam-library-lookup.js
@@ -1,0 +1,58 @@
+// Admin-only API Explorer client for keyed Steam Web API endpoints.
+// Calls the steam-library-lookup edge function, which verifies the caller
+// is an admin with manage_admins before attaching the Steam Web API key
+// and hitting Steam. See supabase/functions/steam-library-lookup/index.ts
+// and issue #221.
+
+import { SUPABASE_URL, SUPABASE_ANON_KEY } from '../config.js?v=ffed3d84';
+
+const ENDPOINT = () => `${SUPABASE_URL}/functions/v1/steam-library-lookup`;
+
+const LIBRARY_ENDPOINT_KEYS = new Set([
+  'steam_get_owned_games',
+  'steam_get_recently_played',
+  'steam_resolve_vanity',
+]);
+
+export function isLibraryEndpoint(key) {
+  return LIBRARY_ENDPOINT_KEYS.has(String(key));
+}
+
+// Grabs the current signed-in session via the global supabase client so callers
+// don't have to plumb the token in. Matches the pattern in boxart.js _authedFetch.
+async function _session() {
+  const SupaAuth = window.SupaAuth || window.protonPulseAuth;
+  if (!SupaAuth || typeof SupaAuth.getSession !== 'function') return null;
+  try { return await SupaAuth.getSession(); } catch { return null; }
+}
+
+// Client for the three admin-gated Steam Web API endpoints. Returns the
+// same envelope shape steam-explore returns: { ok, endpoint, arg, url,
+// method, status, data, error? } so the Explorer renders it uniformly.
+export async function lookupLibrary(endpoint, { steamid = '', vanityurl = '' } = {}) {
+  const session = await _session();
+  if (!session?.access_token) {
+    return { ok: false, endpoint, error: 'sign in as an admin first' };
+  }
+  try {
+    const res = await fetch(ENDPOINT(), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${session.access_token}`,
+        apikey: SUPABASE_ANON_KEY,
+      },
+      body: JSON.stringify({
+        endpoint: String(endpoint),
+        steamid: String(steamid || ''),
+        vanityurl: String(vanityurl || ''),
+      }),
+      cache: 'no-store',
+    });
+    const body = await res.json().catch(() => null);
+    if (!body) return { ok: false, endpoint, error: `proxy HTTP ${res.status} (no body)` };
+    return body;
+  } catch (e) {
+    return { ok: false, endpoint, error: `network: ${e.message || String(e)}` };
+  }
+}

--- a/js/admin/components/admins.js
+++ b/js/admin/components/admins.js
@@ -1,7 +1,7 @@
 // admins (components) for the admin page.
 
 import { escapeHtml, fmtDateTime } from '../utils.js?v=2668b2f0';
-import { PERMISSION_LABELS, effectivePermissions, resolveRoleLabel, permissionsToAdd } from '../permissions.js?v=12b82ef4';
+import { PERMISSION_LABELS, effectivePermissions, resolveRoleLabel, permissionsToAdd } from '../permissions.js?v=0708a804';
 
 // Role <select> for a row or the add form. `uuid` is 'new' for the add form.
 function roleSelectHtml(label, uuid) {

--- a/js/admin/components/api-explorer.js
+++ b/js/admin/components/api-explorer.js
@@ -11,6 +11,7 @@
 import { dataUrl } from '../../lib/data-url.js?v=3c2e7ac9';
 import { escapeHtml } from '../utils.js?v=2668b2f0';
 import { exploreStore } from '../api/steam-explore.js?v=17281b89';
+import { isLibraryEndpoint, lookupLibrary } from '../api/steam-library-lookup.js?v=748599e3';
 
 // Store -> endpoints. `arg` is 'id' (numeric app/product id, name-resolvable)
 // or 'term' (free-text search). Keys match the edge function's ENDPOINTS.
@@ -29,6 +30,12 @@ const STORES = {
       { key: 'steam_community_search', label: 'community search (autocomplete)', arg: 'term' },
       { key: 'steam_featured', label: 'store featured (front page)', arg: 'none' },
       { key: 'steam_featured_categories', label: 'store featured categories', arg: 'none' },
+      // Keyed Steam Web API endpoints. Filtered out for non-admin users
+      // in populateEndpoints below; the edge fn also verifies manage_admins
+      // so the key never leaves the server for a non-admin caller. #221.
+      { key: 'steam_get_owned_games',     label: 'GetOwnedGames -- library for steamid (admin)',           arg: 'steamid', adminGated: true },
+      { key: 'steam_get_recently_played', label: 'GetRecentlyPlayedGames -- recent for steamid (admin)',   arg: 'steamid', adminGated: true },
+      { key: 'steam_resolve_vanity',      label: 'ResolveVanityURL -- vanity name -> steamid (admin)',     arg: 'vanity',  adminGated: true },
     ],
   },
   gog: {
@@ -169,6 +176,36 @@ const FIELD_DOCS = {
       ['elements[].price.totalPrice', 'discountPrice / originalPrice (in cents).'],
     ],
   },
+  steam_get_owned_games: {
+    title: 'Owned games (IPlayerService/GetOwnedGames)',
+    rows: [
+      ['response.game_count', 'Total games on the account (including F2P titles the user has launched).'],
+      ['response.games[].appid', 'Numeric Steam app ID -- cross-reference with the search index.'],
+      ['response.games[].name', 'Store title (present because we sent include_appinfo=1).'],
+      ['response.games[].playtime_forever', 'Lifetime playtime in minutes across all sessions.'],
+      ['response.games[].playtime_2weeks', 'Recent (last 2 weeks) playtime in minutes. Absent if the user has not played it recently.'],
+      ['response.games[].img_icon_url', 'Icon hash. Combine as https://media.steampowered.com/steamcommunity/public/images/apps/<appid>/<hash>.jpg.'],
+      ['response.games[].rtime_last_played', 'Unix timestamp of the most recent session for that title.'],
+    ],
+  },
+  steam_get_recently_played: {
+    title: 'Recently played (IPlayerService/GetRecentlyPlayedGames)',
+    rows: [
+      ['response.total_count', 'Number of games played in the last two weeks. Steam caps the list at 10-20 apps.'],
+      ['response.games[]', 'One entry per recently-played app.'],
+      ['response.games[].appid / .name / .img_icon_url', 'Same fields as GetOwnedGames -- resolve the icon URL the same way.'],
+      ['response.games[].playtime_forever', 'Lifetime playtime in minutes (mirror of GetOwnedGames).'],
+      ['response.games[].playtime_2weeks', 'Minutes played in the current 2-week window. Drives the "recent" ordering.'],
+    ],
+  },
+  steam_resolve_vanity: {
+    title: 'Resolve vanity URL (ISteamUser/ResolveVanityURL)',
+    rows: [
+      ['response.success', '1 = matched, 42 = no match, other = error. Steam only exposes success=1 with a steamid you can use.'],
+      ['response.steamid', 'Numeric 64-bit steamid you can feed into GetOwnedGames or the other library endpoints.'],
+      ['response.message', 'Human-readable error string when success != 1.'],
+    ],
+  },
 };
 
 function _showFieldDocs(endpointKey) {
@@ -261,6 +298,16 @@ async function _resolveArg(store, endpointArg, input) {
   if (endpointArg === 'none') return { id: '', title: '' };
   if (!q) return { error: 'Enter an ID, name, or search term.' };
   if (endpointArg === 'term') return { term: q };
+  // Keyed Steam Web API endpoints (#221): steamid is a numeric 17-digit id,
+  // vanity is the alphanumeric profile name. Both are passed straight through.
+  if (endpointArg === 'steamid') {
+    if (!/^\d{5,20}$/.test(q)) return { error: 'Steam ID must be a numeric 17-digit value (starts with 7656...).' };
+    return { steamid: q };
+  }
+  if (endpointArg === 'vanity') {
+    if (!/^[A-Za-z0-9_-]{2,64}$/.test(q)) return { error: 'Vanity URL is the profile name (letters, digits, _ or -).' };
+    return { vanityurl: q };
+  }
   if (/^\d+$/.test(q)) return { id: q };
   const idx = await _loadIndex();
   const ql = q.toLowerCase();
@@ -279,7 +326,11 @@ async function _resolveArg(store, endpointArg, input) {
   return { id, title: String(match[1] || '') };
 }
 
-export function renderApiExplorer() {
+// #221: `canManageAdmins` gates the three keyed Steam Web API endpoints
+// (GetOwnedGames / GetRecentlyPlayedGames / ResolveVanityURL). Passed
+// through from main.js so we don't need to duplicate the permission
+// resolution logic here.
+export function renderApiExplorer({ canManageAdmins = false } = {}) {
   const el = document.getElementById('api-explorer-content');
   if (!el) return;
 
@@ -340,10 +391,29 @@ export function renderApiExplorer() {
   const inputEl = el.querySelector('#apix-input');
 
   const populateEndpoints = () => {
-    endpointSel.innerHTML = STORES[store].endpoints
+    // Hide admin-gated endpoints when the current user lacks manage_admins.
+    // The edge fn also refuses to run for non-admins (defense in depth); this
+    // just keeps the dropdown clean so we don't tempt regular signed-in users
+    // with options that would 403. #221.
+    const list = STORES[store].endpoints.filter(
+      (e) => !e.adminGated || canManageAdmins,
+    );
+    endpointSel.innerHTML = list
       .map((e) => `<option value="${e.key}" data-arg="${e.arg}">${escapeHtml(e.label)}</option>`)
       .join('');
-    inputEl.placeholder = STORES[store].placeholder;
+    // Placeholder updates with the currently selected endpoint's arg type so
+    // admins see "Steam ID (17 digits)" instead of a stale "App ID or name"
+    // hint. Rebuilt on populate + on select change below.
+    const updatePlaceholder = () => {
+      const opt = endpointSel.options[endpointSel.selectedIndex];
+      const arg = opt?.dataset.arg || 'id';
+      const hint = arg === 'steamid' ? 'Steam ID (17 digits, e.g. 76561197960287930)'
+        : arg === 'vanity' ? 'Vanity URL profile name (e.g. gaben)'
+        : STORES[store].placeholder;
+      inputEl.placeholder = hint;
+    };
+    updatePlaceholder();
+    endpointSel.onchange = updatePlaceholder;
   };
   populateEndpoints();
 
@@ -364,18 +434,26 @@ export function renderApiExplorer() {
     if (resolved.error) { setStatus(resolved.error, true); return; }
     const label = arg === 'none'
       ? '(no argument)'
-      : resolved.id
-        ? `app ${resolved.id}${resolved.title ? ` (${resolved.title})` : ''}`
-        : `"${resolved.term}"`;
+      : resolved.steamid
+        ? `steamid ${resolved.steamid}`
+        : resolved.vanityurl
+          ? `vanity "${resolved.vanityurl}"`
+          : resolved.id
+            ? `app ${resolved.id}${resolved.title ? ` (${resolved.title})` : ''}`
+            : `"${resolved.term}"`;
     setStatus(`Fetching ${endpoint} for ${label}...`);
     const btn = document.getElementById('apix-fetch');
     if (btn) btn.disabled = true;
-    const payload = await exploreStore(endpoint, { id: resolved.id, term: resolved.term });
+    // #221: keyed endpoints go through the admin-only proxy. Public endpoints
+    // stay on steam-explore. isLibraryEndpoint keeps the routing in one place.
+    const payload = isLibraryEndpoint(endpoint)
+      ? await lookupLibrary(endpoint, { steamid: resolved.steamid, vanityurl: resolved.vanityurl })
+      : await exploreStore(endpoint, { id: resolved.id, term: resolved.term });
     if (btn) btn.disabled = false;
     lastPayload = payload;
     const rawMode = document.getElementById('apix-raw')?.checked;
     lastJson = JSON.stringify(rawMode ? payload : (payload && 'data' in payload ? payload.data : payload), null, 2);
-    lastName = `${endpoint}-${resolved.id || (resolved.term || '').replace(/\W+/g, '-').slice(0, 40)}`;
+    lastName = `${endpoint}-${resolved.id || resolved.steamid || resolved.vanityurl || (resolved.term || '').replace(/\W+/g, '-').slice(0, 40)}`;
     const out = document.getElementById('apix-output');
     if (out) { out.hidden = false; out.textContent = lastJson; }
     document.getElementById('apix-toolbar').hidden = false;

--- a/js/admin/components/gameManager.js
+++ b/js/admin/components/gameManager.js
@@ -1,0 +1,268 @@
+// Admin "Games" tab -- the manual fallback for bad app IDs (#234).
+//
+// Three sub-sections:
+//   1. Hidden games:   admin blacklist. Row: app_id / title / reason /
+//                      hidden by / when / unhide.
+//   2. Remapped IDs:   admin-forced redirects. Row: from / to / reason /
+//                      when / clear.
+//   3. Pipeline suspects: read-only view of app-id-redirects.json (from
+//                      #233's validator). Admin can promote a suspect to a
+//                      real remap or hide with one click.
+//
+// The panel writes go through Supabase (game_hides / game_remaps tables).
+// RLS on both is gated by the manage_games permission -- super_admin also
+// gets it via the current_user_has_permission short-circuit. Consumers
+// (frontend filter, pipeline bake) are a follow-up ticket; this MVP just
+// gives moderators the write path.
+
+import { dataUrl } from '../../lib/data-url.js?v=3c2e7ac9';
+import { escapeHtml } from '../utils.js?v=2668b2f0';
+import {
+  listGameHides, upsertGameHide, deleteGameHide,
+  listGameRemaps, upsertGameRemap, deleteGameRemap,
+  loadPipelineSuspects,
+} from '../api/gameManager.js?v=596babe0';
+
+// Small in-memory cache of the search-index so we can render titles next
+// to raw app ids. Fetched once when the tab mounts.
+let _searchIndex = null;
+async function _loadIndex() {
+  if (_searchIndex) return _searchIndex;
+  try {
+    const res = await fetch(await dataUrl('search-index.json'));
+    _searchIndex = res.ok ? await res.json() : [];
+  } catch { _searchIndex = []; }
+  return _searchIndex;
+}
+
+// Map { app_id -> title } for O(1) lookups when rendering rows.
+async function _titleMap() {
+  const idx = await _loadIndex();
+  const out = new Map();
+  for (const row of idx) {
+    if (Array.isArray(row) && row[0]) out.set(String(row[0]), String(row[1] || ''));
+  }
+  return out;
+}
+
+function _fmtDate(iso) {
+  if (!iso) return '-';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '-';
+  return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+function _titleFor(titleMap, appId) {
+  const t = titleMap.get(String(appId));
+  return t || `App ${appId}`;
+}
+
+// ── Public entry point ────────────────────────────────────────────────
+
+export async function renderGameManager() {
+  const el = document.getElementById('game-manager-content');
+  if (!el) return;
+  el.innerHTML = `<div class="admin-loading">Loading Game Manager...</div>`;
+
+  const [hides, remaps, suspects, titleMap] = await Promise.all([
+    listGameHides(),
+    listGameRemaps(),
+    loadPipelineSuspects(),
+    _titleMap(),
+  ]);
+
+  el.innerHTML = `
+    <div class="admin-card gm-card">
+      <div class="admin-subhead">Hidden games</div>
+      <p class="admin-hint">Blacklist an app id so it stops appearing in the site's search + list pages. Requires a reason so the paper trail explains the take-down. Frontend consumer is a follow-up ticket -- for now the panel just writes the row.</p>
+      <form class="gm-form" id="gm-hide-form">
+        <input class="admin-input gm-form-id" name="app_id" placeholder="App ID (e.g. 26670 or gog:123)" required>
+        <input class="admin-input gm-form-reason" name="reason" placeholder="Reason (required)" required>
+        <button class="admin-btn admin-btn--primary" type="submit">Hide</button>
+      </form>
+      <div id="gm-hide-status" class="admin-hint" hidden></div>
+      <table class="admin-table gm-table">
+        <thead><tr><th>App ID</th><th>Title</th><th>Reason</th><th>Hidden</th><th></th></tr></thead>
+        <tbody id="gm-hides-body"></tbody>
+      </table>
+    </div>
+
+    <div class="admin-card gm-card">
+      <div class="admin-subhead">Remapped IDs</div>
+      <p class="admin-hint">Redirect a bad app id to the correct one. Strongly overrules the pipeline's <code>replaced_by</code> detection when Steam's own redirects are wrong or missing. Reason required.</p>
+      <form class="gm-form" id="gm-remap-form">
+        <input class="admin-input gm-form-id" name="from_app_id" placeholder="From App ID" required>
+        <input class="admin-input gm-form-id" name="to_app_id" placeholder="To App ID" required>
+        <input class="admin-input gm-form-reason" name="reason" placeholder="Reason (required)" required>
+        <button class="admin-btn admin-btn--primary" type="submit">Remap</button>
+      </form>
+      <div id="gm-remap-status" class="admin-hint" hidden></div>
+      <table class="admin-table gm-table">
+        <thead><tr><th>From</th><th>To</th><th>Reason</th><th>Updated</th><th></th></tr></thead>
+        <tbody id="gm-remaps-body"></tbody>
+      </table>
+    </div>
+
+    <div class="admin-card gm-card">
+      <div class="admin-subhead">Pipeline-flagged suspects</div>
+      <p class="admin-hint">Read-only view of <code>app-id-redirects.json</code>, populated by the pipeline validator (#233 / #235). Empty when the file hasn't been published yet.</p>
+      <table class="admin-table gm-table">
+        <thead><tr><th>App ID</th><th>Title</th><th>Status</th><th>Suggested target</th><th></th></tr></thead>
+        <tbody id="gm-suspects-body"></tbody>
+      </table>
+    </div>
+  `;
+
+  _renderHides(el, hides, titleMap);
+  _renderRemaps(el, remaps, titleMap);
+  _renderSuspects(el, suspects, titleMap);
+  _wireForms(el, titleMap);
+}
+
+// ── Section renderers ─────────────────────────────────────────────────
+
+function _renderHides(root, rows, titleMap) {
+  const tbody = root.querySelector('#gm-hides-body');
+  if (!tbody) return;
+  if (!rows.length) {
+    tbody.innerHTML = `<tr><td colspan="5" class="admin-empty">No games hidden.</td></tr>`;
+    return;
+  }
+  tbody.innerHTML = rows.map((r) => `
+    <tr data-app-id="${escapeHtml(r.app_id)}">
+      <td><code>${escapeHtml(r.app_id)}</code></td>
+      <td><a href="app.html#/app/${encodeURIComponent(r.app_id)}" target="_blank" rel="noopener">${escapeHtml(_titleFor(titleMap, r.app_id))}</a></td>
+      <td>${escapeHtml(r.reason)}</td>
+      <td>${escapeHtml(_fmtDate(r.hidden_at))}</td>
+      <td><button class="admin-btn" data-action="unhide" data-app-id="${escapeHtml(r.app_id)}">Unhide</button></td>
+    </tr>
+  `).join('');
+}
+
+function _renderRemaps(root, rows, titleMap) {
+  const tbody = root.querySelector('#gm-remaps-body');
+  if (!tbody) return;
+  if (!rows.length) {
+    tbody.innerHTML = `<tr><td colspan="5" class="admin-empty">No remaps set.</td></tr>`;
+    return;
+  }
+  tbody.innerHTML = rows.map((r) => `
+    <tr data-app-id="${escapeHtml(r.from_app_id)}">
+      <td><code>${escapeHtml(r.from_app_id)}</code></td>
+      <td><a href="app.html#/app/${encodeURIComponent(r.to_app_id)}" target="_blank" rel="noopener"><code>${escapeHtml(r.to_app_id)}</code> ${escapeHtml(_titleFor(titleMap, r.to_app_id))}</a></td>
+      <td>${escapeHtml(r.reason)}</td>
+      <td>${escapeHtml(_fmtDate(r.updated_at || r.created_at))}</td>
+      <td><button class="admin-btn" data-action="clear-remap" data-app-id="${escapeHtml(r.from_app_id)}">Clear</button></td>
+    </tr>
+  `).join('');
+}
+
+function _renderSuspects(root, suspects, titleMap) {
+  const tbody = root.querySelector('#gm-suspects-body');
+  if (!tbody) return;
+  const rows = Object.entries(suspects || {});
+  if (!rows.length) {
+    tbody.innerHTML = `<tr><td colspan="5" class="admin-empty">No pipeline-flagged suspects. This list is populated once the validator has run and pushed <code>app-id-redirects.json</code> to gh-pages.</td></tr>`;
+    return;
+  }
+  tbody.innerHTML = rows.map(([appId, entry]) => {
+    const status = entry.status || 'unknown';
+    const target = entry.replaced_by || '';
+    const action = target
+      ? `<button class="admin-btn admin-btn--primary" data-action="promote-remap" data-app-id="${escapeHtml(appId)}" data-target="${escapeHtml(target)}">Remap -> ${escapeHtml(target)}</button>`
+      : `<button class="admin-btn" data-action="promote-hide" data-app-id="${escapeHtml(appId)}">Hide</button>`;
+    return `
+      <tr data-app-id="${escapeHtml(appId)}">
+        <td><code>${escapeHtml(appId)}</code></td>
+        <td>${escapeHtml(_titleFor(titleMap, appId))}</td>
+        <td><span class="gm-suspect-status gm-suspect-status--${escapeHtml(status)}">${escapeHtml(status)}</span></td>
+        <td>${target ? `<code>${escapeHtml(target)}</code>` : '-'}</td>
+        <td>${action}</td>
+      </tr>
+    `;
+  }).join('');
+}
+
+// ── Form + row-action wiring ─────────────────────────────────────────
+
+function _setStatus(el, id, text, tone = 'info') {
+  const s = el.querySelector(`#${id}`);
+  if (!s) return;
+  s.hidden = false;
+  s.textContent = text;
+  s.className = 'admin-hint' + (tone === 'error' ? ' admin-error' : '');
+}
+
+function _wireForms(el, titleMap) {
+  const hideForm = el.querySelector('#gm-hide-form');
+  hideForm?.addEventListener('submit', async (ev) => {
+    ev.preventDefault();
+    const f = new FormData(hideForm);
+    const res = await upsertGameHide(f.get('app_id'), f.get('reason'));
+    if (!res.ok) return _setStatus(el, 'gm-hide-status', `Failed: ${res.error}`, 'error');
+    hideForm.reset();
+    const hides = await listGameHides();
+    _renderHides(el, hides, titleMap);
+    _setStatus(el, 'gm-hide-status', 'Saved.');
+  });
+
+  const remapForm = el.querySelector('#gm-remap-form');
+  remapForm?.addEventListener('submit', async (ev) => {
+    ev.preventDefault();
+    const f = new FormData(remapForm);
+    const res = await upsertGameRemap(f.get('from_app_id'), f.get('to_app_id'), f.get('reason'));
+    if (!res.ok) return _setStatus(el, 'gm-remap-status', `Failed: ${res.error}`, 'error');
+    remapForm.reset();
+    const remaps = await listGameRemaps();
+    _renderRemaps(el, remaps, titleMap);
+    _setStatus(el, 'gm-remap-status', 'Saved.');
+  });
+
+  // Row-action delegation. Unhide + clear + promote-* all live here so a
+  // fresh render doesn't require re-wiring individual buttons.
+  el.addEventListener('click', async (ev) => {
+    const btn = ev.target.closest('button[data-action]');
+    if (!btn) return;
+    const action = btn.dataset.action;
+    const appId = btn.dataset.appId;
+    if (!action || !appId) return;
+
+    if (action === 'unhide') {
+      const res = await deleteGameHide(appId);
+      if (!res.ok) return _setStatus(el, 'gm-hide-status', `Failed: ${res.error}`, 'error');
+      _renderHides(el, await listGameHides(), titleMap);
+      return;
+    }
+
+    if (action === 'clear-remap') {
+      const res = await deleteGameRemap(appId);
+      if (!res.ok) return _setStatus(el, 'gm-remap-status', `Failed: ${res.error}`, 'error');
+      _renderRemaps(el, await listGameRemaps(), titleMap);
+      return;
+    }
+
+    if (action === 'promote-remap') {
+      const target = btn.dataset.target;
+      const reason = window.prompt(
+        `Reason to remap ${appId} -> ${target}?\n(Pipeline validator flagged this. Cancel to skip.)`,
+        'Pipeline validator flagged as replaced.',
+      );
+      if (!reason || !reason.trim()) return;
+      const res = await upsertGameRemap(appId, target, reason);
+      if (!res.ok) return _setStatus(el, 'gm-remap-status', `Failed: ${res.error}`, 'error');
+      _renderRemaps(el, await listGameRemaps(), titleMap);
+      return;
+    }
+
+    if (action === 'promote-hide') {
+      const reason = window.prompt(
+        `Reason to hide ${appId}?\n(Pipeline validator flagged this as dead. Cancel to skip.)`,
+        'Pipeline validator flagged as dead app id.',
+      );
+      if (!reason || !reason.trim()) return;
+      const res = await upsertGameHide(appId, reason);
+      if (!res.ok) return _setStatus(el, 'gm-hide-status', `Failed: ${res.error}`, 'error');
+      _renderHides(el, await listGameHides(), titleMap);
+    }
+  });
+}

--- a/js/admin/main.js
+++ b/js/admin/main.js
@@ -18,7 +18,7 @@ import { fetchAnalytics } from './api/analytics.js?v=a1c14331';
 import { renderAnalytics } from './components/analytics.js?v=e538dd08';
 import { renderCacheStatus } from './components/cache-status.js?v=0c6c0cb7';
 import { renderBoxartAdmin, renderBoxartAdminDetail } from './components/boxart.js?v=bd0825b6';
-import { renderApiExplorer } from './components/api-explorer.js?v=1d2d1835';
+import { renderApiExplorer } from './components/api-explorer.js?v=73d3d3d5';
 import { renderAllReports, updateAllReportsRow, renderAllReportsDetail } from './components/allReports.js?v=99d5c1f5';
 import { patchReportFlags, fetchReportById } from './api/allReports.js?v=ce9b13c3';
 import { approveReport } from './api/pending.js?v=84292a58';
@@ -454,7 +454,7 @@ const TAB_LOADERS = {
   phrases: loadPhrases,
   analytics: loadAnalytics,
   boxart: () => renderBoxartAdmin().catch(e => console.error('[boxart]', e)),
-  'api-explorer': () => renderApiExplorer(),
+  'api-explorer': () => renderApiExplorer({ canManageAdmins: can('manage_admins') }),
 };
 
 // Activate a tab, load its data, and reflect it in the URL as ?tab=<name> so a

--- a/js/admin/main.js
+++ b/js/admin/main.js
@@ -1,6 +1,6 @@
 import { SupaAuth, SUPABASE_URL } from './config.js?v=ffed3d84';
 import { supabaseHeaders, escapeHtml } from './utils.js?v=2668b2f0';
-import { effectivePermissions, hasPermission, canSeeTab, resolveRoleLabel, PERMISSION_LABELS, presetFor, addPermission, removePermission } from './permissions.js?v=12b82ef4';
+import { effectivePermissions, hasPermission, canSeeTab, resolveRoleLabel, PERMISSION_LABELS, presetFor, addPermission, removePermission } from './permissions.js?v=0708a804';
 import { fetchFlaggedReports, updateFlagStatus, deleteFlaggedReport, fetchFlagReportContent, findPulseConfigId, shadowBanReport, releaseReportContent, deleteReportContent, suppressMirrorReport, unsuppressMirrorReport, fetchReportState } from './api/flagged.js?v=9359a45e';
 import { renderFlagged, renderFlagDetail } from './components/flagged.js?v=5e2c6b60';
 import { fetchBannedUsers, banUser, unbanUser } from './api/banned.js?v=0d6ec118';
@@ -19,6 +19,7 @@ import { renderAnalytics } from './components/analytics.js?v=e538dd08';
 import { renderCacheStatus } from './components/cache-status.js?v=0c6c0cb7';
 import { renderBoxartAdmin, renderBoxartAdminDetail } from './components/boxart.js?v=bd0825b6';
 import { renderApiExplorer } from './components/api-explorer.js?v=73d3d3d5';
+import { renderGameManager } from './components/gameManager.js?v=de1dd326';
 import { renderAllReports, updateAllReportsRow, renderAllReportsDetail } from './components/allReports.js?v=99d5c1f5';
 import { patchReportFlags, fetchReportById } from './api/allReports.js?v=ce9b13c3';
 import { approveReport } from './api/pending.js?v=84292a58';
@@ -455,6 +456,7 @@ const TAB_LOADERS = {
   analytics: loadAnalytics,
   boxart: () => renderBoxartAdmin().catch(e => console.error('[boxart]', e)),
   'api-explorer': () => renderApiExplorer({ canManageAdmins: can('manage_admins') }),
+  games: () => renderGameManager().catch(e => console.error('[game-manager]', e)),
 };
 
 // Activate a tab, load its data, and reflect it in the URL as ?tab=<name> so a

--- a/js/admin/permissions.js
+++ b/js/admin/permissions.js
@@ -9,6 +9,7 @@ export const PERMISSIONS = [
   { key: 'manage_phrases', label: 'Manage banned phrases' },
   { key: 'manage_admins',  label: 'Manage admins' },
   { key: 'view_analytics', label: 'View analytics' },
+  { key: 'manage_games',   label: 'Manage games (hide / remap)' },
 ];
 
 export const ALL_PERMISSION_KEYS = PERMISSIONS.map(p => p.key);
@@ -17,7 +18,7 @@ export const PERMISSION_LABELS = Object.fromEntries(PERMISSIONS.map(p => [p.key,
 
 // Role presets fill a permission group; a super_admin always has everything.
 export const ROLE_PRESETS = {
-  moderator:   ['manage_reports', 'delete_reports', 'ban_users', 'view_analytics'],
+  moderator:   ['manage_reports', 'delete_reports', 'ban_users', 'view_analytics', 'manage_games'],
   super_admin: ALL_PERMISSION_KEYS.slice(),
 };
 
@@ -31,6 +32,7 @@ export const TAB_PERMISSIONS = {
   analytics:      ['view_analytics'],
   boxart:         ['view_analytics'],
   'api-explorer': ['view_analytics'],
+  games:          ['manage_games'],
 };
 
 // Effective permissions for an admin. super_admin short-circuits to all.

--- a/js/app/api/protondb.js
+++ b/js/app/api/protondb.js
@@ -62,12 +62,17 @@ export async function fetchProtonDbLive(appId) {
     console.log(`[proton-pulse] live check for ${appId} | tier=${data.tier} total=${data.total} source=protondb-summary-proxy`);
     const result = [{
       appId,
-      tier:         data.tier,
-      total:        data.total || 0,
-      trendingTier: data.trendingTier || data.tier,
-      score:        data.score || 0,
-      source:       'protondb-live',
-      _liveOnly:    true,
+      tier:             data.tier,
+      total:            data.total || 0,
+      trendingTier:     data.trendingTier || data.tier,
+      // ProtonDB's summary also exposes bestReportedTier (highest ever) and
+      // confidence ('strong'|'moderate'|'weak'). Surfacing both lets the
+      // aggregate block on the game page show more than just "one tier".
+      bestReportedTier: data.bestReportedTier || data.tier,
+      confidence:       data.confidence || '',
+      score:            data.score || 0,
+      source:           'protondb-live',
+      _liveOnly:        true,
     }];
     _protonDbLiveCache.set(key, result);
     return result;

--- a/js/app/api/votes.js
+++ b/js/app/api/votes.js
@@ -1,6 +1,6 @@
 // votes (api) for the app page. Relocated from app.js.
 
-import { getWebClientId } from '../../shared/submit.js?v=339c68ea';
+import { getWebClientId } from '../../shared/submit.js?v=bfe659f0';
 import { SB_KEY, SB_URL } from '../config.js?v=f9591262';
 
 export async function fetchVotes(appId) {

--- a/js/app/components/config-cards.js
+++ b/js/app/components/config-cards.js
@@ -1,6 +1,6 @@
 // config-cards (components) for the app page. Relocated from app.js.
 
-import { getWebClientId } from '../../shared/submit.js?v=339c68ea';
+import { getWebClientId } from '../../shared/submit.js?v=bfe659f0';
 import { isNonSteamAppId } from '../config.js?v=f9591262';
 import { cfgNa, configKey, esc, utcStamp } from '../utils.js?v=c7e1268c';
 

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -847,14 +847,32 @@ export async function renderGamePage(appId) {
     const TIER_ORDER = ['platinum', 'gold', 'silver', 'bronze', 'borked'];
     const TIER_FULL = { platinum: 'PLATINUM', gold: 'GOLD', silver: 'SILVER', bronze: 'BRONZE', borked: 'BORKED' };
     const maxTierCount = Math.max(1, ...TIER_ORDER.map((t) => ratingCounts[t]));
+    const _mirrorTotalCount = TIER_ORDER.reduce((s, t) => s + ratingCounts[t], 0);
+    // When we have a live summary but the mirror sample is empty (or all reports
+    // lack a valid rating), render a single filled "primary tier" bar using the
+    // live summary tier + total. Beats five empty PLATINUM/GOLD/... 0 rows and
+    // still keeps the visual language of the bars section (#219 follow-up).
+    const _liveTierKey = liveSummary ? String(liveSummary.tier || '').toLowerCase() : '';
+    const _liveTierValid = TIER_ORDER.includes(_liveTierKey);
+    const _useLiveBar = !!liveSummary && _liveTierValid && _mirrorTotalCount === 0;
     // Attribution note when ProtonDB's live total exceeds what we have mirrored:
     // the per-tier bars are only from our mirror sample, but the aggregate count
     // and dial confidence are drawn from ProtonDB's real total (#219).
-    const _mirrorSampleNote = (!liveOnly && liveSummary && liveTotal > cdn.length)
-      ? `<div class="grp-bars-note grp-bars-note--sample">Per-tier bars reflect our mirrored sample (${cdn.length}); dial uses ProtonDB's live total (${liveTotal.toLocaleString()}).</div>`
+    const _mirrorSampleNote = (!liveOnly && !_useLiveBar && liveSummary && liveTotal > _mirrorTotalCount)
+      ? `<div class="grp-bars-note grp-bars-note--sample">Per-tier bars reflect our mirrored sample (${_mirrorTotalCount}); dial uses ProtonDB's live total (${liveTotal.toLocaleString()}).</div>`
       : '';
-    const tierBars = liveOnly
-      ? '<div class="grp-bars-note">Per-tier breakdown is not available from ProtonDB\'s live summary.</div>'
+    const _liveBarBlock = _useLiveBar
+      ? `<div class="grp-bars">
+          <div class="grp-bar grp-bar-${_liveTierKey}" title="${liveTotal.toLocaleString()} ${_liveTierKey} report${liveTotal !== 1 ? 's' : ''} (ProtonDB live summary)">
+            <span class="grp-bar-label">${TIER_FULL[_liveTierKey]}</span>
+            <span class="grp-bar-track"><span class="grp-bar-fill" style="width:100%;background:${RATING_COLORS[_liveTierKey]}"></span></span>
+            <span class="grp-bar-count">${liveTotal.toLocaleString()}</span>
+          </div>
+          <div class="grp-bars-note grp-bars-note--sample">Aggregate tier from ProtonDB (${liveTotal.toLocaleString()} report${liveTotal !== 1 ? 's' : ''}). Individual reports aren't mirrored here yet, so we can't show the full breakdown.</div>
+        </div>`
+      : '';
+    const tierBars = _useLiveBar
+      ? _liveBarBlock
       : `<div class="grp-bars">${TIER_ORDER.map((t) => {
           const n = ratingCounts[t];
           const pct = Math.round((n / maxTierCount) * 100);

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -262,17 +262,16 @@ async function _openMetadataModal(appId) {
   const list = (items) => (items || []).length
     ? `<div class="gm-chips">${items.map(i => `<span class="gm-chip">${esc(i)}</span>`).join('')}</div>`
     : '';
-  // Per-OS depot row: Steam does not publish per-depot last-updated dates
-  // via appdetails (that lives in PICS / SteamDB). Show the app-wide
-  // release date next to each supported OS + a SteamDB depot link so
-  // viewers can drill in. Tracked in #214.
+  // Per-OS depot row. Steam does not publish per-depot last-updated dates
+  // via appdetails (that lives in PICS / SteamDB), so we cache them via
+  // steamcmd nightly (#215) into steam_depot_updates and observation
+  // history into steam_depot_manifest_history. The edge fn returns:
+  //   { found, os: { windows|mac|linux: { tracked_since, last_updated, depots } } }
+  // Values are only populated when we have real observations -- we
+  // deliberately do NOT fall back to app-wide release date or to the
+  // branch timestamp for tracked_since. Better to show a dash than lie.
   const platformsRows = (p, releaseDate) => {
     if (!p) return '';
-    // depotInfo shape: { found: bool, os: { windows|mac|linux: {
-    //   first_seen, last_updated, depots } } }
-    // Populated by the #215 pipeline (steamcmd nightly). When we have a
-    // real last-updated date for an OS we render it; otherwise we fall
-    // through to the SteamDB deep link.
     const dOs = depotInfo?.found && depotInfo.os ? depotInfo.os : {};
     const fmtDate = (iso) => {
       if (!iso) return null;
@@ -280,38 +279,53 @@ async function _openMetadataModal(appId) {
       if (Number.isNaN(d.getTime())) return null;
       return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
     };
-    // First seen + Last update ONLY come from the steamcmd depot cache
-    // (steam_depot_updates via #215). We deliberately do NOT fall through
-    // to the app-wide release date -- that used to be shown here and
-    // confused viewers into thinking it was per-OS depot data, which it
-    // is not. Release date has its own row above the table.
+    // #237: brown package icon that deep-links to the per-game depots.json
+    // we publish alongside latest.json. GitHub blob URL so users see the
+    // raw JSON with syntax highlighting + a "Raw" download button.
+    const DEPOT_FILE_URL = `https://github.com/mdeguzis/proton-pulse-web/blob/gh-pages/data/${esc(String(meta.appId))}/depots.json`;
+    const _packageIcon = (os) => `
+      <a class="gm-depot-file" href="${DEPOT_FILE_URL}#os=${esc(os)}" target="_blank" rel="noopener" title="View the raw depots.json this modal was built from">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+          <path d="M21 8V19a2 2 0 01-2 2H5a2 2 0 01-2-2V8"/>
+          <path d="M1 5h22v3H1z"/>
+          <path d="M10 12h4"/>
+        </svg>
+      </a>`;
     const row = (key, label) => {
       const on = !!p[key];
       const cached = dOs[key];
       const lastFmt = fmtDate(cached?.last_updated);
-      let depotsCell;
-      let lastCell;
+      const trackedFmt = fmtDate(cached?.tracked_since);
+      let depotsCell, trackedCell, lastCell;
       if (!on) {
-        depotsCell = '<span class="gm-mute">not offered</span>';
-        lastCell   = '-';
-      } else if (lastFmt) {
-        depotsCell = `<span class="gm-mute">${cached.depots} tracked</span>`;
-        lastCell   = `<span class="gm-depot-date" title="Branch-level timeupdated from PICS -- every OS depot on a shared branch inherits this value. Per-OS 'First seen' requires observation history (#226).">${esc(lastFmt)}</span>`;
+        depotsCell  = '<span class="gm-mute">not offered</span>';
+        trackedCell = '-';
+        lastCell    = '-';
+      } else if (cached) {
+        depotsCell  = `<span class="gm-mute">${cached.depots} tracked</span>${_packageIcon(key)}`;
+        trackedCell = trackedFmt
+          ? `<span class="gm-depot-date" title="Earliest first_observed_at from steam_depot_manifest_history (#226)">${esc(trackedFmt)}</span>`
+          : '<span class="gm-mute" title="No observation history yet -- once the nightly pipeline observes this depot again with the same manifest, we will record a real tracked-since date">-</span>';
+        lastCell    = lastFmt
+          ? `<span class="gm-depot-date" title="Branch-level timeupdated from PICS -- every OS depot on a shared branch inherits this value">${esc(lastFmt)}</span>`
+          : '-';
       } else {
-        depotsCell = '<span class="gm-mute" title="Not cached yet -- pipeline #215 populates this nightly">pending</span>';
-        lastCell   = `<a class="gm-depot-link" href="https://steamdb.info/app/${esc(meta.appId)}/depots/" target="_blank" rel="noopener">SteamDB -&gt;</a>`;
+        depotsCell  = '<span class="gm-mute" title="Not cached yet -- pipeline #215 populates this nightly">pending</span>';
+        trackedCell = '-';
+        lastCell    = `<a class="gm-depot-link" href="https://steamdb.info/app/${esc(meta.appId)}/depots/" target="_blank" rel="noopener">SteamDB -&gt;</a>`;
       }
       return `
         <tr>
           <td><span class="gm-plat${on ? ' gm-plat--on' : ''}">${esc(label)}</span></td>
           <td>${depotsCell}</td>
+          <td>${trackedCell}</td>
           <td>${lastCell}</td>
         </tr>`;
     };
     return `<table class="gm-plat-table">
-      <thead><tr><th>OS</th><th>Depots</th><th>Last update</th></tr></thead>
+      <thead><tr><th>OS</th><th>Depots</th><th>Tracked since</th><th>Last update</th></tr></thead>
       <tbody>${row('windows','Windows')}${row('mac','macOS')}${row('linux','Linux')}</tbody>
-      <tfoot><tr><td colspan="3" class="gm-plat-foot">Last update is the branch-level timestamp from PICS -- every OS depot on the same branch shares one value. Per-OS 'first seen' needs observation history (#226). ${
+      <tfoot><tr><td colspan="4" class="gm-plat-foot">Tracked-since is the earliest observation we recorded for that OS. Last update is the branch-level PICS timestamp -- every depot on a shared branch inherits it. The brown icon on each row opens the raw <code>depots.json</code> we publish for this game. ${
         newsInfo?.found && newsInfo.newest_ts
           ? `App-wide 'Last patch note' (${esc(new Date(newsInfo.newest_ts * 1000).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }))}) below is the public-API fallback when a specific OS row shows 'pending'.`
           : ''

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -3,7 +3,7 @@
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=b4fbb7ef';
 import { populateScoringTooltip, pulseTierFromReports, tierFromReports } from '../../shared/scoring.js?v=1b8ae722';
 import { computeCompatTrend, RECENT_DAYS, PRIOR_WINDOW_DAYS } from '../../lib/scoring/gameStats.js?v=8dc92cf7';
-import { getWebClientId } from '../../shared/submit.js?v=339c68ea';
+import { getWebClientId } from '../../shared/submit.js?v=bfe659f0';
 import { fetchAppDepotInfo, fetchAppMetadata, fetchAppNews, fetchDeckStatusForApp, fetchMinRequirements, fetchLinuxNativeSupport } from '../api/deck-status.js?v=09d5c67e';
 import { fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=55a861cb';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=01961c8d';
@@ -1056,7 +1056,7 @@ export async function renderGamePage(appId) {
           const availRunTypes = [...new Set(combined.map(r => r.runType).filter(Boolean))].sort();
           const runTypeSel = availRunTypes.length > 0 ? `
             <div class="filter-item">
-              <label for="fRunType">Run type</label>
+              <label for="fRunType">Runtime Type</label>
               <select id="fRunType">
                 <option value="">Any</option>
                 ${availRunTypes.map(v => `<option value="${esc(v)}" ${filterRunType===v?'selected':''}>${RUN_TYPE_LABEL[v]||v}</option>`).join('')}

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -5,7 +5,7 @@ import { populateScoringTooltip, pulseTierFromReports, tierFromReports } from '.
 import { computeCompatTrend, RECENT_DAYS, PRIOR_WINDOW_DAYS } from '../../lib/scoring/gameStats.js?v=8dc92cf7';
 import { getWebClientId } from '../../shared/submit.js?v=339c68ea';
 import { fetchAppDepotInfo, fetchAppMetadata, fetchAppNews, fetchDeckStatusForApp, fetchMinRequirements, fetchLinuxNativeSupport } from '../api/deck-status.js?v=09d5c67e';
-import { _protonDbLiveCache, fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=083594fa';
+import { fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=083594fa';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=01961c8d';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=aba6619f';
 import { enhanceAuthorBlocks } from './author.js?v=3a8cb3c7';
@@ -506,7 +506,7 @@ export async function renderGamePage(appId) {
       return fallback;
     }
   };
-  const [cdnRaw, configs, nativeReports, votes, userVotes, playtimeTotals, suppressedKeys] = await Promise.all([
+  const [cdnRaw, configs, nativeReports, votes, userVotes, playtimeTotals, suppressedKeys, liveFetched] = await Promise.all([
     safeFetch(() => fetchCdn(appId), 'fetchCdn', []),
     safeFetch(() => fetchSupabase(appId), 'fetchSupabase', []),
     safeFetch(() => fetchNativeReports(appId), 'fetchNativeReports', []),
@@ -514,6 +514,11 @@ export async function renderGamePage(appId) {
     safeFetch(() => fetchUserVotes(appId), 'fetchUserVotes', {}),
     safeFetch(() => fetchConfigPlaytimeTotals(appId), 'fetchConfigPlaytimeTotals', []),
     safeFetch(() => _fetchReportModeration(appId), 'reportModeration', new Set()),
+    // Auto-fetch the ProtonDB live summary on every page load so aggregate
+    // stats (tier + total) stay accurate even when our CDN mirror is sparse
+    // or missing entirely (#219). The proxy is cached per-appId per-session
+    // so re-renders don't re-hit the network.
+    safeFetch(() => fetchProtonDbLive(appId), 'fetchProtonDbLive', []),
   ]);
 
   // Drop ProtonDB mirror reports an admin has shadow-banned or deleted. Pulse
@@ -525,17 +530,19 @@ export async function renderGamePage(appId) {
     console.debug('[game-page] filtered suppressed ProtonDB reports', { appId, removed: cdnRaw.length - cdn.length, source: 'report_moderation' });
   }
 
-  // If CDN was empty but the user already clicked "Check ProtonDB Live" this
-  // session, use the cached live result so the page re-renders correctly.
   // ProtonDB's public summaries API only returns an aggregate (tier + total),
   // not individual reports, so the live result is a single `_liveOnly` summary.
   // It must NOT be rendered as a report card (it has no hardware/date and shows
   // up as a broken "Unknown / NAN days ago" row); instead it drives the header
   // tier + ProtonDB count below.
-  const liveCached = !cdn.length ? (_protonDbLiveCache.get(String(appId)) || []) : [];
-  const liveSummary = liveCached.find(r => r._liveOnly) || null;
+  //
+  // We auto-fetch the summary on every load (#219) so aggregate stats reflect
+  // ProtonDB's real numbers even when our CDN mirror only carries a few reports.
+  // `liveSummary` is populated whenever we got data; `liveOnly` means we have
+  // ZERO cdn reports and are relying purely on the summary.
+  const liveSummary = (liveFetched || []).find(r => r._liveOnly) || null;
   const liveOnly = !!liveSummary && !cdn.length;
-  const cdnMiss = !cdn.length && !liveCached.length;
+  const cdnMiss = !cdn.length && !(liveFetched || []).length;
 
   const reports = [
     ...cdn.map(r => ({ ...r, source: 'protondb' })),
@@ -635,11 +642,18 @@ export async function renderGamePage(appId) {
   const replacedByTitle = replacedBy
     ? (searchIndex || []).find(row => String(row[0]) === replacedBy)?.[1] || `App ${replacedBy}`
     : '';
-  // Effective ProtonDB report count: the mirrored count when we have it, else
-  // the live aggregate total. Drives the header counts so a live-only game
-  // shows the real ProtonDB rating instead of "0 reports / pending".
-  const protonDbCount = cdn.length || (liveSummary ? (liveSummary.total || 0) : 0);
-  const protonDbTier = liveOnly ? String(liveSummary.tier || '').toLowerCase() : tierFromReports(cdn);
+  // Effective ProtonDB report count: MAX of mirrored count and live aggregate
+  // (#219). ProtonDB's mirror often lags -- Hollow Knight has thousands of
+  // reports on ProtonDB but only a handful in our CDN. Take the higher number
+  // so the confidence % + "N reports" text reflect ProtonDB's real breadth,
+  // not just what we happen to have cached.
+  const liveTotal = liveSummary ? (liveSummary.total || 0) : 0;
+  const protonDbCount = Math.max(cdn.length, liveTotal);
+  // Tier: prefer the mirrored sample when we have cards to back it up,
+  // otherwise the live summary tier. Both use the same tier vocabulary.
+  const protonDbTier = liveOnly
+    ? String(liveSummary.tier || '').toLowerCase()
+    : (tierFromReports(cdn) || String(liveSummary?.tier || '').toLowerCase());
   const pulseTier = pulseTierFromReports(nativeReports, protonDbCount);
   document.title = `${title} - Proton Pulse`;
   if (typeof window.ppTrack === 'function') window.ppTrack('game_view', { app_id: String(appId), title });
@@ -815,8 +829,12 @@ export async function renderGamePage(appId) {
     // the "why?" page never disagree (#187). The old code bucketed by report
     // COUNT, which said "medium" for a 14-report game the dial showed at 95%.
     const confBucket = !hasAnyReports ? '' : overallConfidencePct >= 80 ? 'high' : overallConfidencePct >= 50 ? 'moderate' : 'low';
+    // "N reports" where N = pulse + protonDbCount (which is MAX(mirror, live)).
+    // When the live total drives the count, tag the source so users understand
+    // the summary is authoritative even when we mirror only a small slice (#219).
+    const _fromLive = !!liveSummary && liveTotal > cdn.length;
     const overallTileSummary = hasAnyReports
-      ? `${confBucket} confidence across ${totalReports} report${totalReports !== 1 ? 's' : ''}${pulseHasConfigs ? ` / ${configs.length} config${configs.length !== 1 ? 's' : ''}` : ''}`
+      ? `${confBucket} confidence across ${totalReports.toLocaleString()} report${totalReports !== 1 ? 's' : ''}${_fromLive ? ' (via ProtonDB live)' : ''}${pulseHasConfigs ? ` / ${configs.length} config${configs.length !== 1 ? 's' : ''}` : ''}`
       : (pulseHasConfigs ? 'Community-submitted configs available' : 'No community data yet');
     // Rating distribution: one horizontal bar per tier, filled with the tier
     // color and scaled to the busiest tier so the shape reads at a glance.
@@ -829,6 +847,12 @@ export async function renderGamePage(appId) {
     const TIER_ORDER = ['platinum', 'gold', 'silver', 'bronze', 'borked'];
     const TIER_FULL = { platinum: 'PLATINUM', gold: 'GOLD', silver: 'SILVER', bronze: 'BRONZE', borked: 'BORKED' };
     const maxTierCount = Math.max(1, ...TIER_ORDER.map((t) => ratingCounts[t]));
+    // Attribution note when ProtonDB's live total exceeds what we have mirrored:
+    // the per-tier bars are only from our mirror sample, but the aggregate count
+    // and dial confidence are drawn from ProtonDB's real total (#219).
+    const _mirrorSampleNote = (!liveOnly && liveSummary && liveTotal > cdn.length)
+      ? `<div class="grp-bars-note grp-bars-note--sample">Per-tier bars reflect our mirrored sample (${cdn.length}); dial uses ProtonDB's live total (${liveTotal.toLocaleString()}).</div>`
+      : '';
     const tierBars = liveOnly
       ? '<div class="grp-bars-note">Per-tier breakdown is not available from ProtonDB\'s live summary.</div>'
       : `<div class="grp-bars">${TIER_ORDER.map((t) => {
@@ -839,7 +863,7 @@ export async function renderGamePage(appId) {
               <span class="grp-bar-track"><span class="grp-bar-fill" style="width:${pct}%;background:${RATING_COLORS[t]}"></span></span>
               <span class="grp-bar-count">${n}</span>
             </div>`;
-        }).join('')}</div>`;
+        }).join('')}${_mirrorSampleNote}</div>`;
 
     // Confidence gauge dial: ring fill = overall confidence %, with the tier
     // name and a "confidence" caption in the center.

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -5,7 +5,7 @@ import { populateScoringTooltip, pulseTierFromReports, tierFromReports } from '.
 import { computeCompatTrend, RECENT_DAYS, PRIOR_WINDOW_DAYS } from '../../lib/scoring/gameStats.js?v=8dc92cf7';
 import { getWebClientId } from '../../shared/submit.js?v=339c68ea';
 import { fetchAppDepotInfo, fetchAppMetadata, fetchAppNews, fetchDeckStatusForApp, fetchMinRequirements, fetchLinuxNativeSupport } from '../api/deck-status.js?v=09d5c67e';
-import { fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=083594fa';
+import { fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=55a861cb';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=01961c8d';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=aba6619f';
 import { enhanceAuthorBlocks } from './author.js?v=3a8cb3c7';
@@ -847,33 +847,18 @@ export async function renderGamePage(appId) {
     const TIER_ORDER = ['platinum', 'gold', 'silver', 'bronze', 'borked'];
     const TIER_FULL = { platinum: 'PLATINUM', gold: 'GOLD', silver: 'SILVER', bronze: 'BRONZE', borked: 'BORKED' };
     const maxTierCount = Math.max(1, ...TIER_ORDER.map((t) => ratingCounts[t]));
-    const _mirrorTotalCount = TIER_ORDER.reduce((s, t) => s + ratingCounts[t], 0);
-    // When we have a live summary but the mirror sample is empty (or all reports
-    // lack a valid rating), render a single filled "primary tier" bar using the
-    // live summary tier + total. Beats five empty PLATINUM/GOLD/... 0 rows and
-    // still keeps the visual language of the bars section (#219 follow-up).
+    // ProtonDB's summary API only exposes aggregate fields (no per-tier
+    // counts), so we can never draw the 5-bar breakdown from a live-only
+    // game. Keep the standard 5-bar layout no matter what, and prepend a
+    // one-line note showing the ProtonDB rating + total when we have it so
+    // users see "PLATINUM * 371 reports" alongside the (possibly empty) bars.
     const _liveTierKey = liveSummary ? String(liveSummary.tier || '').toLowerCase() : '';
-    const _liveTierValid = TIER_ORDER.includes(_liveTierKey);
-    const _useLiveBar = !!liveSummary && _liveTierValid && _mirrorTotalCount === 0;
-    // Attribution note when ProtonDB's live total exceeds what we have mirrored:
-    // the per-tier bars are only from our mirror sample, but the aggregate count
-    // and dial confidence are drawn from ProtonDB's real total (#219).
-    const _mirrorSampleNote = (!liveOnly && !_useLiveBar && liveSummary && liveTotal > _mirrorTotalCount)
-      ? `<div class="grp-bars-note grp-bars-note--sample">Per-tier bars reflect our mirrored sample (${_mirrorTotalCount}); dial uses ProtonDB's live total (${liveTotal.toLocaleString()}).</div>`
-      : '';
-    const _liveBarBlock = _useLiveBar
-      ? `<div class="grp-bars">
-          <div class="grp-bar grp-bar-${_liveTierKey}" title="${liveTotal.toLocaleString()} ${_liveTierKey} report${liveTotal !== 1 ? 's' : ''} (ProtonDB live summary)">
-            <span class="grp-bar-label">${TIER_FULL[_liveTierKey]}</span>
-            <span class="grp-bar-track"><span class="grp-bar-fill" style="width:100%;background:${RATING_COLORS[_liveTierKey]}"></span></span>
-            <span class="grp-bar-count">${liveTotal.toLocaleString()}</span>
-          </div>
-          <div class="grp-bars-note grp-bars-note--sample">Aggregate tier from ProtonDB (${liveTotal.toLocaleString()} report${liveTotal !== 1 ? 's' : ''}). Individual reports aren't mirrored here yet, so we can't show the full breakdown.</div>
+    const _liveNote = liveSummary
+      ? `<div class="grp-bars-note grp-bars-note--live">
+          ProtonDB rating: <strong>${esc(String(liveSummary.tier || '').toUpperCase())}</strong> &middot; <strong>${liveTotal.toLocaleString()}</strong> report${liveTotal !== 1 ? 's' : ''}
         </div>`
       : '';
-    const tierBars = _useLiveBar
-      ? _liveBarBlock
-      : `<div class="grp-bars">${TIER_ORDER.map((t) => {
+    const tierBars = `<div class="grp-bars">${_liveNote}${TIER_ORDER.map((t) => {
           const n = ratingCounts[t];
           const pct = Math.round((n / maxTierCount) * 100);
           return `<div class="grp-bar grp-bar-${t}" title="${n} ${t} report${n !== 1 ? 's' : ''}">
@@ -881,7 +866,7 @@ export async function renderGamePage(appId) {
               <span class="grp-bar-track"><span class="grp-bar-fill" style="width:${pct}%;background:${RATING_COLORS[t]}"></span></span>
               <span class="grp-bar-count">${n}</span>
             </div>`;
-        }).join('')}${_mirrorSampleNote}</div>`;
+        }).join('')}</div>`;
 
     // Confidence gauge dial: ring fill = overall confidence %, with the tier
     // name and a "confidence" caption in the center.

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -283,53 +283,60 @@ async function _openMetadataModal(appId) {
     // we publish alongside latest.json. GitHub blob URL so users see the
     // raw JSON with syntax highlighting + a "Raw" download button.
     const DEPOT_FILE_URL = `https://github.com/mdeguzis/proton-pulse-web/blob/gh-pages/data/${esc(String(meta.appId))}/depots.json`;
-    const _packageIcon = (os) => `
-      <a class="gm-depot-file" href="${DEPOT_FILE_URL}#os=${esc(os)}" target="_blank" rel="noopener" title="View the raw depots.json this modal was built from">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
-          <path d="M21 8V19a2 2 0 01-2 2H5a2 2 0 01-2-2V8"/>
-          <path d="M1 5h22v3H1z"/>
-          <path d="M10 12h4"/>
-        </svg>
-      </a>`;
     const row = (key, label) => {
       const on = !!p[key];
       const cached = dOs[key];
       const lastFmt = fmtDate(cached?.last_updated);
       const trackedFmt = fmtDate(cached?.tracked_since);
-      let depotsCell, trackedCell, lastCell;
+      let trackedCell, lastCell, depotsCell;
       if (!on) {
-        depotsCell  = '<span class="gm-mute">not offered</span>';
         trackedCell = '-';
         lastCell    = '-';
+        depotsCell  = '<span class="gm-mute" title="No depot on this OS">-</span>';
       } else if (cached) {
-        depotsCell  = `<span class="gm-mute">${cached.depots} tracked</span>${_packageIcon(key)}`;
+        // Tracked-since is the honest floor: earliest first_observed_at we
+        // recorded for this (app, os). It is NOT "when the OS build was
+        // added" for existing games -- see the footer note.
         trackedCell = trackedFmt
-          ? `<span class="gm-depot-date" title="Earliest first_observed_at from steam_depot_manifest_history (#226)">${esc(trackedFmt)}</span>`
-          : '<span class="gm-mute" title="No observation history yet -- once the nightly pipeline observes this depot again with the same manifest, we will record a real tracked-since date">-</span>';
+          ? `<span class="gm-depot-date" title="Earliest observation date we recorded for this OS. Retroactive 'added on' isn't derivable from PICS (see footer).">${esc(trackedFmt)}</span>`
+          : '<span class="gm-mute" title="No observation history yet. Once the nightly pipeline observes this depot a second time, we lock in a real tracked-since date.">-</span>';
         lastCell    = lastFmt
-          ? `<span class="gm-depot-date" title="Branch-level timeupdated from PICS -- every OS depot on a shared branch inherits this value">${esc(lastFmt)}</span>`
+          ? `<span class="gm-depot-date" title="Branch-level timeupdated from PICS -- every OS depot on a shared branch inherits this value.">${esc(lastFmt)}</span>`
           : '-';
+        // #237 (v2): depots column now icon-only. Count moves into the icon's
+        // tooltip so we save a column on mobile. The icon links to the raw
+        // depots.json we publish for this app.
+        depotsCell = `<a class="gm-depot-file" href="${DEPOT_FILE_URL}#os=${esc(key)}" target="_blank" rel="noopener" title="${cached.depots} depot${cached.depots !== 1 ? 's' : ''} tracked -- click to open the raw depots.json this modal was built from">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+            <path d="M21 8V19a2 2 0 01-2 2H5a2 2 0 01-2-2V8"/>
+            <path d="M1 5h22v3H1z"/>
+            <path d="M10 12h4"/>
+          </svg>
+        </a>`;
       } else {
-        depotsCell  = '<span class="gm-mute" title="Not cached yet -- pipeline #215 populates this nightly">pending</span>';
         trackedCell = '-';
         lastCell    = `<a class="gm-depot-link" href="https://steamdb.info/app/${esc(meta.appId)}/depots/" target="_blank" rel="noopener">SteamDB -&gt;</a>`;
+        depotsCell  = '<span class="gm-mute" title="Not cached yet -- pipeline #215 populates this nightly">-</span>';
       }
       return `
         <tr>
           <td><span class="gm-plat${on ? ' gm-plat--on' : ''}">${esc(label)}</span></td>
-          <td>${depotsCell}</td>
           <td>${trackedCell}</td>
           <td>${lastCell}</td>
+          <td class="gm-plat-depots">${depotsCell}</td>
         </tr>`;
     };
     return `<table class="gm-plat-table">
-      <thead><tr><th>OS</th><th>Depots</th><th>Tracked since</th><th>Last update</th></tr></thead>
+      <thead><tr><th>OS</th><th>Tracked since</th><th>Last update</th><th class="gm-plat-depots-th">Depots</th></tr></thead>
       <tbody>${row('windows','Windows')}${row('mac','macOS')}${row('linux','Linux')}</tbody>
-      <tfoot><tr><td colspan="4" class="gm-plat-foot">Tracked-since is the earliest observation we recorded for that OS. Last update is the branch-level PICS timestamp -- every depot on a shared branch inherits it. The brown icon on each row opens the raw <code>depots.json</code> we publish for this game. ${
-        newsInfo?.found && newsInfo.newest_ts
-          ? `App-wide 'Last patch note' (${esc(new Date(newsInfo.newest_ts * 1000).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }))}) below is the public-API fallback when a specific OS row shows 'pending'.`
-          : ''
-      }</td></tr></tfoot>
+      <tfoot><tr><td colspan="4" class="gm-plat-foot">
+        <strong>Tracked since</strong> is the earliest observation we recorded for that OS -- not the historical date the OS build was added. Steam doesn't expose depot creation dates via PICS, so for games already shipping all three OSes when we started tracking, this is our observation floor. Newly-added OS builds for games we're already tracking WILL show an accurate add-date going forward.
+        <br><strong>Last update</strong> is the branch-level PICS timestamp -- every depot on a shared branch inherits it.
+        <br>The brown package icon opens the raw <code>depots.json</code> we publish for this game.
+        ${newsInfo?.found && newsInfo.newest_ts
+          ? `<br>App-wide 'Last patch note' (${esc(new Date(newsInfo.newest_ts * 1000).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }))}) below is the public-API fallback when a specific OS row shows 'pending'.`
+          : ''}
+      </td></tr></tfoot>
     </table>`;
   };
   // System requirements: fold into one collapsible block per OS. Text is

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -1,7 +1,7 @@
 // report-card (components) for the app page. Relocated from app.js.
 
 import { estimateScore } from '../../shared/scoring.js?v=1b8ae722';
-import { getWebClientId } from '../../shared/submit.js?v=339c68ea';
+import { getWebClientId } from '../../shared/submit.js?v=bfe659f0';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=b4fbb7ef';
 import { renderAuthorBlock } from './author.js?v=3a8cb3c7';
 import { buildFormRows } from './config-cards.js?v=c67740f8';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=1b8ae722';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=003f23c0';
-import { renderGamePage } from './game-page.js?v=4901ebe4';
+import { renderGamePage } from './game-page.js?v=3937d3af';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId, fetchDataWithProdFallback } from '../config.js?v=f9591262';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=c7e1268c';
 import { renderGameCard } from '../lib/card.js?v=5642a459';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=1b8ae722';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=003f23c0';
-import { renderGamePage } from './game-page.js?v=ed252acf';
+import { renderGamePage } from './game-page.js?v=483b0579';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId, fetchDataWithProdFallback } from '../config.js?v=f9591262';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=c7e1268c';
 import { renderGameCard } from '../lib/card.js?v=5642a459';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=1b8ae722';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=003f23c0';
-import { renderGamePage } from './game-page.js?v=2a9a7aa8';
+import { renderGamePage } from './game-page.js?v=4901ebe4';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId, fetchDataWithProdFallback } from '../config.js?v=f9591262';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=c7e1268c';
 import { renderGameCard } from '../lib/card.js?v=5642a459';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=1b8ae722';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=003f23c0';
-import { renderGamePage } from './game-page.js?v=5a0c3324';
+import { renderGamePage } from './game-page.js?v=ed252acf';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId, fetchDataWithProdFallback } from '../config.js?v=f9591262';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=c7e1268c';
 import { renderGameCard } from '../lib/card.js?v=5642a459';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=1b8ae722';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=003f23c0';
-import { renderGamePage } from './game-page.js?v=483b0579';
+import { renderGamePage } from './game-page.js?v=2a9a7aa8';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId, fetchDataWithProdFallback } from '../config.js?v=f9591262';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=c7e1268c';
 import { renderGameCard } from '../lib/card.js?v=5642a459';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=1b8ae722';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=003f23c0';
-import { renderGamePage } from './game-page.js?v=3937d3af';
+import { renderGamePage } from './game-page.js?v=d8d8b666';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId, fetchDataWithProdFallback } from '../config.js?v=f9591262';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=c7e1268c';
 import { renderGameCard } from '../lib/card.js?v=5642a459';

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,6 +1,6 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=4901ebe4';
+import { renderGamePage } from './components/game-page.js?v=3937d3af';
 import { renderHomePage } from './components/home.js?v=1aa3e1ab';
 import { renderSearchPage } from './components/search.js?v=598aaad1';
 

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,6 +1,6 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=ed252acf';
+import { renderGamePage } from './components/game-page.js?v=483b0579';
 import { renderHomePage } from './components/home.js?v=1aa3e1ab';
 import { renderSearchPage } from './components/search.js?v=598aaad1';
 

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,6 +1,6 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=2a9a7aa8';
+import { renderGamePage } from './components/game-page.js?v=4901ebe4';
 import { renderHomePage } from './components/home.js?v=1aa3e1ab';
 import { renderSearchPage } from './components/search.js?v=598aaad1';
 

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,6 +1,6 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=5a0c3324';
+import { renderGamePage } from './components/game-page.js?v=ed252acf';
 import { renderHomePage } from './components/home.js?v=1aa3e1ab';
 import { renderSearchPage } from './components/search.js?v=598aaad1';
 

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,6 +1,6 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=3937d3af';
+import { renderGamePage } from './components/game-page.js?v=d8d8b666';
 import { renderHomePage } from './components/home.js?v=1aa3e1ab';
 import { renderSearchPage } from './components/search.js?v=598aaad1';
 

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,6 +1,6 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=483b0579';
+import { renderGamePage } from './components/game-page.js?v=2a9a7aa8';
 import { renderHomePage } from './components/home.js?v=1aa3e1ab';
 import { renderSearchPage } from './components/search.js?v=598aaad1';
 

--- a/js/game-stats/main.js
+++ b/js/game-stats/main.js
@@ -73,15 +73,43 @@ import { appIdToDir } from '../lib/app-id.js?v=18a73fb7';
     } catch { return []; }
   }
 
+  // ProtonDB live summary via the same edge fn the game page uses. Gives us
+  // an aggregate tier + total count so the stats page can still say something
+  // useful when our CDN mirror has no reports for a game (#219 follow-up).
+  const PROTONDB_LIVE_URL =
+    'https://ilsgdshkaocrmibwdezk.supabase.co/functions/v1/protondb-summary';
+  async function loadProtonDbLive(appId) {
+    try {
+      const r = await fetch(`${PROTONDB_LIVE_URL}?appId=${encodeURIComponent(appId)}`, { headers: { Accept: 'application/json' } });
+      if (!r.ok) {
+        console.debug(`[game-stats] ProtonDB live check not ok | appId=${appId} status=${r.status} source=protondb-summary-proxy`);
+        return null;
+      }
+      const data = await r.json();
+      if (!data || data.found === false || !data.tier) {
+        console.debug(`[game-stats] ProtonDB live check empty | appId=${appId} source=protondb-summary-proxy`);
+        return null;
+      }
+      return { tier: data.tier, total: data.total || 0, score: data.score || 0, confidence: data.confidence || '' };
+    } catch (e) {
+      console.debug(`[game-stats] ProtonDB live check failed | appId=${appId} error=${e.message} source=protondb-summary-proxy`);
+      return null;
+    }
+  }
+
   // --- header rendering ---
 
-  function renderHeader(appId, title, { pulseCount = 0, protonDbCount = 0 } = {}) {
+  function renderHeader(appId, title, { pulseCount = 0, protonDbCount = 0, liveTotal = 0 } = {}) {
     const headerImg = `https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/${appId}/header.jpg`;
     const gameUrl = `app.html#/app/${esc(appId)}`;
     // Per-source split moved here from the game page hero so the numbers
     // still live SOMEWHERE without cluttering the hero on small screens.
-    const sourceBit = (pulseCount || protonDbCount)
-      ? ` &middot; <strong>${pulseCount}</strong> Pulse / <strong>${protonDbCount}</strong> ProtonDB`
+    // When ProtonDB's live total exceeds our mirrored count, tag the effective
+    // number so users see the true breadth (#219 follow-up).
+    const effectiveProtonDb = Math.max(protonDbCount, liveTotal);
+    const _liveTag = liveTotal > protonDbCount ? ' (live)' : '';
+    const sourceBit = (pulseCount || effectiveProtonDb)
+      ? ` &middot; <strong>${pulseCount}</strong> Pulse / <strong>${effectiveProtonDb.toLocaleString()}</strong> ProtonDB${_liveTag}`
       : '';
     // Whole left side (image + name + appid) is a single anchor so clicking
     // the boxart or title takes you back to the game page. The dedicated
@@ -494,12 +522,14 @@ import { appIdToDir } from '../lib/app-id.js?v=18a73fb7';
 
     metaEl.textContent = `// app id ${appId} · live computation from CDN + Pulse data`;
 
-    // Pull search index in parallel with CDN data so we can show the proper title
-    const [cdnReports, searchIndex, pulseReports, configs] = await Promise.all([
+    // Pull search index in parallel with CDN + Pulse + live summary so the
+    // page can still say something useful when the mirror is empty (#219).
+    const [cdnReports, searchIndex, pulseReports, configs, liveSummary] = await Promise.all([
       loadGame(appId),
       loadSearchIndex(),
       loadPulseReports(appId),
       loadConfigs(appId),
+      loadProtonDbLive(appId),
     ]);
 
     // Find the game's title - search index entries are [appId, title, ...] tuples
@@ -511,12 +541,28 @@ import { appIdToDir } from '../lib/app-id.js?v=18a73fb7';
 
     const allReports = [...cdnReports, ...pulseReports];
     if (allReports.length === 0 && configs.length === 0) {
-      root.innerHTML = renderHeader(appId, title, { pulseCount: pulseReports.length, protonDbCount: cdnReports.length }) + `
-        <div class="error-state">
-          <p>No reports or configs found for this game.</p>
-          <p style="font-size:0.78rem;margin-top:8px">
+      // Nothing mirrored -- but ProtonDB may still have an aggregate. Fall
+      // through to a stub view that surfaces the live tier + total instead
+      // of just saying "no data" (#219).
+      const liveBlock = liveSummary
+        ? `<div class="gs-live-summary">
+            <div class="gs-live-summary-head">
+              <span class="gs-live-summary-tier gs-live-summary-tier-${esc(String(liveSummary.tier).toLowerCase())}">${esc(String(liveSummary.tier).toUpperCase())}</span>
+              <span class="gs-live-summary-total"><strong>${liveSummary.total.toLocaleString()}</strong> ProtonDB report${liveSummary.total !== 1 ? 's' : ''}</span>
+              ${liveSummary.confidence ? `<span class="gs-live-summary-conf">${esc(liveSummary.confidence)} confidence</span>` : ''}
+            </div>
+            <p class="gs-live-summary-note">
+              ProtonDB has aggregate data for this game but we haven't mirrored the individual reports yet, so the full per-report stats below are unavailable.
+              <a href="https://www.protondb.com/app/${esc(appId)}" target="_blank" rel="noopener">Read them on ProtonDB &gt;</a>
+            </p>
+          </div>`
+        : `<p style="font-size:0.78rem;margin-top:8px">
             Try <a href="app.html#/app/${esc(appId)}">the game page</a> and submit the first report.
-          </p>
+          </p>`;
+      root.innerHTML = renderHeader(appId, title, { pulseCount: pulseReports.length, protonDbCount: cdnReports.length, liveTotal: liveSummary?.total || 0 }) + `
+        <div class="error-state">
+          <p>${liveSummary ? 'No individual reports mirrored yet for this game.' : 'No reports or configs found for this game.'}</p>
+          ${liveBlock}
         </div>
       `;
       return;
@@ -534,6 +580,7 @@ import { appIdToDir } from '../lib/app-id.js?v=18a73fb7';
     const { html, wire } = renderAll(appId, title, stats, {
       pulseCount: pulseReports.length,
       protonDbCount: cdnReports.length,
+      liveTotal: liveSummary?.total || 0,
     });
     root.innerHTML = previewBanner + html;
     // wire() must run AFTER innerHTML so the hover helper sees real DOM rects.

--- a/js/profile/components/edit-modals.js
+++ b/js/profile/components/edit-modals.js
@@ -10,7 +10,7 @@ import {
   fetchReportHistory, patchUserConfig,
 } from '../api/configs.js?v=0c5650ed';
 import { updateSystem } from '../api/systems.js?v=770d14b7';
-import { notesFormattingHelpHtml } from '../../shared/submit.js?v=339c68ea';
+import { notesFormattingHelpHtml } from '../../shared/submit.js?v=bfe659f0';
 
 export let _cloudEditModal = null;
 export function getCloudEditModal() {

--- a/js/shared/run-type.js
+++ b/js/shared/run-type.js
@@ -48,28 +48,35 @@ export const RUN_TYPES = Object.freeze({
     key:      'proton-experimental',
     label:    'Proton Experimental',
     subtitle: 'Valve\'s bleeding-edge Proton branch',
-    versionPattern: /(proton[\s-]?experimental|bleeding[-\s]?edge)/i,
+    // Also accepts bare "Experimental" -- when the user already picked the
+    // proton-experimental runtime, "Experimental" is unambiguous.
+    versionPattern: /(proton[\s-]?experimental|bleeding[-\s]?edge|^\s*experimental\s*$)/i,
     versionExample: 'e.g. Proton Experimental',
   },
   'proton-ge': {
     key:      'proton-ge',
     label:    'Proton GE',
     subtitle: 'GloriousEggroll community fork',
-    versionPattern: /^(ge[-_ ]?proton|proton[-_ ]?ge)[-_ ]?\d+([-_.]\d+)*$/i,
+    // Accepts alphanumeric suffixes (rc1, beta, "9-27b") since GE tags
+    // ship those variants. \w in the trailing segments covers letters +
+    // digits without breaking anchored matching.
+    versionPattern: /^(ge[-_ ]?proton|proton[-_ ]?ge)[-_ ]?\d+([-_.]\w+)*$/i,
     versionExample: 'e.g. GE-Proton9-27',
   },
   'proton-cachyos': {
     key:      'proton-cachyos',
     label:    'CachyOS Proton',
     subtitle: 'CachyOS-tuned Proton',
-    versionPattern: /cachy(os)?[-\s]?proton/i,
+    // Also accepts bare "CachyOS" when the user already picked cachyos.
+    versionPattern: /(cachy(os)?[-\s]?proton|^\s*cachy(os)?\s*$)/i,
     versionExample: 'e.g. CachyOS Proton 9.0-4',
   },
   'proton-tkg': {
     key:      'proton-tkg',
     label:    'Proton-TKG',
     subtitle: 'TKG custom Proton build',
-    versionPattern: /(proton[-_ ]?tkg|tkg[-_ ]?proton)/i,
+    // Also accepts bare "TKG" when the user already picked tkg.
+    versionPattern: /(proton[-_ ]?tkg|tkg[-_ ]?proton|^\s*tkg\s*$)/i,
     versionExample: 'e.g. Proton-TKG 9.0-4',
   },
   'proton-lsfg': {

--- a/js/shared/run-type.js
+++ b/js/shared/run-type.js
@@ -37,8 +37,12 @@ export const RUN_TYPES = Object.freeze({
     key:      'proton',
     label:    'Proton',
     subtitle: 'Valve\'s official Proton (stable / hotfix)',
-    versionPattern: /^proton[\s-]?(\d+(?:\.\d+)*(?:[-_]\w+)?|hotfix)$/i,
-    versionExample: 'e.g. Proton 9.0-4 or Proton Hotfix',
+    // Also accepts the named branches Valve ships under the same "Proton"
+    // umbrella in the Steam client (Experimental, Next, Hotfix) so the user
+    // doesn't get a fake "does not look like Proton" warning when they pick
+    // plain Proton but paste one of those variant strings.
+    versionPattern: /^proton[\s-]?(\d+(?:\.\d+)*(?:[-_]\w+)?|hotfix|experimental|next)$/i,
+    versionExample: 'e.g. Proton 9.0-4, Proton Hotfix, or Proton Experimental',
   },
   'proton-experimental': {
     key:      'proton-experimental',

--- a/js/shared/submit.js
+++ b/js/shared/submit.js
@@ -573,7 +573,7 @@ export async function populateSubmitForm(el) {
       <div class="sf-section-label">Game</div>
       <div class="sf-row"><label>Game title</label><input name="gameTitle" readonly style="cursor:default;color:var(--muted);border-color:var(--border2);background:var(--s1);" placeholder="Loading..."></div>
       <div class="sf-row sf-row--run-type">
-        <label>Run type *</label>
+        <label>Runtime Type *</label>
         <select name="runType" id="sf-run-type-select">
           <option value="native">Native Linux -- Linux build, no Proton</option>
           <option value="proton" selected>Proton -- Valve's official (stable/hotfix)</option>
@@ -585,6 +585,13 @@ export async function populateSubmitForm(el) {
         </select>
       </div>
       <div class="sf-row-hint sf-run-type-hint" id="sf-run-type-hint" hidden></div>
+      <div class="sf-row" id="sf-runtime-version-row"><label id="sf-runtime-version-label">Runtime Version *</label>
+        <div class="sf-autocomplete" style="position:relative;flex:1;">
+          <input name="protonVersion" placeholder="e.g. Proton 9.0-4 or GE-Proton9-27" autocomplete="off" style="width:100%">
+          <ul class="sf-suggestions" style="display:none;position:absolute;top:100%;left:0;right:0;z-index:100;background:var(--s2);border:1px solid var(--border);border-top:none;max-height:200px;overflow-y:auto;list-style:none;margin:0;padding:0;"></ul>
+        </div>
+      </div>
+      <div class="sf-row-hint sf-runtime-version-warn" id="sf-runtime-version-warn" hidden></div>
       <div class="sf-row sf-row--also-linux" id="sf-also-linux-row" hidden>
         <label>Also tested Linux?</label>
         <div class="sf-also-linux-body">
@@ -609,13 +616,6 @@ export async function populateSubmitForm(el) {
         </select>
         <span class="sf-row-hint">Pick a saved system to prefill hardware fields</span>
       </div>
-      <div class="sf-row" id="sf-runtime-version-row"><label id="sf-runtime-version-label">Runtime Version *</label>
-        <div class="sf-autocomplete" style="position:relative;flex:1;">
-          <input name="protonVersion" placeholder="e.g. Proton 9.0-4 or GE-Proton9-27" autocomplete="off" style="width:100%">
-          <ul class="sf-suggestions" style="display:none;position:absolute;top:100%;left:0;right:0;z-index:100;background:var(--s2);border:1px solid var(--border);border-top:none;max-height:200px;overflow-y:auto;list-style:none;margin:0;padding:0;"></ul>
-        </div>
-      </div>
-      <div class="sf-row-hint sf-runtime-version-warn" id="sf-runtime-version-warn" hidden></div>
       <div class="sf-row"><label>GPU *</label><input name="gpu" placeholder="e.g. NVIDIA GeForce RTX 4070"></div>
       <div class="sf-row"><label>GPU Vendor *</label><select name="gpuVendor"><option value="" disabled selected>-- choose one --</option>${opts(gpuVendors,true)}</select></div>
       <div class="sf-row"><label>GPU Driver</label><input name="gpuDriver" placeholder="e.g. Mesa 24.1.0 or 555.42.02"></div>
@@ -1096,9 +1096,11 @@ function wireRunTypeToggle(container) {
         if (isNative) input.value = '';
       }
       if (versionLabel) {
+        // "Runtime Version" stays the label; the runtime type is picked in
+        // the field above so we don't need to repeat "(Proton)" here.
         versionLabel.textContent = isNative
           ? 'Runtime Version'
-          : `Runtime Version * (${meta?.label || 'Proton'})`;
+          : 'Runtime Version *';
       }
       protonRow.classList.toggle('sf-row--disabled', isNative);
     }

--- a/js/shared/submit.js
+++ b/js/shared/submit.js
@@ -2,7 +2,7 @@
 
 import { SupaAuth } from './config.js?v=f6f2c00a';
 import { FAULT_KEYS_WEB, deriveRatingFromState, inferProtonType } from './scoring.js?v=1b8ae722';
-import { RUN_TYPES, normalizeRunType, validateRuntimeVersion } from './run-type.js?v=01ec5b4d';
+import { RUN_TYPES, normalizeRunType, validateRuntimeVersion } from './run-type.js?v=c38e39e0';
 import { detectGpuArch } from '../lib/gpu-arch-detector.js?v=b4fbb7ef';
 
 // Form submission + populate-submit-form -- factored out of app.js.

--- a/js/shared/submit.js
+++ b/js/shared/submit.js
@@ -2,7 +2,7 @@
 
 import { SupaAuth } from './config.js?v=f6f2c00a';
 import { FAULT_KEYS_WEB, deriveRatingFromState, inferProtonType } from './scoring.js?v=1b8ae722';
-import { RUN_TYPES, normalizeRunType, validateRuntimeVersion } from './run-type.js?v=c38e39e0';
+import { RUN_TYPES, normalizeRunType, validateRuntimeVersion } from './run-type.js?v=b7e95db6';
 import { detectGpuArch } from '../lib/gpu-arch-detector.js?v=b4fbb7ef';
 
 // Form submission + populate-submit-form -- factored out of app.js.

--- a/js/stats/charts.js
+++ b/js/stats/charts.js
@@ -1,6 +1,6 @@
 // Stats page chart renderers.
 
-import { label, fmt, niceCeil, formatAxisLabel, vramLabel, TIER_COLORS } from './utils.js?v=c63d96b0';
+import { label, fmt, niceCeil, formatAxisLabel, vramLabel, TIER_COLORS } from './utils.js?v=2dd62302';
 import { getFilter } from './filters.js?v=f364d0eb';
 
 // Render N horizontal bar rows sorted descending by count.

--- a/js/stats/filters.js
+++ b/js/stats/filters.js
@@ -1,6 +1,6 @@
 // Stats page filter state and UI logic.
 
-import { FILTER_DIMS, dimDef, label, fmt, sum } from './utils.js?v=c63d96b0';
+import { FILTER_DIMS, dimDef, label, fmt, sum } from './utils.js?v=2dd62302';
 
 // Active filter. Only one dim active at a time (because the cross-tabs
 // we ship only key off one dim), but multiple values within that dim.

--- a/js/stats/main.js
+++ b/js/stats/main.js
@@ -1,7 +1,7 @@
 // Entry module for stats.html. Orchestrates data fetch, filter state, and
 // chart rendering by delegating to utils, filters, and charts modules.
 
-import { FILTER_DIMS, dimDef, label, fmt } from './utils.js?v=c63d96b0';
+import { FILTER_DIMS, dimDef, label, fmt } from './utils.js?v=2dd62302';
 import { dataUrl } from '../lib/data-url.js?v=3c2e7ac9';
 import {
   applyFilter, getFilter, getOpenDropdown, setOpenDropdown,

--- a/js/stats/utils.js
+++ b/js/stats/utils.js
@@ -9,7 +9,7 @@ export const FILTER_DIMS = [
   { id: 'device', label: 'Device',  statsKey: 'by_device_family',  crossKey: 'by_rating_x_device_family' },
   { id: 'store',  label: 'Store',   statsKey: 'by_store',          crossKey: 'by_rating_x_store' },
   { id: 'source', label: 'Source',  statsKey: 'by_source',         crossKey: 'by_rating_x_source' },
-  { id: 'runType', label: 'Run type', statsKey: 'by_run_type',     crossKey: 'by_rating_x_run_type' },
+  { id: 'runType', label: 'Runtime Type', statsKey: 'by_run_type',     crossKey: 'by_rating_x_run_type' },
   { id: 'rating', label: 'Rating',  statsKey: 'by_rating',         crossKey: null },
 ];
 

--- a/js/submit/main.js
+++ b/js/submit/main.js
@@ -1,6 +1,6 @@
 // Entry module for submit.html. Migrated from the page's inline script.
 import { FAULT_KEYS_WEB } from '../shared/scoring.js?v=1b8ae722';
-import { applyDraftSnapshot, populateSubmitForm, prefillSubmitFormFromMyHardware, renderVerifiedOwnerStatus, setRunTypeNativeAvailable, submitReport } from '../shared/submit.js?v=339c68ea';
+import { applyDraftSnapshot, populateSubmitForm, prefillSubmitFormFromMyHardware, renderVerifiedOwnerStatus, setRunTypeNativeAvailable, submitReport } from '../shared/submit.js?v=bfe659f0';
 import { fetchLinuxNativeSupport } from '../app/api/deck-status.js?v=09d5c67e';
 import { deleteDraft, getDraft, snapshotFormData, upsertDraft } from '../shared/drafts.js?v=da9caf1e';
 import { SupaAuth } from '../shared/config.js?v=f6f2c00a';

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "babel-jest": "^30.4.1",
         "jest": "^30.3.0",
         "jest-environment-jsdom": "^30.3.0",
+        "js-yaml": "^4.3.0",
         "supabase": "^2.109.0",
         "vite": "^5.4.10"
       }
@@ -2392,6 +2393,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
@@ -3969,14 +3994,11 @@
       }
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "license": "Python-2.0"
     },
     "node_modules/babel-jest": {
       "version": "30.4.1",
@@ -6083,14 +6105,23 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "babel-jest": "^30.4.1",
     "jest": "^30.3.0",
     "jest-environment-jsdom": "^30.3.0",
+    "js-yaml": "^4.3.0",
     "supabase": "^2.109.0",
     "vite": "^5.4.10"
   }

--- a/scripts/pipeline/finalize.py
+++ b/scripts/pipeline/finalize.py
@@ -54,6 +54,7 @@ from .release_years import enrich_search_index_with_release_years
 from .pulse import merge_pulse_into_data_dir
 from .state import read_pipeline_state
 from .stats import write_stats_json
+from .validate_app_ids import validate_steam_app_ids
 
 
 def log_summary(
@@ -1780,6 +1781,7 @@ def finalize_output(output_dir, skip_probe: bool = False):
     # appdetails. Flag them in search-index.json column 7 so the frontend can
     # render a DELISTED chip without re-fetching anything client-side.
     enrich_search_index_with_delisted(output_path)
+    validate_steam_app_ids(output_dir)
     # Issue #134: emit the extended Steam index AFTER the primary index has
     # been finalized (release-year + delisted enrichment runs first), so the
     # primary id set we read back is the final one.

--- a/scripts/pipeline/finalize.py
+++ b/scripts/pipeline/finalize.py
@@ -52,6 +52,7 @@ from .deck_status import build_deck_status
 from .most_played import build_most_played
 from .release_years import enrich_search_index_with_release_years
 from .pulse import merge_pulse_into_data_dir
+from .write_depot_files import write_depot_files
 from .state import read_pipeline_state
 from .stats import write_stats_json
 
@@ -1786,6 +1787,10 @@ def finalize_output(output_dir, skip_probe: bool = False):
     generate_extended_steam_index(output_path, steam_catalog=steam_catalog)
     _backfill_most_played_header_images(output_path, overrides)
     write_proton_versions_json(output_path)
+    # #237: emit per-Steam-app depots.json under {data}/{appId}/. Reads the
+    # steam_depot_* tables in Supabase and includes both current per-OS
+    # rollups and the full parsed PICS depots dict.
+    write_depot_files(data_output_path)
     # Hash every emitted data file and write data-versions.json so the
     # frontend can cache-bust each data fetch individually. Must run LAST so
     # the hashes reflect every other generator's final output. See #119.

--- a/scripts/pipeline/steam_metadata.py
+++ b/scripts/pipeline/steam_metadata.py
@@ -324,6 +324,12 @@ def run_steamcmd_app_info(app_id: int, timeout: int = 60) -> str:
 # --- Supabase upsert -------------------------------------------------------
 
 
+def _dry_run() -> bool:
+    """#218: honor DRY_RUN=true so a dispatched run can preview PICS output
+    without writing to steam_depot_updates / manifest_history / fetch_status."""
+    return os.environ.get("DRY_RUN", "").strip().lower() == "true"
+
+
 def _supabase_headers() -> dict:
     key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     if not key:
@@ -358,6 +364,9 @@ def upsert_depot_rows(rows: Iterable[DepotRow]) -> int:
     ]
     if not payload:
         return 0
+    if _dry_run():
+        log(f"steam-metadata: dry-run, would upsert {len(payload)} depot rows: sample={payload[0]}")
+        return len(payload)
     url = f"{_supabase_base()}/steam_depot_updates?on_conflict=app_id,depot_id,os"
     req = urllib.request.Request(
         url, data=json.dumps(payload).encode(), method="POST",
@@ -368,13 +377,16 @@ def upsert_depot_rows(rows: Iterable[DepotRow]) -> int:
 
 
 def upsert_fetch_status(app_id: int, status: str, depot_count: int, error: str | None = None) -> None:
-    url = f"{_supabase_base()}/steam_depot_fetch_status?on_conflict=app_id"
     payload = [{
         "app_id":      app_id,
         "app_status":  status,
         "depot_count": depot_count,
         "error":       error,
     }]
+    if _dry_run():
+        log(f"steam-metadata: dry-run, would upsert fetch_status={payload[0]}")
+        return
+    url = f"{_supabase_base()}/steam_depot_fetch_status?on_conflict=app_id"
     req = urllib.request.Request(
         url, data=json.dumps(payload).encode(), method="POST",
         headers=_supabase_headers(),

--- a/scripts/pipeline/steam_metadata.py
+++ b/scripts/pipeline/steam_metadata.py
@@ -376,15 +376,30 @@ def upsert_depot_rows(rows: Iterable[DepotRow]) -> int:
     return len(payload)
 
 
-def upsert_fetch_status(app_id: int, status: str, depot_count: int, error: str | None = None) -> None:
-    payload = [{
+def upsert_fetch_status(
+    app_id: int,
+    status: str,
+    depot_count: int,
+    error: str | None = None,
+    raw_pics: dict | None = None,
+) -> None:
+    """Upsert the per-app fetch status row.
+
+    #237: `raw_pics` is the full parsed depots dict from PICS. Persisting it
+    verbatim lets downstream stages (write_depot_files.py) surface every
+    field steamcmd emitted without a second PICS round-trip.
+    """
+    row: dict = {
         "app_id":      app_id,
         "app_status":  status,
         "depot_count": depot_count,
         "error":       error,
-    }]
+    }
+    if raw_pics is not None:
+        row["raw_pics"] = raw_pics
+    payload = [row]
     if _dry_run():
-        log(f"steam-metadata: dry-run, would upsert fetch_status={payload[0]}")
+        log(f"steam-metadata: dry-run, would upsert fetch_status={row}")
         return
     url = f"{_supabase_base()}/steam_depot_fetch_status?on_conflict=app_id"
     req = urllib.request.Request(
@@ -441,10 +456,16 @@ def fetch_and_store(app_id: int, sleep_between: float = 3.0) -> tuple[str, int]:
             except (TypeError, ValueError):
                 sample_json = str(sample)[:1500]
             log(f"steam-metadata: app={app_id} sample_depot={first_num_key} shape={sample_json}")
-        upsert_fetch_status(app_id, "no_public_manifest", 0, "parsed appinfo but no OS-bound depot rows")
+        # #237: even when we could not extract OS-bound rows, keep the raw
+        # depots dict so we can inspect what PICS returned via the on-disk
+        # depots.json without a re-fetch.
+        upsert_fetch_status(app_id, "no_public_manifest", 0, "parsed appinfo but no OS-bound depot rows", raw_pics=parsed.get("depots"))
         return "no_public_manifest", 0
     n = upsert_depot_rows(rows)
-    upsert_fetch_status(app_id, "ok", n, None)
+    # #237: persist the full parsed depots dict alongside the status. Everything
+    # steamcmd emitted (config.oslist, manifests.public.*, branches, sharedinstall,
+    # dlc_appids, ...) lands as a single JSONB blob for downstream consumers.
+    upsert_fetch_status(app_id, "ok", n, None, raw_pics=parsed.get("depots"))
     log(f"steam-metadata: app={app_id} rows={n} source=steamcmd-pics")
     return "ok", n
 

--- a/scripts/pipeline/validate_app_ids.py
+++ b/scripts/pipeline/validate_app_ids.py
@@ -1,0 +1,171 @@
+"""Validate Steam app IDs by following store page redirects.
+
+Detects:
+  - Dead app IDs that redirect to the Steam homepage (removed/invalid)
+  - Replaced app IDs that redirect to a different app (superseded entries)
+  - Valid app IDs that resolve to their own store page
+
+Output: app-id-redirects.json
+  { "<original_id>": { "status": "replaced", "replaced_by": "<new_id>" },
+    "<original_id>": { "status": "dead", "final_url": "..." },
+    ... }
+
+Only entries with problems are written (valid IDs are omitted to keep the file
+small). The frontend and admin panel can use this to fix links and surface
+warnings. A persistent cache (app-id-validation-cache.json) avoids re-probing
+IDs that have already been checked.
+"""
+
+import json
+import re
+import time
+import urllib.request
+import urllib.error
+from datetime import date, timedelta
+from pathlib import Path
+
+from .common import log
+
+STEAM_STORE_URL = "https://store.steampowered.com/app/{app_id}/"
+PROBE_CAP = 200
+STALE_DAYS = 90
+BATCH_DELAY = 0.35
+
+
+def _follow_redirects(app_id: str) -> dict:
+    """Follow redirects for a Steam store page and return the resolution."""
+    url = STEAM_STORE_URL.format(app_id=app_id)
+    try:
+        req = urllib.request.Request(
+            url,
+            headers={
+                "User-Agent": "Mozilla/5.0 (compatible; ProtonPulse/1.0)",
+                "Cookie": "birthtime=0; wants_mature_content=1",
+            },
+        )
+        opener = urllib.request.build_opener(urllib.request.HTTPRedirectHandler)
+        resp = opener.open(req, timeout=15)
+        final_url = resp.url
+        resp.close()
+
+        if f"/app/{app_id}" in final_url:
+            return {"status": "valid"}
+
+        app_match = re.search(r"/app/(\d+)", final_url)
+        if app_match:
+            new_id = app_match.group(1)
+            if new_id != app_id:
+                return {"status": "replaced", "replaced_by": new_id, "final_url": final_url}
+
+        if "/app/" not in final_url:
+            return {"status": "dead", "final_url": final_url}
+
+        return {"status": "valid"}
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return {"status": "dead", "final_url": url, "http_status": 404}
+        return {"status": "error", "http_status": e.code}
+    except Exception as exc:
+        return {"status": "error", "error": str(exc)}
+
+
+def _load_cache(output_dir: Path) -> dict:
+    cache_path = output_dir / "app-id-validation-cache.json"
+    if cache_path.exists():
+        try:
+            return json.loads(cache_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            log(f"[validate-appids] WARN: could not load cache: {exc}")
+    return {}
+
+
+def _save_cache(output_dir: Path, cache: dict) -> None:
+    cache_path = output_dir / "app-id-validation-cache.json"
+    cache_path.write_text(json.dumps(cache, separators=(",", ":")), encoding="utf-8")
+
+
+def _is_stale(entry: dict) -> bool:
+    probed = entry.get("probed_at", "")
+    if not probed:
+        return True
+    try:
+        probed_date = date.fromisoformat(probed)
+        return (date.today() - probed_date) > timedelta(days=STALE_DAYS)
+    except ValueError:
+        return True
+
+
+def validate_steam_app_ids(output_dir: str) -> dict:
+    """Validate Steam app IDs from the search index. Returns the redirect map."""
+    output_path = Path(output_dir)
+    search_index_path = output_path / "search-index.json"
+    if not search_index_path.exists():
+        log("[validate-appids] No search-index.json found, skipping")
+        return {}
+
+    index = json.loads(search_index_path.read_text(encoding="utf-8"))
+    steam_ids = []
+    for row in index:
+        if not isinstance(row, list) or len(row) < 6:
+            continue
+        app_id = str(row[0])
+        app_type = row[5] if len(row) > 5 else "steam"
+        if app_type == "steam" and app_id.isdigit():
+            steam_ids.append(app_id)
+
+    cache = _load_cache(output_path)
+    today = date.today().isoformat()
+
+    to_probe = []
+    for app_id in steam_ids:
+        entry = cache.get(app_id)
+        if entry is None or _is_stale(entry):
+            to_probe.append(app_id)
+
+    if not to_probe:
+        log("[validate-appids] All app IDs cached and fresh, nothing to probe")
+    else:
+        capped = to_probe[:PROBE_CAP]
+        log(f"[validate-appids] Probing {len(capped)}/{len(to_probe)} uncached/stale Steam app IDs")
+
+        probed = 0
+        for app_id in capped:
+            result = _follow_redirects(app_id)
+            result["probed_at"] = today
+            cache[app_id] = result
+            probed += 1
+            if probed % 50 == 0:
+                log(f"[validate-appids]   ...{probed}/{len(capped)} probed")
+            if result.get("status") == "error":
+                log(f"[validate-appids] WARN: error probing {app_id}: {result}")
+            time.sleep(BATCH_DELAY)
+
+        _save_cache(output_path, cache)
+        log(f"[validate-appids] Probed {probed} app IDs, cache now has {len(cache)} entries")
+
+    redirects = {}
+    for app_id, entry in cache.items():
+        status = entry.get("status")
+        if status == "replaced":
+            redirects[app_id] = {
+                "status": "replaced",
+                "replaced_by": entry["replaced_by"],
+                "final_url": entry.get("final_url", ""),
+            }
+        elif status == "dead":
+            redirects[app_id] = {
+                "status": "dead",
+                "final_url": entry.get("final_url", ""),
+            }
+
+    redirect_path = output_path / "app-id-redirects.json"
+    redirect_path.write_text(
+        json.dumps(redirects, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    replaced_count = sum(1 for v in redirects.values() if v["status"] == "replaced")
+    dead_count = sum(1 for v in redirects.values() if v["status"] == "dead")
+    log(f"[validate-appids] Results: {replaced_count} replaced, {dead_count} dead, written to app-id-redirects.json")
+
+    return redirects

--- a/scripts/pipeline/validate_app_ids.py
+++ b/scripts/pipeline/validate_app_ids.py
@@ -33,34 +33,43 @@ BATCH_DELAY = 0.35
 
 
 def _follow_redirects(app_id: str) -> dict:
-    """Follow redirects for a Steam store page and return the resolution."""
+    """Follow redirects for a Steam store page and return the resolution.
+
+    Steam categorization comes from the final path segment after urllib
+    resolves 3xx redirects transparently:
+      - `/app/<same_id>/...` -> valid
+      - `/app/<different_id>/...` -> replaced (superseded appid)
+      - no `/app/<digits>/` -> dead (redirected to homepage or elsewhere)
+    """
     url = STEAM_STORE_URL.format(app_id=app_id)
     try:
         req = urllib.request.Request(
             url,
             headers={
+                # Age-gate bypass cookies -- mature titles otherwise redirect
+                # to /agecheck/ instead of the store page.
                 "User-Agent": "Mozilla/5.0 (compatible; ProtonPulse/1.0)",
                 "Cookie": "birthtime=0; wants_mature_content=1",
             },
         )
-        opener = urllib.request.build_opener(urllib.request.HTTPRedirectHandler)
-        resp = opener.open(req, timeout=15)
+        # urlopen() already follows 3xx via the default opener; no need for
+        # a custom HTTPRedirectHandler.
+        resp = urllib.request.urlopen(req, timeout=15)
         final_url = resp.url
         resp.close()
 
-        if f"/app/{app_id}" in final_url:
-            return {"status": "valid"}
-
+        # Compare IDs exactly against the extracted numeric segment. A naive
+        # substring check like `f"/app/{app_id}" in final_url` false-positives
+        # when the redirect target's ID starts with app_id -- e.g. app_id=26
+        # redirected to /app/2670/ would look "valid" but is actually replaced.
         app_match = re.search(r"/app/(\d+)", final_url)
         if app_match:
             new_id = app_match.group(1)
-            if new_id != app_id:
-                return {"status": "replaced", "replaced_by": new_id, "final_url": final_url}
+            if new_id == app_id:
+                return {"status": "valid"}
+            return {"status": "replaced", "replaced_by": new_id, "final_url": final_url}
 
-        if "/app/" not in final_url:
-            return {"status": "dead", "final_url": final_url}
-
-        return {"status": "valid"}
+        return {"status": "dead", "final_url": final_url}
     except urllib.error.HTTPError as e:
         if e.code == 404:
             return {"status": "dead", "final_url": url, "http_status": 404}

--- a/scripts/pipeline/write_depot_files.py
+++ b/scripts/pipeline/write_depot_files.py
@@ -1,0 +1,207 @@
+"""Emit per-Steam-app depots.json files during finalize (#237).
+
+Reads:
+  - public.steam_depot_updates            (current per-OS depot rows)
+  - public.steam_depot_manifest_history   (observed manifest history, first_seen)
+  - public.steam_depot_fetch_status       (raw_pics JSONB blob per app)
+
+Writes:
+  {data_output_path}/{appIdDir}/depots.json
+
+Shape (per-file):
+  {
+    "app_id": 367520,
+    "fetched_at": "...",
+    "status": "ok" | "no_public_manifest" | "error",
+    "os": {
+      "linux": {
+        "depots": 1,
+        "last_updated": "...",       # max last_updated_at across depots for this OS
+        "tracked_since": "...",      # earliest first_observed_at we recorded
+        "manifests": [ ... ]         # every manifest we have ever observed
+      },
+      ...
+    },
+    "raw_pics": { ... }              # full parsed depots dict from steamcmd
+  }
+
+Only Steam-numeric app IDs are written; GOG/Epic ids are skipped (no PICS).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.parse
+import urllib.request
+from collections import defaultdict
+from pathlib import Path
+from typing import Iterable
+
+from .common import log, app_id_to_dir
+
+
+PAGE_SIZE = 1000  # PostgREST default range; we page for safety on large scans.
+
+
+def _supabase_url() -> str | None:
+    return os.environ.get("SUPABASE_URL")
+
+
+def _service_key() -> str | None:
+    return os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+
+
+def _headers() -> dict:
+    key = _service_key()
+    if not key:
+        raise RuntimeError("SUPABASE_SERVICE_ROLE_KEY missing; cannot read depot tables")
+    return {
+        "apikey": key,
+        "Authorization": f"Bearer {key}",
+        "Accept": "application/json",
+    }
+
+
+def _get(path: str, params: dict) -> list[dict]:
+    base = _supabase_url()
+    if not base:
+        raise RuntimeError("SUPABASE_URL missing; cannot read depot tables")
+    url = f"{base}/rest/v1{path}?{urllib.parse.urlencode(params)}"
+    req = urllib.request.Request(url, headers=_headers(), method="GET")
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        return json.loads(resp.read())
+
+
+def _fetch_all(path: str, select: str, order: str) -> list[dict]:
+    """Page through a PostgREST endpoint until it stops returning rows."""
+    out: list[dict] = []
+    offset = 0
+    while True:
+        params = {"select": select, "order": order, "limit": PAGE_SIZE, "offset": offset}
+        batch = _get(path, params)
+        if not batch:
+            break
+        out.extend(batch)
+        if len(batch) < PAGE_SIZE:
+            break
+        offset += PAGE_SIZE
+    return out
+
+
+def _load_all() -> tuple[dict, dict, dict]:
+    """Pull every relevant row once and group by app_id in Python.
+
+    A single scan beats one HTTP request per app when we have thousands of
+    tracked apps. For the current ~10 apps this is trivial, but the design
+    scales with #215 growing the tracked set.
+    """
+    updates = _fetch_all(
+        "/steam_depot_updates",
+        select="app_id,depot_id,os,name,manifest_id,last_updated_at",
+        order="app_id.asc",
+    )
+    history = _fetch_all(
+        "/steam_depot_manifest_history",
+        select="app_id,depot_id,os,manifest_id,first_observed_at,latest_observed_at",
+        order="app_id.asc",
+    )
+    status = _fetch_all(
+        "/steam_depot_fetch_status",
+        select="app_id,app_status,depot_count,fetched_at,error,raw_pics",
+        order="app_id.asc",
+    )
+
+    upd_by_app: dict = defaultdict(list)
+    hist_by_app: dict = defaultdict(list)
+    for row in updates:
+        upd_by_app[row["app_id"]].append(row)
+    for row in history:
+        hist_by_app[row["app_id"]].append(row)
+    status_by_app = {row["app_id"]: row for row in status}
+    return upd_by_app, hist_by_app, status_by_app
+
+
+def _build_depot_file(app_id: int, updates: list[dict], history: list[dict], status: dict | None) -> dict:
+    """Group updates + history into a per-OS structure and attach raw_pics."""
+    by_os: dict = {}
+    upd_by_os: dict = defaultdict(list)
+    hist_by_os: dict = defaultdict(list)
+    for row in updates:
+        upd_by_os[row["os"]].append(row)
+    for row in history:
+        hist_by_os[row["os"]].append(row)
+
+    for os_key in sorted(set(list(upd_by_os) + list(hist_by_os))):
+        upds = upd_by_os.get(os_key, [])
+        hist = hist_by_os.get(os_key, [])
+        last_updates = [r["last_updated_at"] for r in upds if r.get("last_updated_at")]
+        first_seens = [r["first_observed_at"] for r in hist if r.get("first_observed_at")]
+        depots_seen = {r["depot_id"] for r in upds} | {r["depot_id"] for r in hist}
+        by_os[os_key] = {
+            "depots": len(depots_seen),
+            "last_updated": max(last_updates) if last_updates else None,
+            "tracked_since": min(first_seens) if first_seens else None,
+            "manifests": [
+                {
+                    "depot_id":            r["depot_id"],
+                    "manifest_id":         r["manifest_id"],
+                    "first_observed_at":   r.get("first_observed_at"),
+                    "latest_observed_at":  r.get("latest_observed_at"),
+                }
+                for r in hist
+            ],
+        }
+
+    return {
+        "app_id":     app_id,
+        "fetched_at": status.get("fetched_at") if status else None,
+        "status":     status.get("app_status") if status else "unknown",
+        "os":         by_os,
+        "raw_pics":   status.get("raw_pics") if status else None,
+    }
+
+
+def write_depot_files(data_output_path: str | Path) -> int:
+    """Emit depots.json per Steam app under `{data_output_path}/{appId}/`.
+
+    Returns the number of files written. Non-Steam ids are skipped.
+    """
+    if not _supabase_url() or not _service_key():
+        log("[depot-files] SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY missing -- skipping")
+        return 0
+
+    base = Path(data_output_path)
+    upd_by_app, hist_by_app, status_by_app = _load_all()
+
+    app_ids = set(upd_by_app) | set(hist_by_app) | set(status_by_app)
+    if not app_ids:
+        log("[depot-files] no depot rows in Supabase yet -- nothing to write")
+        return 0
+
+    written = 0
+    for app_id in sorted(app_ids):
+        payload = _build_depot_file(
+            app_id,
+            upd_by_app.get(app_id, []),
+            hist_by_app.get(app_id, []),
+            status_by_app.get(app_id),
+        )
+        app_dir = base / app_id_to_dir(str(app_id))
+        app_dir.mkdir(parents=True, exist_ok=True)
+        (app_dir / "depots.json").write_text(
+            json.dumps(payload, sort_keys=True, indent=2),
+            encoding="utf-8",
+        )
+        written += 1
+    log(f"[depot-files] wrote {written} depots.json file(s) source=steam_depot_*")
+    return written
+
+
+if __name__ == "__main__":
+    # `python -m scripts.pipeline.write_depot_files /tmp/protondb-output/data`
+    import sys
+    if len(sys.argv) != 2:
+        print("usage: python -m scripts.pipeline.write_depot_files <data_output_dir>", file=sys.stderr)
+        sys.exit(2)
+    write_depot_files(sys.argv[1])

--- a/submit.html
+++ b/submit.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=c550d77b">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/app/game-header.css?v=dbecc5e0">
+<link rel="stylesheet" href="css/app/game-header.css?v=eeae198f">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=6df19441">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">

--- a/submit.html
+++ b/submit.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=c550d77b">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/app/game-header.css?v=8dc8f5f9">
+<link rel="stylesheet" href="css/app/game-header.css?v=9d16d085">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=6df19441">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">

--- a/submit.html
+++ b/submit.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=c550d77b">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/app/game-header.css?v=eeae198f">
+<link rel="stylesheet" href="css/app/game-header.css?v=8dc8f5f9">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=6df19441">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">

--- a/submit.html
+++ b/submit.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=c550d77b">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=0817c80a">
-<link rel="stylesheet" href="css/app/game-header.css?v=9d16d085">
+<link rel="stylesheet" href="css/app/game-header.css?v=bfb9d9a1">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=6df19441">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -39,3 +39,9 @@ verify_jwt = false
 
 [functions.steam-explore]
 verify_jwt = false
+
+[functions.steam-library-lookup]
+# JWT is verified inside the function (same pattern as image-refetch): we
+# need to hit current_user_has_permission() after auth.getUser(), which
+# the built-in middleware does not do.
+verify_jwt = false

--- a/supabase/functions/steam-depot-info/index.ts
+++ b/supabase/functions/steam-depot-info/index.ts
@@ -1,17 +1,26 @@
-// steam-depot-info: per-OS depot last-updated dates for the Metadata modal.
+// steam-depot-info: per-OS depot last-updated + tracked-since dates for
+// the Metadata modal.
 //
-// Reads from public.steam_depot_updates (populated nightly by the Steam
-// PICS pipeline via steamcmd; see .github/workflows/steam-metadata-fetch.yml).
-// Aggregates rows into a compact { windows, mac, linux } shape:
+// Sources (both populated by the Steam PICS pipeline via steamcmd; see
+// .github/workflows/steam-metadata-fetch.yml):
+//   - public.steam_depot_updates          -> current per-OS depot rollup
+//   - public.steam_depot_manifest_history -> earliest observation per OS
+//                                            (#226 -- honest tracked_since)
 //
+// Response:
 //   { appId: "367520", found: true, os: {
-//       linux:   { first_seen: "...", last_updated: "...", depots: 1 },
+//       linux:   { tracked_since: "...", last_updated: "...", depots: 1 },
 //       ...
 //     }}
 //
 // When no rows exist for the app yet the response is { found: false }
 // so the frontend can fall through to the SteamDB deep-link fallback
 // without treating a cache miss as an error.
+//
+// tracked_since is only reported when we have real manifest history for
+// that OS -- we deliberately do NOT fall back to last_updated_at because
+// that was previously mistaken for a first-seen date. Better to show a
+// dash than to lie. #237.
 //
 // Public (verify_jwt = false). Read-only. #215.
 
@@ -23,11 +32,17 @@ const corsHeaders = {
   "Access-Control-Allow-Methods": "GET, OPTIONS",
 };
 
-type Row = {
+type UpdateRow = {
   app_id: number;
   os: string;
   depot_id: number;
   last_updated_at: string;
+};
+type HistoryRow = {
+  app_id: number;
+  os: string;
+  depot_id: number;
+  first_observed_at: string;
 };
 
 Deno.serve(async (req: Request) => {
@@ -51,20 +66,33 @@ Deno.serve(async (req: Request) => {
     );
   }
   const supabase = createClient(supabaseUrl, supabaseKey);
-  const { data, error } = await supabase
-    .from("steam_depot_updates")
-    .select("app_id,os,depot_id,last_updated_at")
-    .eq("app_id", Number(appId));
+  const [updatesRes, historyRes] = await Promise.all([
+    supabase
+      .from("steam_depot_updates")
+      .select("app_id,os,depot_id,last_updated_at")
+      .eq("app_id", Number(appId)),
+    supabase
+      .from("steam_depot_manifest_history")
+      .select("app_id,os,depot_id,first_observed_at")
+      .eq("app_id", Number(appId)),
+  ]);
 
-  if (error) {
-    console.error(`[steam-depot-info] appId=${appId} query error=${error.message}`);
+  if (updatesRes.error) {
+    console.error(`[steam-depot-info] appId=${appId} updates error=${updatesRes.error.message}`);
     return Response.json(
-      { error: error.message, appId },
+      { error: updatesRes.error.message, appId },
       { status: 502, headers: corsHeaders },
     );
   }
-  const rows = (data as Row[]) || [];
-  if (rows.length === 0) {
+  if (historyRes.error) {
+    // History is optional -- log but keep going with just the update rollup.
+    console.warn(`[steam-depot-info] appId=${appId} history query soft-failed error=${historyRes.error.message}`);
+  }
+
+  const updates = (updatesRes.data as UpdateRow[]) || [];
+  const history = (historyRes.data as HistoryRow[]) || [];
+
+  if (updates.length === 0 && history.length === 0) {
     console.log(`[steam-depot-info] appId=${appId} found=false source=cache-miss`);
     return Response.json(
       { appId, found: false, os: {} },
@@ -72,24 +100,36 @@ Deno.serve(async (req: Request) => {
     );
   }
 
-  // Reduce to per-OS min / max timestamps + depot count.
-  type Bucket = { first: number; last: number; depots: Set<number> };
+  // Per-OS aggregate: max last_updated_at from updates, min first_observed_at
+  // from history, union of depot_ids for the count.
+  type Bucket = { last: number; trackedSince: number | null; depots: Set<number> };
   const byOs = new Map<string, Bucket>();
-  for (const row of rows) {
+  const bucket = (os: string): Bucket => {
+    let b = byOs.get(os);
+    if (!b) { b = { last: -Infinity, trackedSince: null, depots: new Set() }; byOs.set(os, b); }
+    return b;
+  };
+  for (const row of updates) {
     const ts = Date.parse(row.last_updated_at);
     if (!Number.isFinite(ts)) continue;
-    let b = byOs.get(row.os);
-    if (!b) { b = { first: ts, last: ts, depots: new Set() }; byOs.set(row.os, b); }
-    if (ts < b.first) b.first = ts;
-    if (ts > b.last)  b.last  = ts;
+    const b = bucket(row.os);
+    if (ts > b.last) b.last = ts;
     b.depots.add(row.depot_id);
   }
-  const os: Record<string, { first_seen: string; last_updated: string; depots: number }> = {};
+  for (const row of history) {
+    const ts = Date.parse(row.first_observed_at);
+    if (!Number.isFinite(ts)) continue;
+    const b = bucket(row.os);
+    if (b.trackedSince === null || ts < b.trackedSince) b.trackedSince = ts;
+    b.depots.add(row.depot_id);
+  }
+
+  const os: Record<string, { tracked_since: string | null; last_updated: string | null; depots: number }> = {};
   for (const [key, b] of byOs.entries()) {
     os[key] = {
-      first_seen:   new Date(b.first).toISOString(),
-      last_updated: new Date(b.last).toISOString(),
-      depots:       b.depots.size,
+      tracked_since: b.trackedSince != null ? new Date(b.trackedSince).toISOString() : null,
+      last_updated:  Number.isFinite(b.last) ? new Date(b.last).toISOString() : null,
+      depots:        b.depots.size,
     };
   }
   console.log(`[steam-depot-info] appId=${appId} found=true osCount=${Object.keys(os).length} source=cache`);

--- a/supabase/functions/steam-library-lookup/index.ts
+++ b/supabase/functions/steam-library-lookup/index.ts
@@ -1,0 +1,198 @@
+// steam-library-lookup: admin-only proxy for keyed Steam Web API endpoints.
+//
+// Public Steam endpoints already have a proxy (steam-explore, verify_jwt=false).
+// The three below require the Steam Web API key, so we:
+//   1. Verify the caller's JWT.
+//   2. Check the manage_admins permission via current_user_has_permission RPC.
+//   3. Only then attach the key and hit Steam.
+//
+// The key never leaves the server. Response shape mirrors steam-explore so the
+// API Explorer renders it the same way.
+//
+// Endpoints (see issue #221):
+//   steam_get_owned_games         IPlayerService/GetOwnedGames/v1/
+//   steam_get_recently_played     IPlayerService/GetRecentlyPlayedGames/v1/
+//   steam_resolve_vanity          ISteamUser/ResolveVanityURL/v1/
+//
+// Env:
+//   STEAM_WEB_API_KEY  - get at https://steamcommunity.com/dev/apikey
+
+import { createRequestAuthClient } from "../_shared/auth.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+type Envelope = {
+  ok: boolean;
+  endpoint: string;
+  arg: string;
+  url: string;
+  method: string;
+  status?: number;
+  data?: unknown;
+  error?: string;
+};
+
+// Which endpoint key maps to which upstream URL builder + arg name. Anything
+// not in this map is rejected before we touch Steam so we cannot be tricked
+// into forwarding arbitrary requests via the admin key.
+const ENDPOINTS: Record<
+  string,
+  { argName: "steamid" | "vanityurl"; build: (arg: string, key: string) => string }
+> = {
+  steam_get_owned_games: {
+    argName: "steamid",
+    // include_appinfo=1 gives us titles + img_icon_url. include_played_free_games=1
+    // includes F2P titles the account has actually launched (Dota 2, TF2, etc).
+    build: (steamid, key) =>
+      `https://api.steampowered.com/IPlayerService/GetOwnedGames/v1/` +
+      `?key=${encodeURIComponent(key)}` +
+      `&steamid=${encodeURIComponent(steamid)}` +
+      `&include_appinfo=1&include_played_free_games=1&format=json`,
+  },
+  steam_get_recently_played: {
+    argName: "steamid",
+    // count=0 = all recently played (Steam caps at ~10-20). Explicit for clarity.
+    build: (steamid, key) =>
+      `https://api.steampowered.com/IPlayerService/GetRecentlyPlayedGames/v1/` +
+      `?key=${encodeURIComponent(key)}` +
+      `&steamid=${encodeURIComponent(steamid)}` +
+      `&count=0&format=json`,
+  },
+  steam_resolve_vanity: {
+    argName: "vanityurl",
+    // url_type=1 = individual profile. Steam also supports group (2) and
+    // official game group (3), but the Explorer only needs profiles.
+    build: (vanity, key) =>
+      `https://api.steampowered.com/ISteamUser/ResolveVanityURL/v1/` +
+      `?key=${encodeURIComponent(key)}` +
+      `&vanityurl=${encodeURIComponent(vanity)}` +
+      `&url_type=1&format=json`,
+  },
+};
+
+// Steam vanity URLs are alphanumerics + underscore + hyphen. Steam IDs are 17
+// digits (76561...). Loose regexes here just guard against injecting `&` or
+// path segments into the upstream URL; Steam does the real validation.
+const STEAMID_RE = /^\d{5,20}$/;
+const VANITY_RE = /^[A-Za-z0-9_-]{2,64}$/;
+
+function jsonResponse(body: Envelope, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders });
+  if (req.method !== "POST") {
+    return jsonResponse(
+      { ok: false, endpoint: "", arg: "", url: "", method: "", error: "POST required" },
+      405,
+    );
+  }
+
+  let payload: { endpoint?: string; steamid?: string; vanityurl?: string } = {};
+  try {
+    payload = await req.json();
+  } catch {
+    return jsonResponse(
+      { ok: false, endpoint: "", arg: "", url: "", method: "POST", error: "invalid JSON body" },
+      400,
+    );
+  }
+
+  const endpoint = String(payload.endpoint || "");
+  const meta = ENDPOINTS[endpoint];
+  if (!meta) {
+    return jsonResponse(
+      { ok: false, endpoint, arg: "", url: "", method: "POST", error: "unknown endpoint" },
+      400,
+    );
+  }
+
+  // Verify caller is a signed-in admin with manage_admins. RLS + edge-fn side
+  // gate. Same shape as image-refetch's _requireAdmin (#175).
+  const authClient = createRequestAuthClient(req);
+  const { data: userData, error: userErr } = await authClient.auth.getUser();
+  if (userErr || !userData.user) {
+    return jsonResponse(
+      { ok: false, endpoint, arg: "", url: "", method: "GET", error: "authentication required" },
+      401,
+    );
+  }
+  const { data: hasPerm, error: rpcErr } = await authClient
+    .rpc("current_user_has_permission", { p: "manage_admins" });
+  if (rpcErr) {
+    return jsonResponse(
+      { ok: false, endpoint, arg: "", url: "", method: "GET", error: `permission check: ${rpcErr.message}` },
+      500,
+    );
+  }
+  if (!hasPerm) {
+    return jsonResponse(
+      { ok: false, endpoint, arg: "", url: "", method: "GET", error: "manage_admins permission required" },
+      403,
+    );
+  }
+
+  const rawArg = meta.argName === "steamid"
+    ? String(payload.steamid || "").trim()
+    : String(payload.vanityurl || "").trim();
+  if (!rawArg) {
+    return jsonResponse(
+      { ok: false, endpoint, arg: "", url: "", method: "GET", error: `${meta.argName} is required` },
+      400,
+    );
+  }
+  const argOk = meta.argName === "steamid" ? STEAMID_RE.test(rawArg) : VANITY_RE.test(rawArg);
+  if (!argOk) {
+    return jsonResponse(
+      { ok: false, endpoint, arg: rawArg, url: "", method: "GET", error: `invalid ${meta.argName} format` },
+      400,
+    );
+  }
+
+  const apiKey = Deno.env.get("STEAM_WEB_API_KEY");
+  if (!apiKey) {
+    console.error(`[steam-library-lookup] STEAM_WEB_API_KEY not configured`);
+    return jsonResponse(
+      { ok: false, endpoint, arg: rawArg, url: "", method: "GET", error: "server misconfigured: missing STEAM_WEB_API_KEY" },
+      500,
+    );
+  }
+
+  const url = meta.build(rawArg, apiKey);
+  // Never expose the api key back to the client via the response envelope.
+  const safeUrl = url.replace(encodeURIComponent(apiKey), "***");
+  try {
+    const upstream = await fetch(url, { headers: { Accept: "application/json" } });
+    const text = await upstream.text();
+    let data: unknown = null;
+    try { data = JSON.parse(text); } catch { data = text.slice(0, 500); }
+    console.log(`[steam-library-lookup] endpoint=${endpoint} arg=${rawArg} status=${upstream.status} source=steamworks`);
+    return jsonResponse(
+      {
+        ok: upstream.ok,
+        endpoint,
+        arg: rawArg,
+        url: safeUrl,
+        method: "GET",
+        status: upstream.status,
+        data,
+        error: upstream.ok ? undefined : `Steam HTTP ${upstream.status}`,
+      },
+      200,
+    );
+  } catch (e) {
+    console.error(`[steam-library-lookup] endpoint=${endpoint} arg=${rawArg} network error=${(e as Error).message}`);
+    return jsonResponse(
+      { ok: false, endpoint, arg: rawArg, url: safeUrl, method: "GET", error: `network: ${(e as Error).message}` },
+      502,
+    );
+  }
+});

--- a/supabase/functions/steam-library-lookup/index.ts
+++ b/supabase/functions/steam-library-lookup/index.ts
@@ -15,7 +15,7 @@
 //   steam_resolve_vanity          ISteamUser/ResolveVanityURL/v1/
 //
 // Env:
-//   STEAM_WEB_API_KEY  - get at https://steamcommunity.com/dev/apikey
+//   STEAM_API_KEY  - get at https://steamcommunity.com/dev/apikey
 
 import { createRequestAuthClient } from "../_shared/auth.ts";
 
@@ -157,11 +157,11 @@ Deno.serve(async (req: Request) => {
     );
   }
 
-  const apiKey = Deno.env.get("STEAM_WEB_API_KEY");
+  const apiKey = Deno.env.get("STEAM_API_KEY");
   if (!apiKey) {
-    console.error(`[steam-library-lookup] STEAM_WEB_API_KEY not configured`);
+    console.error(`[steam-library-lookup] STEAM_API_KEY not configured`);
     return jsonResponse(
-      { ok: false, endpoint, arg: rawArg, url: "", method: "GET", error: "server misconfigured: missing STEAM_WEB_API_KEY" },
+      { ok: false, endpoint, arg: rawArg, url: "", method: "GET", error: "server misconfigured: missing STEAM_API_KEY" },
       500,
     );
   }

--- a/supabase/migrations/20260708080000_steam_depot_raw_pics.sql
+++ b/supabase/migrations/20260708080000_steam_depot_raw_pics.sql
@@ -1,0 +1,26 @@
+-- #237: capture the full parsed PICS depots block per app.
+--
+-- steam_depot_updates holds the narrow columns the metadata modal needs
+-- (app_id, depot_id, os, manifest_id, last_updated_at). PICS gives us
+-- more than that -- shared install flags, encryptedmanifests, dlc_appids,
+-- config.installscripts, branch buildids, etc.
+--
+-- Rather than schema-thrash for each new field, persist the raw parsed
+-- depots dict as a JSONB blob on the existing fetch_status row (already
+-- one per app). Cheap to store (~2 KB per game) and the pipeline can
+-- read it back later without another PICS round-trip.
+--
+-- The frontend never reads this column directly. It flows out via the
+-- write_depot_files pipeline step -> data/{shard}/{appId}/depots.json
+-- so the Metadata modal can deep-link to it.
+
+alter table public.steam_depot_fetch_status
+  add column if not exists raw_pics jsonb;
+
+-- No index needed -- this column is read app-by-app during finalize,
+-- never in a scan. Public read stays intact.
+
+comment on column public.steam_depot_fetch_status.raw_pics is
+  'Full parsed PICS depots dict from steamcmd app_info_print. Includes '
+  'every field steamcmd emitted (config.oslist, manifests.public.*, '
+  'branches.public.*, sharedinstall, dlc_appids, ...). #237.';

--- a/supabase/migrations/20260708100000_game_manager_tables.sql
+++ b/supabase/migrations/20260708100000_game_manager_tables.sql
@@ -1,0 +1,124 @@
+-- #234: Admin Game Manager tables.
+--
+-- Two admin-curated tables that let a moderator hide a bogus game or
+-- remap a stale/incorrect app id to the correct one. Both are the
+-- manual fallback for cases the pipeline validator (#233) can't handle.
+--
+-- game_hides:  app_id blacklist. Pipeline + frontend can filter these
+--              rows out of search-index and per-app fetches. Admin sets
+--              a free-text `reason` so the paper trail explains why.
+-- game_remaps: from_app_id -> to_app_id. A stronger form of #27's
+--              `replaced_by` detection: admins overrule the pipeline's
+--              guess when Steam's own redirects are wrong (or missing).
+--
+-- Both keyed on app_id TEXT so they support the same store-prefixed
+-- ids the rest of the site does (`gog:123`, `epic:MyGame`, etc.).
+
+-- ── game_hides ──
+CREATE TABLE IF NOT EXISTS public.game_hides (
+  app_id      TEXT PRIMARY KEY,
+  reason      TEXT NOT NULL,
+  hidden_by   UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  hidden_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE public.game_hides ENABLE ROW LEVEL SECURITY;
+
+-- Public read: the pipeline needs to enforce hides at build time and
+-- the frontend may also filter on the fly.
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='game_hides' AND policyname='anyone can read game_hides') THEN
+    CREATE POLICY "anyone can read game_hides" ON public.game_hides
+      FOR SELECT TO anon, authenticated USING (true);
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='game_hides' AND policyname='admins with manage_games can insert') THEN
+    CREATE POLICY "admins with manage_games can insert" ON public.game_hides
+      FOR INSERT TO authenticated
+      WITH CHECK (public.current_user_has_permission('manage_games'));
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='game_hides' AND policyname='admins with manage_games can update') THEN
+    CREATE POLICY "admins with manage_games can update" ON public.game_hides
+      FOR UPDATE TO authenticated
+      USING (public.current_user_has_permission('manage_games'));
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='game_hides' AND policyname='admins with manage_games can delete') THEN
+    CREATE POLICY "admins with manage_games can delete" ON public.game_hides
+      FOR DELETE TO authenticated
+      USING (public.current_user_has_permission('manage_games'));
+  END IF;
+END $$;
+
+-- ── game_remaps ──
+CREATE TABLE IF NOT EXISTS public.game_remaps (
+  from_app_id  TEXT PRIMARY KEY,
+  to_app_id    TEXT NOT NULL,
+  reason       TEXT NOT NULL,
+  remapped_by  UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT game_remaps_no_self_loop CHECK (from_app_id <> to_app_id)
+);
+
+ALTER TABLE public.game_remaps ENABLE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='game_remaps' AND policyname='anyone can read game_remaps') THEN
+    CREATE POLICY "anyone can read game_remaps" ON public.game_remaps
+      FOR SELECT TO anon, authenticated USING (true);
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='game_remaps' AND policyname='admins with manage_games can insert') THEN
+    CREATE POLICY "admins with manage_games can insert" ON public.game_remaps
+      FOR INSERT TO authenticated
+      WITH CHECK (public.current_user_has_permission('manage_games'));
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='game_remaps' AND policyname='admins with manage_games can update') THEN
+    CREATE POLICY "admins with manage_games can update" ON public.game_remaps
+      FOR UPDATE TO authenticated
+      USING (public.current_user_has_permission('manage_games'));
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='game_remaps' AND policyname='admins with manage_games can delete') THEN
+    CREATE POLICY "admins with manage_games can delete" ON public.game_remaps
+      FOR DELETE TO authenticated
+      USING (public.current_user_has_permission('manage_games'));
+  END IF;
+END $$;
+
+CREATE OR REPLACE FUNCTION public.update_game_remaps_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS game_remaps_updated_at ON public.game_remaps;
+CREATE TRIGGER game_remaps_updated_at
+  BEFORE UPDATE ON public.game_remaps
+  FOR EACH ROW EXECUTE FUNCTION public.update_game_remaps_updated_at();
+
+-- ── Backfill existing moderators with manage_games ──
+UPDATE public.admins
+  SET permissions = array_append(permissions, 'manage_games')
+  WHERE role = 'moderator'
+    AND NOT ('manage_games' = ANY(permissions));
+
+-- Super admins short-circuit to all permissions via current_user_has_permission,
+-- so no explicit grant needed there.

--- a/tests/apiExplorer.test.js
+++ b/tests/apiExplorer.test.js
@@ -99,9 +99,11 @@ describe('API Explorer admin wiring', () => {
     expect(HTML).toContain('id="api-explorer-content"');
   });
 
-  test('main.js maps the tab to renderApiExplorer', () => {
+  test('main.js maps the tab to renderApiExplorer with the admin permission flag', () => {
     expect(MAIN).toContain('import { renderApiExplorer }');
-    expect(MAIN).toContain("'api-explorer': () => renderApiExplorer()");
+    // #221: the admin-gated Steam Web API endpoints (GetOwnedGames etc.)
+    // need the `canManageAdmins` flag to decide whether to surface them.
+    expect(MAIN).toContain("renderApiExplorer({ canManageAdmins: can('manage_admins') })");
   });
 
   test('tab is gated behind view_analytics like the other tools', () => {

--- a/tests/depotFile.test.js
+++ b/tests/depotFile.test.js
@@ -1,0 +1,105 @@
+/**
+ * #237: metadata modal renders a "Tracked since" column and a brown
+ * package-icon link to the per-game depots.json we publish under
+ * data/{appId}/. Also pins the steam-depot-info edge fn contract:
+ * both current updates and observation history are queried, tracked_since
+ * only fires from real first_observed_at rows, and the response drops the
+ * old misleading `first_seen` field.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const read = (p) => fs.readFileSync(path.join(ROOT, p), 'utf8');
+
+const EDGE = read('supabase/functions/steam-depot-info/index.ts');
+const COMP = read('js/app/components/game-page.js');
+const CSS  = read('css/app/game-header.css');
+const WRITER = read('scripts/pipeline/write_depot_files.py');
+const FINAL  = read('scripts/pipeline/finalize.py');
+const MIG    = read('supabase/migrations/20260708080000_steam_depot_raw_pics.sql');
+
+describe('#237: steam-depot-info edge fn returns tracked_since', () => {
+  test('queries both current updates AND manifest history', () => {
+    expect(EDGE).toContain('.from("steam_depot_updates")');
+    expect(EDGE).toContain('.from("steam_depot_manifest_history")');
+    // Both queries fire in parallel so an app-wide fetch is one round-trip.
+    expect(EDGE).toContain('await Promise.all(');
+  });
+
+  test('exposes tracked_since per OS from earliest first_observed_at', () => {
+    expect(EDGE).toContain('tracked_since:');
+    expect(EDGE).toContain('first_observed_at');
+    expect(EDGE).toContain('trackedSince: number | null');
+    // We deliberately never fall back to last_updated for tracked_since --
+    // better to return null than lie.
+    expect(EDGE).toContain('tracked_since: b.trackedSince != null');
+  });
+
+  test('drops the misleading first_seen field from the response', () => {
+    // Old shape had first_seen derived from min(last_updated_at) which was
+    // wrong -- it's just the earliest depot last-update, not observation.
+    expect(EDGE).not.toContain('first_seen:');
+  });
+
+  test('history query failure is soft -- current updates alone are still served', () => {
+    expect(EDGE).toContain('history query soft-failed');
+    expect(EDGE).toContain('console.warn');
+  });
+});
+
+describe('#237: metadata modal wires tracked_since + depot file icon', () => {
+  test('renders a 4-column table (OS / Depots / Tracked since / Last update)', () => {
+    expect(COMP).toContain('<th>OS</th><th>Depots</th><th>Tracked since</th><th>Last update</th>');
+    // Footer colspan updated to match the new column count.
+    expect(COMP).toContain('colspan="4"');
+  });
+
+  test('formats tracked_since from cached.tracked_since', () => {
+    expect(COMP).toContain('const trackedFmt = fmtDate(cached?.tracked_since)');
+    expect(COMP).toContain('Earliest first_observed_at');
+  });
+
+  test('brown package icon links to the gh-pages depots.json blob', () => {
+    expect(COMP).toContain('gm-depot-file');
+    expect(COMP).toContain('/blob/gh-pages/data/${esc(String(meta.appId))}/depots.json');
+    // Deep-links to the OS anchor so we can scroll to a specific block later.
+    expect(COMP).toContain('#os=${esc(os)}');
+    // Package icon markup lives in an inline SVG so we don't need a new asset.
+    expect(COMP).toContain('<svg viewBox="0 0 24 24"');
+  });
+
+  test('icon has its own CSS class with the brown Steam-package palette', () => {
+    expect(CSS).toContain('.gm-depot-file {');
+    // Palette matches the existing bronze tier accent so it reads as
+    // "packaging" without introducing a new site color.
+    expect(CSS).toContain('color: #b07040');
+  });
+});
+
+describe('#237: pipeline emits per-game depots.json during finalize', () => {
+  test('finalize.py imports and calls write_depot_files', () => {
+    expect(FINAL).toContain('from .write_depot_files import write_depot_files');
+    expect(FINAL).toContain('write_depot_files(data_output_path)');
+  });
+
+  test('writer emits one file per Steam app under {appId}/depots.json', () => {
+    expect(WRITER).toContain('app_dir = base / app_id_to_dir(str(app_id))');
+    expect(WRITER).toContain('"depots.json"');
+  });
+
+  test('writer pulls raw_pics + tracked_since + manifests from Supabase', () => {
+    expect(WRITER).toContain('steam_depot_updates');
+    expect(WRITER).toContain('steam_depot_manifest_history');
+    expect(WRITER).toContain('steam_depot_fetch_status');
+    expect(WRITER).toContain('raw_pics');
+    expect(WRITER).toContain('tracked_since');
+  });
+});
+
+describe('#237: migration adds raw_pics jsonb column', () => {
+  test('adds a jsonb column on steam_depot_fetch_status', () => {
+    expect(MIG).toContain('alter table public.steam_depot_fetch_status');
+    expect(MIG).toContain('add column if not exists raw_pics jsonb');
+  });
+});

--- a/tests/depotFile.test.js
+++ b/tests/depotFile.test.js
@@ -49,22 +49,41 @@ describe('#237: steam-depot-info edge fn returns tracked_since', () => {
 });
 
 describe('#237: metadata modal wires tracked_since + depot file icon', () => {
-  test('renders a 4-column table (OS / Depots / Tracked since / Last update)', () => {
-    expect(COMP).toContain('<th>OS</th><th>Depots</th><th>Tracked since</th><th>Last update</th>');
-    // Footer colspan updated to match the new column count.
+  test('renders a 4-column table with Depots as the icon-only last column', () => {
+    // #237 v2: Depots moved to the right so mobile can collapse it to just
+    // the icon without pushing the important date columns off-screen.
+    expect(COMP).toContain('<th>OS</th><th>Tracked since</th><th>Last update</th><th class="gm-plat-depots-th">Depots</th>');
+    // Footer colspan matches the column count.
     expect(COMP).toContain('colspan="4"');
+  });
+
+  test('depots cell is icon-only (no "N tracked" text) with count in the tooltip', () => {
+    // Old cell had `${cached.depots} tracked` visible text; new cell inlines
+    // the icon directly and puts the count in the title attribute.
+    expect(COMP).toContain('gm-plat-depots');
+    expect(COMP).not.toContain('${cached.depots} tracked');
+    expect(COMP).toMatch(/\$\{cached\.depots\} depot\$\{cached\.depots !== 1 \? 's' : ''\} tracked/);
+  });
+
+  test('footer explains that tracked-since is our observation floor, not the historical add-date', () => {
+    // Users kept asking "why isn't this the date macOS was added?" -- spell
+    // out that PICS doesn't expose depot creation dates.
+    expect(COMP).toContain("not the historical date the OS build was added");
+    expect(COMP).toContain("Newly-added OS builds");
   });
 
   test('formats tracked_since from cached.tracked_since', () => {
     expect(COMP).toContain('const trackedFmt = fmtDate(cached?.tracked_since)');
-    expect(COMP).toContain('Earliest first_observed_at');
+    // Tooltip explains the field is our observation floor, not a historical
+    // add-date -- prevents users from misreading it as "when Mac was added".
+    expect(COMP).toContain('Earliest observation date we recorded');
   });
 
   test('brown package icon links to the gh-pages depots.json blob', () => {
     expect(COMP).toContain('gm-depot-file');
     expect(COMP).toContain('/blob/gh-pages/data/${esc(String(meta.appId))}/depots.json');
     // Deep-links to the OS anchor so we can scroll to a specific block later.
-    expect(COMP).toContain('#os=${esc(os)}');
+    expect(COMP).toContain('#os=${esc(key)}');
     // Package icon markup lives in an inline SVG so we don't need a new asset.
     expect(COMP).toContain('<svg viewBox="0 0 24 24"');
   });

--- a/tests/gameManager.test.js
+++ b/tests/gameManager.test.js
@@ -1,0 +1,140 @@
+/**
+ * #234: Game Manager admin panel -- API client + component wiring.
+ *
+ * The MVP writes hides + remaps to Supabase and shows a read-only view
+ * of the pipeline suspect list from app-id-redirects.json. Frontend
+ * enforcement (search filter, redirect on remap) is a follow-up ticket;
+ * this test file pins the admin write path + the UI contract that goes
+ * with it.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const read = (p) => fs.readFileSync(path.join(ROOT, p), 'utf8');
+
+const MIG   = read('supabase/migrations/20260708100000_game_manager_tables.sql');
+const PERMS = read('js/admin/permissions.js');
+const API   = read('js/admin/api/gameManager.js');
+const COMP  = read('js/admin/components/gameManager.js');
+const HTML  = read('admin.html');
+const MAIN  = read('js/admin/main.js');
+const MANIF = read('gh-pages-manifest.txt').split('\n').map((l) => l.trim());
+
+describe('#234: migration adds game_hides + game_remaps + manage_games perm', () => {
+  test('creates both tables keyed on app_id / from_app_id', () => {
+    expect(MIG).toContain('CREATE TABLE IF NOT EXISTS public.game_hides');
+    expect(MIG).toContain('app_id      TEXT PRIMARY KEY');
+    expect(MIG).toContain('CREATE TABLE IF NOT EXISTS public.game_remaps');
+    expect(MIG).toContain('from_app_id  TEXT PRIMARY KEY');
+    expect(MIG).toContain('to_app_id    TEXT NOT NULL');
+  });
+
+  test('game_remaps blocks self-loops via CHECK constraint', () => {
+    expect(MIG).toContain('game_remaps_no_self_loop CHECK (from_app_id <> to_app_id)');
+  });
+
+  test('RLS gates writes on manage_games; reads are public', () => {
+    // Both tables must permit public SELECT (pipeline + frontend read them).
+    expect(MIG).toMatch(/anyone can read game_hides/);
+    expect(MIG).toMatch(/anyone can read game_remaps/);
+    // Writes are gated on the new permission for both tables.
+    const gates = MIG.match(/current_user_has_permission\('manage_games'\)/g) || [];
+    // 3 policies (insert/update/delete) x 2 tables = 6 permission checks.
+    expect(gates.length).toBeGreaterThanOrEqual(6);
+  });
+
+  test('backfills existing moderators with manage_games', () => {
+    expect(MIG).toContain('array_append(permissions, \'manage_games\')');
+    expect(MIG).toContain('role = \'moderator\'');
+  });
+});
+
+describe('#234: frontend permission vocabulary + tab gating', () => {
+  test('permissions.js registers manage_games and gates the games tab on it', () => {
+    expect(PERMS).toContain("{ key: 'manage_games'");
+    expect(PERMS).toContain('Manage games (hide / remap)');
+    // Tab gate lives in TAB_PERMISSIONS so canSeeTab returns false without the perm.
+    expect(PERMS).toContain("games:          ['manage_games']");
+    // Moderator preset should get it so a fresh moderator has access.
+    expect(PERMS).toContain("moderator:   ['manage_reports', 'delete_reports', 'ban_users', 'view_analytics', 'manage_games']");
+  });
+
+  test('admin.html declares the tab + section', () => {
+    expect(HTML).toContain('<option value="games">Game Manager</option>');
+    expect(HTML).toContain('id="tab-games"');
+    expect(HTML).toContain('id="game-manager-content"');
+  });
+
+  test('main.js registers the tab loader with the render function', () => {
+    expect(MAIN).toContain("import { renderGameManager }");
+    expect(MAIN).toContain("games: () => renderGameManager()");
+  });
+
+  test('gh-pages manifest lists both new client files', () => {
+    expect(MANIF).toContain('js/admin/api/gameManager.js');
+    expect(MANIF).toContain('js/admin/components/gameManager.js');
+  });
+});
+
+describe('#234: API client uses PostgREST with merge-duplicates upserts', () => {
+  test('upsertGameHide posts to game_hides with on_conflict=app_id', () => {
+    expect(API).toContain('export async function upsertGameHide');
+    expect(API).toContain('/game_hides?on_conflict=app_id');
+    expect(API).toContain("Prefer: 'resolution=merge-duplicates,return=representation'");
+  });
+
+  test('upsertGameRemap posts to game_remaps with on_conflict=from_app_id + self-loop guard', () => {
+    expect(API).toContain('export async function upsertGameRemap');
+    expect(API).toContain('/game_remaps?on_conflict=from_app_id');
+    // Panel-side self-loop check so the error message is human-friendly
+    // instead of a raw CHECK constraint violation.
+    expect(API).toContain('from and to app ids must differ');
+  });
+
+  test('delete helpers scope to the primary key via .eq filter', () => {
+    expect(API).toContain('/game_hides?app_id=eq.${encodeURIComponent');
+    expect(API).toContain('/game_remaps?from_app_id=eq.${encodeURIComponent');
+  });
+
+  test('loadPipelineSuspects fetches app-id-redirects.json off the current origin', () => {
+    // Path resolution must respect the staging repo prefix so the panel
+    // still works on both mdeguzis.github.io/proton-pulse-web(-staging).
+    expect(API).toContain("proton-pulse-web-staging");
+    expect(API).toContain("app-id-redirects.json");
+  });
+
+  test('requires reason on both writers so RLS never sees an empty string', () => {
+    // Server-side has NOT NULL on `reason`; catching it client-side gives
+    // the admin a real error message before the round trip.
+    expect(API).toContain('reason are required');
+    expect(API).toContain("reason?.trim()");
+  });
+});
+
+describe('#234: component renders three sections + wires row actions', () => {
+  test('renders forms for hide + remap and a suspects panel', () => {
+    expect(COMP).toContain('id="gm-hide-form"');
+    expect(COMP).toContain('id="gm-remap-form"');
+    expect(COMP).toContain('Pipeline-flagged suspects');
+  });
+
+  test('promote-remap and promote-hide buttons target the suspects rows', () => {
+    // These are the "one-click promote" buttons on the suspects table that
+    // seed a real hide/remap from the pipeline flag.
+    expect(COMP).toContain("data-action=\"promote-remap\"");
+    expect(COMP).toContain("data-action=\"promote-hide\"");
+  });
+
+  test('unhide + clear-remap use delegated row actions so re-render stays cheap', () => {
+    expect(COMP).toContain("data-action=\"unhide\"");
+    expect(COMP).toContain("data-action=\"clear-remap\"");
+    // Single event delegate on the panel root handles all row actions.
+    expect(COMP).toContain("el.addEventListener('click'");
+  });
+
+  test('title map from search-index is used to render titles alongside raw ids', () => {
+    expect(COMP).toContain('_titleMap()');
+    expect(COMP).toContain("dataUrl('search-index.json')");
+  });
+});

--- a/tests/gamePageLive.test.js
+++ b/tests/gamePageLive.test.js
@@ -8,9 +8,10 @@ const src = fs.readFileSync(
 
 describe('game page: ProtonDB live-only handling', () => {
   test('live summary is not merged into the rendered report list', () => {
-    // reports[] must not spread liveCached (that produced the broken stub card)
+    // reports[] must not spread liveFetched (that produced the broken stub card)
+    expect(src).not.toMatch(/\.\.\.liveFetched\.map/);
     expect(src).not.toMatch(/\.\.\.liveCached\.map/);
-    expect(src).toContain('const liveSummary = liveCached.find(r => r._liveOnly) || null');
+    expect(src).toContain("const liveSummary = (liveFetched || []).find(r => r._liveOnly) || null");
     expect(src).toContain('const liveOnly = !!liveSummary && !cdn.length');
   });
 
@@ -18,10 +19,26 @@ describe('game page: ProtonDB live-only handling', () => {
     expect(src).toContain('if (!reports.length && !configs.length && !liveSummary)');
   });
 
-  test('header tier and count come from the live summary when mirror is empty', () => {
-    expect(src).toContain('const protonDbCount = cdn.length || (liveSummary ? (liveSummary.total || 0) : 0)');
-    expect(src).toContain("const protonDbTier = liveOnly ? String(liveSummary.tier || '').toLowerCase() : tierFromReports(cdn)");
+  test('header count uses MAX(mirror, live total) so ProtonDB totals show through (#219)', () => {
+    // #219: even when we have some mirror reports, use the live total when
+    // ProtonDB says there are more (Hollow Knight etc).
+    expect(src).toContain('const protonDbCount = Math.max(cdn.length, liveTotal)');
+    expect(src).toContain('const liveTotal = liveSummary ? (liveSummary.total || 0) : 0');
     expect(src).toContain('const totalReports = nativeReports.length + protonDbCount');
+  });
+
+  test('tier falls back to live summary when mirror is empty (#219)', () => {
+    // liveOnly branch returns the live tier verbatim; the else branch prefers
+    // tierFromReports but falls back to the live summary tier if empty.
+    expect(src).toContain("liveOnly");
+    expect(src).toContain("String(liveSummary.tier || '').toLowerCase()");
+    expect(src).toContain("(tierFromReports(cdn) || String(liveSummary?.tier || '').toLowerCase())");
+  });
+
+  test('ProtonDB live summary is auto-fetched in the parallel Promise.all (#219)', () => {
+    // #219: the live summary must load automatically on every page render
+    // so aggregate stats reflect ProtonDB reality, not just what we mirror.
+    expect(src).toContain("safeFetch(() => fetchProtonDbLive(appId), 'fetchProtonDbLive', [])");
   });
 
   test('live-only shows an explanatory note instead of fake cards', () => {
@@ -81,6 +98,22 @@ describe('game page: rating panel (dial + per-tier bars + flag)', () => {
   test('box art is preserved in the header grid', () => {
     expect(src).toContain('class="game-header-art"');
     expect(src).toContain('src="${STEAM_IMG(appId)}"');
+  });
+
+  test('mirror-sample note appears when live total exceeds mirror count (#219)', () => {
+    // When cdn has, e.g., 3 reports but ProtonDB reports 500 total, the tier
+    // bars are only from our 3-sample slice. Attribution note tells users the
+    // dial confidence uses the live total instead.
+    expect(src).toContain("grp-bars-note--sample");
+    expect(src).toContain("liveTotal > cdn.length");
+    expect(src).toContain("Per-tier bars reflect our mirrored sample");
+  });
+
+  test('summary tags source when count is driven by ProtonDB live (#219)', () => {
+    // Users need to see whether "N reports" came from mirror or live so the
+    // aggregate makes sense even when the tier bars look tiny.
+    expect(src).toContain("_fromLive");
+    expect(src).toContain("(via ProtonDB live)");
   });
 
   test('confidence summary buckets off the percent, not the report count (#187)', () => {

--- a/tests/gamePageLive.test.js
+++ b/tests/gamePageLive.test.js
@@ -43,7 +43,10 @@ describe('game page: ProtonDB live-only handling', () => {
 
   test('live-only shows an explanatory note instead of fake cards', () => {
     expect(src).toContain('class="live-summary-note"');
-    expect(src).toContain('Per-tier breakdown is not available from ProtonDB');
+    // The old "Per-tier breakdown is not available" fallback was replaced by
+    // a synthesized primary-tier bar (#219 follow-up). See the "synthesized
+    // primary-tier bar" test above for the new contract.
+    expect(src).toContain('Aggregate tier from ProtonDB');
   });
 
   test('report_moderation fetch does not double the /rest/v1 prefix', () => {
@@ -74,9 +77,12 @@ describe('game page: rating panel (dial + per-tier bars + flag)', () => {
     expect(src).toContain('background:${RATING_COLORS[t]}');
   });
 
-  test('live-only games show the no-breakdown note instead of empty bars', () => {
-    expect(src).toContain('class="grp-bars-note"');
-    expect(src).toContain("Per-tier breakdown is not available from ProtonDB");
+  test('live-only games show a synthesized primary-tier bar instead of empty rows', () => {
+    // Old behavior showed 5 empty PLATINUM/GOLD/... 0 bars or a plain note.
+    // New behavior (#219 follow-up): render a single filled bar for the tier
+    // ProtonDB's summary reports.
+    expect(src).toContain('class="grp-bars-note grp-bars-note--sample"');
+    expect(src).toContain('Aggregate tier from ProtonDB');
   });
 
   test('confidence summary links to the scoring breakdown via a "why?" link', () => {
@@ -100,13 +106,22 @@ describe('game page: rating panel (dial + per-tier bars + flag)', () => {
     expect(src).toContain('src="${STEAM_IMG(appId)}"');
   });
 
-  test('mirror-sample note appears when live total exceeds mirror count (#219)', () => {
-    // When cdn has, e.g., 3 reports but ProtonDB reports 500 total, the tier
-    // bars are only from our 3-sample slice. Attribution note tells users the
-    // dial confidence uses the live total instead.
+  test('mirror-sample note appears when live total exceeds mirror sample (#219)', () => {
+    // When cdn/native samples exist but ProtonDB reports more total, tier bars
+    // are only from our slice. Attribution note tells users the dial confidence
+    // uses the live total instead.
     expect(src).toContain("grp-bars-note--sample");
-    expect(src).toContain("liveTotal > cdn.length");
+    expect(src).toContain("liveTotal > _mirrorTotalCount");
     expect(src).toContain("Per-tier bars reflect our mirrored sample");
+  });
+
+  test('synthesized primary-tier bar renders when mirror sample is empty (#219)', () => {
+    // When we have no valid mirror ratings but a live summary tier is known,
+    // show a single filled bar for that tier instead of five empty rows.
+    expect(src).toContain("_useLiveBar");
+    expect(src).toContain("_mirrorTotalCount === 0");
+    expect(src).toContain("Aggregate tier from ProtonDB");
+    expect(src).toContain("grp-bar-${_liveTierKey}");
   });
 
   test('summary tags source when count is driven by ProtonDB live (#219)', () => {

--- a/tests/gamePageLive.test.js
+++ b/tests/gamePageLive.test.js
@@ -41,12 +41,11 @@ describe('game page: ProtonDB live-only handling', () => {
     expect(src).toContain("safeFetch(() => fetchProtonDbLive(appId), 'fetchProtonDbLive', [])");
   });
 
-  test('live-only shows an explanatory note instead of fake cards', () => {
+  test('live-only shows an explanatory note in the cards area, not fake cards', () => {
+    // The .live-summary-note block still exists to explain why there are no
+    // report cards below when the mirror is empty.
     expect(src).toContain('class="live-summary-note"');
-    // The old "Per-tier breakdown is not available" fallback was replaced by
-    // a synthesized primary-tier bar (#219 follow-up). See the "synthesized
-    // primary-tier bar" test above for the new contract.
-    expect(src).toContain('Aggregate tier from ProtonDB');
+    expect(src).toContain('checked live');
   });
 
   test('report_moderation fetch does not double the /rest/v1 prefix', () => {
@@ -77,12 +76,14 @@ describe('game page: rating panel (dial + per-tier bars + flag)', () => {
     expect(src).toContain('background:${RATING_COLORS[t]}');
   });
 
-  test('live-only games show a synthesized primary-tier bar instead of empty rows', () => {
-    // Old behavior showed 5 empty PLATINUM/GOLD/... 0 bars or a plain note.
-    // New behavior (#219 follow-up): render a single filled bar for the tier
-    // ProtonDB's summary reports.
-    expect(src).toContain('class="grp-bars-note grp-bars-note--sample"');
-    expect(src).toContain('Aggregate tier from ProtonDB');
+  test('live-only games still show the 5-bar breakdown, with a ProtonDB rating + count note above', () => {
+    // ProtonDB's summary API has no per-tier counts, so the bars will read
+    // 0/0/0/0/0 for a live-only game. We prepend a one-line note telling
+    // users the aggregate rating + count so the section still communicates
+    // something (#219 follow-up).
+    expect(src).toContain('class="grp-bars"');
+    expect(src).toContain('grp-bars-note--live');
+    expect(src).toContain('ProtonDB rating:');
   });
 
   test('confidence summary links to the scoring breakdown via a "why?" link', () => {
@@ -106,22 +107,13 @@ describe('game page: rating panel (dial + per-tier bars + flag)', () => {
     expect(src).toContain('src="${STEAM_IMG(appId)}"');
   });
 
-  test('mirror-sample note appears when live total exceeds mirror sample (#219)', () => {
-    // When cdn/native samples exist but ProtonDB reports more total, tier bars
-    // are only from our slice. Attribution note tells users the dial confidence
-    // uses the live total instead.
-    expect(src).toContain("grp-bars-note--sample");
-    expect(src).toContain("liveTotal > _mirrorTotalCount");
-    expect(src).toContain("Per-tier bars reflect our mirrored sample");
-  });
-
-  test('synthesized primary-tier bar renders when mirror sample is empty (#219)', () => {
-    // When we have no valid mirror ratings but a live summary tier is known,
-    // show a single filled bar for that tier instead of five empty rows.
-    expect(src).toContain("_useLiveBar");
-    expect(src).toContain("_mirrorTotalCount === 0");
-    expect(src).toContain("Aggregate tier from ProtonDB");
-    expect(src).toContain("grp-bar-${_liveTierKey}");
+  test('ProtonDB rating + count note renders above the 5-bar stack when live data exists (#219)', () => {
+    // Kept the classic 5-bar breakdown even when mirror sample is empty; just
+    // prepend a one-line "ProtonDB rating: PLATINUM * 371 reports" note so
+    // users see the aggregate alongside the (possibly empty) bars.
+    expect(src).toContain("grp-bars-note--live");
+    expect(src).toContain("ProtonDB rating:");
+    expect(src).toContain("liveTotal.toLocaleString()");
   });
 
   test('summary tags source when count is driven by ProtonDB live (#219)', () => {

--- a/tests/gameStatsLive.test.js
+++ b/tests/gameStatsLive.test.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+
+const src = fs.readFileSync(
+  path.join(__dirname, '..', 'js', 'game-stats', 'main.js'),
+  'utf8'
+);
+
+describe('game-stats page: ProtonDB live summary integration (#219)', () => {
+  test('loadProtonDbLive hits the same edge fn the game page uses', () => {
+    expect(src).toContain("PROTONDB_LIVE_URL");
+    expect(src).toContain("functions/v1/protondb-summary");
+    expect(src).toContain("async function loadProtonDbLive(appId)");
+  });
+
+  test('run() fetches the live summary in parallel with mirror data', () => {
+    expect(src).toMatch(/const \[cdnReports, searchIndex, pulseReports, configs, liveSummary\] = await Promise\.all\(\[/);
+    expect(src).toMatch(/loadProtonDbLive\(appId\),?/);
+  });
+
+  test('no-mirror branch renders live summary block instead of a bare error', () => {
+    expect(src).toContain("gs-live-summary");
+    expect(src).toContain("gs-live-summary-tier");
+    expect(src).toContain("gs-live-summary-total");
+    expect(src).toContain("ProtonDB report");
+    expect(src).toContain("we haven't mirrored");
+  });
+
+  test('renderHeader accepts liveTotal + shows the effective ProtonDB count', () => {
+    expect(src).toContain("liveTotal = 0");
+    expect(src).toContain("Math.max(protonDbCount, liveTotal)");
+    expect(src).toContain("(live)");
+  });
+
+  test('renderAll receives liveTotal so the header stays consistent when reports exist', () => {
+    expect(src).toContain("liveTotal: liveSummary?.total || 0");
+  });
+});

--- a/tests/runType.test.js
+++ b/tests/runType.test.js
@@ -130,10 +130,16 @@ describe('validateRuntimeVersion', () => {
     expect(validateRuntimeVersion('native', 'anything').ok).toBeNull();
   });
 
-  test('proton accepts stable + hotfix syntax', () => {
+  test('proton accepts stable, hotfix, experimental, and next branches', () => {
     expect(validateRuntimeVersion('proton', 'Proton 9.0-4').ok).toBe(true);
     expect(validateRuntimeVersion('proton', 'Proton 8.0-5c').ok).toBe(true);
     expect(validateRuntimeVersion('proton', 'Proton Hotfix').ok).toBe(true);
+    // Valve ships Experimental and Next under the same "Proton" umbrella
+    // in Steam. The plain "Proton" runType should accept them without
+    // firing a fake "does not look like Proton" warning.
+    expect(validateRuntimeVersion('proton', 'Proton Experimental').ok).toBe(true);
+    expect(validateRuntimeVersion('proton', 'proton experimental').ok).toBe(true);
+    expect(validateRuntimeVersion('proton', 'Proton Next').ok).toBe(true);
     // Rejects unrelated strings
     expect(validateRuntimeVersion('proton', 'GE-Proton9-27').ok).toBe(false);
     expect(validateRuntimeVersion('proton', 'wine 9.0').ok).toBe(false);

--- a/tests/runType.test.js
+++ b/tests/runType.test.js
@@ -145,27 +145,38 @@ describe('validateRuntimeVersion', () => {
     expect(validateRuntimeVersion('proton', 'wine 9.0').ok).toBe(false);
   });
 
-  test('proton-ge accepts GE variants only', () => {
+  test('proton-ge accepts GE variants incl. rc/beta suffixes', () => {
     expect(validateRuntimeVersion('proton-ge', 'GE-Proton9-27').ok).toBe(true);
+    expect(validateRuntimeVersion('proton-ge', 'GE-Proton10-15').ok).toBe(true);
     expect(validateRuntimeVersion('proton-ge', 'ge-proton 10-4').ok).toBe(true);
+    // Real GE tags ship rc/beta/letter suffixes; those must not warn.
+    expect(validateRuntimeVersion('proton-ge', 'GE-Proton9-27-rc1').ok).toBe(true);
+    expect(validateRuntimeVersion('proton-ge', 'GE-Proton9-27b').ok).toBe(true);
+    // Still guards obvious mismatches.
     expect(validateRuntimeVersion('proton-ge', 'Proton 9.0-4').ok).toBe(false);
   });
 
-  test('proton-experimental matches experimental / bleeding-edge phrasing', () => {
+  test('proton-experimental matches Proton Experimental, bleeding-edge, or bare Experimental', () => {
     expect(validateRuntimeVersion('proton-experimental', 'Proton Experimental').ok).toBe(true);
     expect(validateRuntimeVersion('proton-experimental', 'bleeding-edge').ok).toBe(true);
+    // Bare "Experimental" is unambiguous once the runtime type is already picked.
+    expect(validateRuntimeVersion('proton-experimental', 'Experimental').ok).toBe(true);
     expect(validateRuntimeVersion('proton-experimental', 'Proton 9.0-4').ok).toBe(false);
   });
 
-  test('proton-cachyos matches CachyOS mentions', () => {
+  test('proton-cachyos matches CachyOS mentions incl. bare CachyOS', () => {
     expect(validateRuntimeVersion('proton-cachyos', 'CachyOS Proton 9.0-4').ok).toBe(true);
     expect(validateRuntimeVersion('proton-cachyos', 'cachy-proton').ok).toBe(true);
+    // Bare "CachyOS" is unambiguous once the runtime type is already picked.
+    expect(validateRuntimeVersion('proton-cachyos', 'CachyOS').ok).toBe(true);
     expect(validateRuntimeVersion('proton-cachyos', 'Proton 9.0-4').ok).toBe(false);
   });
 
-  test('proton-tkg matches TKG mentions', () => {
+  test('proton-tkg matches TKG mentions incl. bare TKG', () => {
     expect(validateRuntimeVersion('proton-tkg', 'Proton-TKG 9.0-4').ok).toBe(true);
     expect(validateRuntimeVersion('proton-tkg', 'tkg proton').ok).toBe(true);
+    // Bare "TKG" is unambiguous once the runtime type is already picked.
+    expect(validateRuntimeVersion('proton-tkg', 'TKG').ok).toBe(true);
     expect(validateRuntimeVersion('proton-tkg', 'Proton 9.0-4').ok).toBe(false);
   });
 

--- a/tests/steamLibraryLookup.test.js
+++ b/tests/steamLibraryLookup.test.js
@@ -1,0 +1,155 @@
+/**
+ * #221: admin-only API Explorer proxy for keyed Steam Web API endpoints.
+ *
+ * The edge fn (supabase/functions/steam-library-lookup/index.ts) wraps three
+ * Steam endpoints -- GetOwnedGames, GetRecentlyPlayedGames, ResolveVanityURL --
+ * behind a manage_admins permission check + STEAM_WEB_API_KEY. This test file
+ * pins the contract at the edge fn, the client wrapper, the Explorer wiring,
+ * and the deploy plumbing so the Steam Web API key can never leak to a
+ * non-admin caller.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const read = (p) => fs.readFileSync(path.join(ROOT, p), 'utf8');
+
+const EDGE = read('supabase/functions/steam-library-lookup/index.ts');
+const API = read('js/admin/api/steam-library-lookup.js');
+const COMP = read('js/admin/components/api-explorer.js');
+const MAIN = read('js/admin/main.js');
+const MANIFEST = read('gh-pages-manifest.txt').split('\n').map((l) => l.trim());
+const CONFIG = read('supabase/config.toml');
+
+describe('steam-library-lookup edge function', () => {
+  test('whitelists exactly the three keyed endpoints', () => {
+    expect(EDGE).toMatch(/const ENDPOINTS: Record<\s*string,/);
+    expect(EDGE).toContain('steam_get_owned_games:');
+    expect(EDGE).toContain('steam_get_recently_played:');
+    expect(EDGE).toContain('steam_resolve_vanity:');
+    // Rejects anything else -- guard against arbitrary URL forwarding.
+    expect(EDGE).toContain('if (!meta) {');
+    expect(EDGE).toContain('"unknown endpoint"');
+  });
+
+  test('builds the correct Steam Web API paths for each endpoint', () => {
+    expect(EDGE).toContain('IPlayerService/GetOwnedGames/v1/');
+    expect(EDGE).toContain('IPlayerService/GetRecentlyPlayedGames/v1/');
+    expect(EDGE).toContain('ISteamUser/ResolveVanityURL/v1/');
+    // Owned-games must include the appinfo + F2P flags so the JSON is useful.
+    expect(EDGE).toContain('include_appinfo=1');
+    expect(EDGE).toContain('include_played_free_games=1');
+    // Vanity resolution is scoped to individual profiles.
+    expect(EDGE).toContain('url_type=1');
+  });
+
+  test('requires an authenticated caller with manage_admins permission', () => {
+    // Same auth pattern image-refetch uses (createRequestAuthClient +
+    // current_user_has_permission). Anything else would defeat the admin
+    // gating that keeps the Steam Web API key out of civilian hands.
+    expect(EDGE).toContain('createRequestAuthClient(req)');
+    expect(EDGE).toContain('auth.getUser()');
+    expect(EDGE).toContain('current_user_has_permission');
+    expect(EDGE).toContain('manage_admins');
+    // Distinct 401 vs 403 branches so the client can render a useful error.
+    expect(EDGE).toContain('"authentication required"');
+    expect(EDGE).toContain('"manage_admins permission required"');
+  });
+
+  test('validates arg format before hitting Steam (defense against URL injection)', () => {
+    expect(EDGE).toMatch(/const STEAMID_RE = \/\^\\d\{5,20\}\$\//);
+    expect(EDGE).toMatch(/const VANITY_RE = \/\^\[A-Za-z0-9_-\]\{2,64\}\$\//);
+    expect(EDGE).toContain('invalid ${meta.argName} format');
+  });
+
+  test('never returns the Steam Web API key in the response envelope', () => {
+    // The url field is echoed to the client for the API Explorer view, so it
+    // must have the key redacted. Anything else is a leak.
+    expect(EDGE).toContain('const safeUrl = url.replace(encodeURIComponent(apiKey), "***")');
+    expect(EDGE).toContain('url: safeUrl');
+  });
+
+  test('returns the steam-explore-shaped envelope so the Explorer renders uniformly', () => {
+    // ok/endpoint/arg/url/method/status/data/error -- identical shape.
+    for (const field of ['ok', 'endpoint', 'arg', 'url', 'method', 'status', 'data']) {
+      expect(EDGE).toContain(`${field}:`);
+    }
+  });
+
+  test('is registered in config.toml (verify_jwt handled inline like image-refetch)', () => {
+    expect(CONFIG).toContain('[functions.steam-library-lookup]');
+    // Every other proxy sets verify_jwt=false and does the auth inline; this
+    // one MUST match so we can call the permission RPC ourselves.
+    const section = CONFIG.split('[functions.steam-library-lookup]')[1] || '';
+    expect(section.split('[functions.')[0]).toContain('verify_jwt = false');
+  });
+});
+
+describe('steam-library-lookup client wrapper', () => {
+  test('isLibraryEndpoint recognizes the three keyed endpoints', () => {
+    expect(API).toContain("steam_get_owned_games");
+    expect(API).toContain("steam_get_recently_played");
+    expect(API).toContain("steam_resolve_vanity");
+    expect(API).toContain('export function isLibraryEndpoint');
+  });
+
+  test('lookupLibrary attaches Bearer <access_token> so the edge fn can verify admin', () => {
+    expect(API).toContain('SupaAuth.getSession');
+    expect(API).toContain('session?.access_token');
+    expect(API).toContain('Authorization: `Bearer ${session.access_token}`');
+    // Never call the edge fn without a session token -- otherwise the fn 401s
+    // and the client shows a confusing "no body" error instead of the real one.
+    expect(API).toContain("'sign in as an admin first'");
+  });
+
+  test('routes steamid vs vanityurl to the correct payload field', () => {
+    expect(API).toContain('steamid: String(steamid');
+    expect(API).toContain('vanityurl: String(vanityurl');
+  });
+});
+
+describe('API Explorer wiring for admin-only endpoints', () => {
+  test('endpoints are declared under STORES.steam with adminGated:true', () => {
+    for (const key of ['steam_get_owned_games', 'steam_get_recently_played', 'steam_resolve_vanity']) {
+      expect(COMP).toContain(`{ key: '${key}',`);
+    }
+    expect(COMP).toContain('adminGated: true');
+  });
+
+  test('populateEndpoints filters admin-gated endpoints when canManageAdmins is false', () => {
+    expect(COMP).toContain('canManageAdmins');
+    expect(COMP).toContain('!e.adminGated || canManageAdmins');
+  });
+
+  test('_resolveArg has branches for steamid and vanity input types', () => {
+    expect(COMP).toContain("endpointArg === 'steamid'");
+    expect(COMP).toContain("endpointArg === 'vanity'");
+    expect(COMP).toMatch(/\/\^\\d\{5,20\}\$\//);
+    expect(COMP).toMatch(/\/\^\[A-Za-z0-9_-\]\{2,64\}\$\//);
+  });
+
+  test('doFetch routes library endpoints through lookupLibrary, not exploreStore', () => {
+    expect(COMP).toContain("isLibraryEndpoint(endpoint)");
+    expect(COMP).toContain('lookupLibrary(endpoint, { steamid: resolved.steamid, vanityurl: resolved.vanityurl })');
+    // Public endpoints still go through the public proxy.
+    expect(COMP).toContain('exploreStore(endpoint, { id: resolved.id, term: resolved.term })');
+  });
+
+  test('field-descriptions modal has entries for all three library endpoints', () => {
+    for (const key of ['steam_get_owned_games', 'steam_get_recently_played', 'steam_resolve_vanity']) {
+      expect(COMP).toContain(`${key}: {`);
+    }
+    // Body prose exists so the modal is not empty for these new endpoints.
+    expect(COMP).toContain('GetOwnedGames');
+    expect(COMP).toContain('GetRecentlyPlayedGames');
+    expect(COMP).toContain('ResolveVanityURL');
+  });
+
+  test('main.js passes canManageAdmins into renderApiExplorer', () => {
+    expect(MAIN).toContain("renderApiExplorer({ canManageAdmins: can('manage_admins') })");
+  });
+
+  test('gh-pages manifest lists the new client file so the deploy copies it', () => {
+    expect(MANIFEST).toContain('js/admin/api/steam-library-lookup.js');
+  });
+});

--- a/tests/steamLibraryLookup.test.js
+++ b/tests/steamLibraryLookup.test.js
@@ -3,7 +3,7 @@
  *
  * The edge fn (supabase/functions/steam-library-lookup/index.ts) wraps three
  * Steam endpoints -- GetOwnedGames, GetRecentlyPlayedGames, ResolveVanityURL --
- * behind a manage_admins permission check + STEAM_WEB_API_KEY. This test file
+ * behind a manage_admins permission check + STEAM_API_KEY. This test file
  * pins the contract at the edge fn, the client wrapper, the Explorer wiring,
  * and the deploy plumbing so the Steam Web API key can never leak to a
  * non-admin caller.

--- a/tests/test_steam_metadata.py
+++ b/tests/test_steam_metadata.py
@@ -322,7 +322,7 @@ class TestNoManifestDiagnostics:
         monkeypatch.setattr(steam_metadata, "run_steamcmd_app_info", lambda app_id, **kw: fake_stdout)
         status_calls, log_calls = [], []
         monkeypatch.setattr(steam_metadata, "upsert_fetch_status",
-            lambda app_id, status, depot_count, error=None: status_calls.append((app_id, status, depot_count, error)))
+            lambda app_id, status, depot_count, error=None, raw_pics=None: status_calls.append((app_id, status, depot_count, error, raw_pics)))
         monkeypatch.setattr(steam_metadata, "upsert_depot_rows", lambda rows: 0)
         monkeypatch.setattr(steam_metadata, "log", lambda msg: log_calls.append(msg))
         status, n = steam_metadata.fetch_and_store(367520)
@@ -370,7 +370,7 @@ class TestFetchAndStoreOffline:
         upserts = []
         status_calls = []
         monkeypatch.setattr(steam_metadata, "upsert_depot_rows", lambda rows: upserts.append(list(rows)) or 0)
-        monkeypatch.setattr(steam_metadata, "upsert_fetch_status", lambda app_id, status, depot_count, error=None: status_calls.append((app_id, status, depot_count, error)))
+        monkeypatch.setattr(steam_metadata, "upsert_fetch_status", lambda app_id, status, depot_count, error=None, raw_pics=None: status_calls.append((app_id, status, depot_count, error)))
         status, n = steam_metadata.fetch_and_store(1)
         assert status == "no_public_manifest"
         assert n == 0
@@ -388,10 +388,42 @@ class TestFetchAndStoreOffline:
             raise RuntimeError("steamcmd missing")
         monkeypatch.setattr(steam_metadata, "run_steamcmd_app_info", boom)
         status_calls = []
-        monkeypatch.setattr(steam_metadata, "upsert_fetch_status", lambda app_id, status, depot_count, error=None: status_calls.append((app_id, status, error)))
+        monkeypatch.setattr(steam_metadata, "upsert_fetch_status", lambda app_id, status, depot_count, error=None, raw_pics=None: status_calls.append((app_id, status, error)))
         status, n = steam_metadata.fetch_and_store(1)
         assert status == "error"
         assert n == 0
         assert status_calls[0][0] == 1
         assert status_calls[0][1] == "error"
         assert "steamcmd missing" in status_calls[0][2]
+
+    def test_ok_run_persists_raw_pics_on_fetch_status(self, monkeypatch):
+        """#237: on a successful fetch, upsert_fetch_status must receive the
+        full parsed depots dict so downstream stages can emit depots.json
+        without a second PICS round-trip."""
+        monkeypatch.setattr(steam_metadata, "run_steamcmd_app_info", lambda app_id, **kw: "ignored -- parse is mocked below")
+        parsed_fixture = {
+            "depots": {
+                "10": {
+                    "config": {"oslist": "linux"},
+                    "manifests": {"public": {"gid": "1", "timeupdated": "1700000000"}},
+                },
+                "branches": {"public": {"buildid": "12", "timeupdated": "1700000000"}},
+            },
+        }
+        monkeypatch.setattr(steam_metadata, "parse_app_info", lambda raw: parsed_fixture)
+        # Return one row so extract_depot_rows short-circuits us into the ok path.
+        monkeypatch.setattr(steam_metadata, "extract_depot_rows",
+                            lambda app_id, parsed: [steam_metadata.DepotRow(
+                                app_id=app_id, depot_id=10, os="linux",
+                                name="linux", manifest_id="1", last_updated_at=1700000000)])
+        monkeypatch.setattr(steam_metadata, "upsert_depot_rows", lambda rows: 1)
+        status_calls = []
+        monkeypatch.setattr(steam_metadata, "upsert_fetch_status",
+                            lambda app_id, status, depot_count, error=None, raw_pics=None:
+                                status_calls.append({"status": status, "raw_pics": raw_pics}))
+        status, n = steam_metadata.fetch_and_store(367520)
+        assert status == "ok" and n == 1
+        assert len(status_calls) == 1
+        # raw_pics is passed as the parsed depots dict verbatim.
+        assert status_calls[0]["raw_pics"] == parsed_fixture["depots"]
+        assert status_calls[0]["raw_pics"]["branches"]["public"]["buildid"] == "12"

--- a/tests/test_validate_app_ids.py
+++ b/tests/test_validate_app_ids.py
@@ -1,0 +1,226 @@
+"""Tests for the Steam app-id redirect validator.
+
+Covers the response classification, the substring-prefix regression case
+(app_id=26 wrongly reported "valid" for /app/2670/), the cache TTL
+lifecycle, and the search-index -> redirects.json output pipeline.
+"""
+
+import json
+from datetime import date, timedelta
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+from urllib.error import HTTPError
+
+import scripts.pipeline.validate_app_ids as validate_module
+from scripts.pipeline.validate_app_ids import (
+    _follow_redirects,
+    _is_stale,
+    _load_cache,
+    _save_cache,
+    validate_steam_app_ids,
+)
+
+
+def _make_response(final_url: str) -> MagicMock:
+    resp = MagicMock()
+    resp.url = final_url
+    resp.close = MagicMock()
+    return resp
+
+
+class TestFollowRedirects:
+    def test_valid_when_final_url_matches_original_app_id(self):
+        with patch("urllib.request.urlopen", return_value=_make_response(
+            "https://store.steampowered.com/app/730/Counter-Strike_2/"
+        )):
+            result = _follow_redirects("730")
+        assert result == {"status": "valid"}
+
+    def test_replaced_when_final_url_is_a_different_app_id(self):
+        with patch("urllib.request.urlopen", return_value=_make_response(
+            "https://store.steampowered.com/app/22670/"
+        )):
+            result = _follow_redirects("26670")
+        assert result["status"] == "replaced"
+        assert result["replaced_by"] == "22670"
+        assert result["final_url"] == "https://store.steampowered.com/app/22670/"
+
+    def test_dead_when_redirected_to_homepage_without_any_app_path(self):
+        with patch("urllib.request.urlopen", return_value=_make_response(
+            "https://store.steampowered.com/"
+        )):
+            result = _follow_redirects("9999999")
+        assert result["status"] == "dead"
+        assert result["final_url"] == "https://store.steampowered.com/"
+
+    def test_prefix_id_is_not_a_false_positive_valid(self):
+        """Regression: app_id=26 must NOT be reported valid when Steam
+        redirects to /app/2670/. The old substring check would fail this."""
+        with patch("urllib.request.urlopen", return_value=_make_response(
+            "https://store.steampowered.com/app/2670/Some_Game/"
+        )):
+            result = _follow_redirects("26")
+        assert result["status"] == "replaced"
+        assert result["replaced_by"] == "2670"
+
+    def test_prefix_id_is_not_a_false_positive_dead(self):
+        """Another prefix scenario: 220 redirected to 22000 should not be
+        misread as valid via substring match."""
+        with patch("urllib.request.urlopen", return_value=_make_response(
+            "https://store.steampowered.com/app/22000/"
+        )):
+            result = _follow_redirects("220")
+        assert result["status"] == "replaced"
+        assert result["replaced_by"] == "22000"
+
+    def test_http_404_marked_dead(self):
+        err = HTTPError(
+            url="https://store.steampowered.com/app/9999999/",
+            code=404,
+            msg="Not Found",
+            hdrs=None,
+            fp=None,
+        )
+        with patch("urllib.request.urlopen", side_effect=err):
+            result = _follow_redirects("9999999")
+        assert result["status"] == "dead"
+        assert result["http_status"] == 404
+
+    def test_non_404_http_error_marked_error_not_dead(self):
+        err = HTTPError(
+            url="https://store.steampowered.com/app/730/",
+            code=503,
+            msg="Service Unavailable",
+            hdrs=None,
+            fp=None,
+        )
+        with patch("urllib.request.urlopen", side_effect=err):
+            result = _follow_redirects("730")
+        assert result["status"] == "error"
+        assert result["http_status"] == 503
+
+    def test_generic_exception_bubbles_as_error_string(self):
+        with patch("urllib.request.urlopen", side_effect=TimeoutError("read timeout")):
+            result = _follow_redirects("730")
+        assert result["status"] == "error"
+        assert "timeout" in result["error"].lower()
+
+
+class TestIsStale:
+    def test_missing_probed_at_is_stale(self):
+        assert _is_stale({}) is True
+
+    def test_invalid_probed_at_is_stale(self):
+        assert _is_stale({"probed_at": "not-a-date"}) is True
+
+    def test_recently_probed_is_fresh(self):
+        yesterday = (date.today() - timedelta(days=1)).isoformat()
+        assert _is_stale({"probed_at": yesterday}) is False
+
+    def test_older_than_ttl_is_stale(self):
+        old = (date.today() - timedelta(days=validate_module.STALE_DAYS + 1)).isoformat()
+        assert _is_stale({"probed_at": old}) is True
+
+
+class TestCacheRoundTrip:
+    def test_load_missing_cache_returns_empty_dict(self, tmp_path: Path):
+        assert _load_cache(tmp_path) == {}
+
+    def test_save_then_load_roundtrips_entries(self, tmp_path: Path):
+        payload = {"730": {"status": "valid", "probed_at": "2026-07-07"}}
+        _save_cache(tmp_path, payload)
+        loaded = _load_cache(tmp_path)
+        assert loaded == payload
+
+    def test_corrupt_cache_is_treated_as_empty(self, tmp_path: Path):
+        cache_path = tmp_path / "app-id-validation-cache.json"
+        cache_path.write_text("{not-json", encoding="utf-8")
+        assert _load_cache(tmp_path) == {}
+
+
+class TestValidateSteamAppIds:
+    def _write_search_index(self, tmp_path: Path, rows):
+        (tmp_path / "search-index.json").write_text(
+            json.dumps(rows), encoding="utf-8"
+        )
+
+    def test_no_search_index_skips_gracefully(self, tmp_path: Path):
+        assert validate_steam_app_ids(str(tmp_path)) == {}
+        assert not (tmp_path / "app-id-redirects.json").exists()
+
+    def test_writes_only_problematic_entries_to_redirects_json(self, tmp_path: Path):
+        # Row shape from search-index.json: [app_id, title, ..., type (col 5), ...]
+        # Column 5 is the store type. "steam" rows are probed; others are skipped.
+        self._write_search_index(tmp_path, [
+            ["730", "Counter-Strike 2", 0, 0, 0, "steam"],
+            ["26670", "Old Game", 0, 0, 0, "steam"],
+            ["9999999", "Dead ID",     0, 0, 0, "steam"],
+            ["gog:123", "GOG Game",    0, 0, 0, "gog"],  # non-steam, skipped
+        ])
+
+        def fake_probe(app_id):
+            return {
+                "730":     {"status": "valid"},
+                "26670":   {"status": "replaced", "replaced_by": "22670",
+                            "final_url": "https://store.steampowered.com/app/22670/"},
+                "9999999": {"status": "dead",
+                            "final_url": "https://store.steampowered.com/"},
+            }[app_id]
+
+        with patch("scripts.pipeline.validate_app_ids._follow_redirects", side_effect=fake_probe), \
+             patch("scripts.pipeline.validate_app_ids.time.sleep"):
+            redirects = validate_steam_app_ids(str(tmp_path))
+
+        # Valid entries are omitted from the output.
+        assert "730" not in redirects
+        assert redirects["26670"]["status"] == "replaced"
+        assert redirects["26670"]["replaced_by"] == "22670"
+        assert redirects["9999999"]["status"] == "dead"
+
+        on_disk = json.loads((tmp_path / "app-id-redirects.json").read_text())
+        assert on_disk == redirects
+
+    def test_fresh_cache_entries_are_not_reprobed(self, tmp_path: Path):
+        self._write_search_index(tmp_path, [
+            ["730", "CS2", 0, 0, 0, "steam"],
+        ])
+        # Prime cache with a fresh valid entry.
+        _save_cache(tmp_path, {
+            "730": {"status": "valid", "probed_at": date.today().isoformat()},
+        })
+
+        with patch("scripts.pipeline.validate_app_ids._follow_redirects") as probe, \
+             patch("scripts.pipeline.validate_app_ids.time.sleep"):
+            validate_steam_app_ids(str(tmp_path))
+
+        probe.assert_not_called()
+
+    def test_stale_cache_entries_are_reprobed(self, tmp_path: Path):
+        self._write_search_index(tmp_path, [
+            ["730", "CS2", 0, 0, 0, "steam"],
+        ])
+        old = (date.today() - timedelta(days=validate_module.STALE_DAYS + 5)).isoformat()
+        _save_cache(tmp_path, {
+            "730": {"status": "valid", "probed_at": old},
+        })
+
+        with patch(
+            "scripts.pipeline.validate_app_ids._follow_redirects",
+            return_value={"status": "valid"},
+        ) as probe, patch("scripts.pipeline.validate_app_ids.time.sleep"):
+            validate_steam_app_ids(str(tmp_path))
+
+        probe.assert_called_once_with("730")
+
+    def test_probe_cap_limits_a_single_run(self, tmp_path: Path):
+        rows = [[str(1000 + i), f"App {i}", 0, 0, 0, "steam"]
+                for i in range(validate_module.PROBE_CAP + 25)]
+        self._write_search_index(tmp_path, rows)
+
+        with patch(
+            "scripts.pipeline.validate_app_ids._follow_redirects",
+            return_value={"status": "valid"},
+        ) as probe, patch("scripts.pipeline.validate_app_ids.time.sleep"):
+            validate_steam_app_ids(str(tmp_path))
+
+        assert probe.call_count == validate_module.PROBE_CAP

--- a/tests/test_write_depot_files.py
+++ b/tests/test_write_depot_files.py
@@ -1,0 +1,116 @@
+"""Tests for scripts/pipeline/write_depot_files.py (#237)."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import scripts.pipeline.write_depot_files as wdf
+
+
+UPDATES = [
+    {"app_id": 367520, "os": "linux", "depot_id": 367521,
+     "name": "linux depot", "manifest_id": "1", "last_updated_at": "2026-03-27T00:00:00Z"},
+    {"app_id": 367520, "os": "windows", "depot_id": 367522,
+     "name": "win depot",  "manifest_id": "2", "last_updated_at": "2026-03-27T00:00:00Z"},
+]
+
+HISTORY = [
+    {"app_id": 367520, "os": "linux", "depot_id": 367521,
+     "manifest_id": "1", "first_observed_at": "2026-01-01T00:00:00Z",
+     "latest_observed_at": "2026-03-27T00:00:00Z"},
+    {"app_id": 367520, "os": "linux", "depot_id": 367521,
+     "manifest_id": "0", "first_observed_at": "2025-06-15T00:00:00Z",
+     "latest_observed_at": "2025-12-31T00:00:00Z"},
+    {"app_id": 367520, "os": "windows", "depot_id": 367522,
+     "manifest_id": "2", "first_observed_at": "2026-02-01T00:00:00Z",
+     "latest_observed_at": "2026-03-27T00:00:00Z"},
+]
+
+STATUS = [{
+    "app_id": 367520,
+    "app_status": "ok",
+    "depot_count": 2,
+    "fetched_at": "2026-03-27T09:00:00Z",
+    "error": None,
+    "raw_pics": {
+        "367521": {
+            "config": {"oslist": "linux"},
+            "manifests": {"public": {"gid": "1", "timeupdated": "1743033600"}},
+        },
+        "367522": {
+            "config": {"oslist": "windows"},
+            "manifests": {"public": {"gid": "2", "timeupdated": "1743033600"}},
+        },
+        "branches": {"public": {"buildid": "12345", "timeupdated": "1743033600"}},
+    },
+}]
+
+
+def _run_writer(tmp_path: Path) -> dict:
+    """Invoke the writer with mocked Supabase reads and return the emitted file."""
+    with patch.object(wdf, "_supabase_url", return_value="https://x"), \
+         patch.object(wdf, "_service_key", return_value="k"), \
+         patch.object(wdf, "_fetch_all", side_effect=[UPDATES, HISTORY, STATUS]):
+        n = wdf.write_depot_files(tmp_path)
+    assert n == 1
+    return json.loads((tmp_path / "367520" / "depots.json").read_text())
+
+
+class TestWriteDepotFiles:
+    def test_emits_one_file_per_steam_app(self, tmp_path: Path):
+        payload = _run_writer(tmp_path)
+        assert payload["app_id"] == 367520
+        assert payload["status"] == "ok"
+
+    def test_tracked_since_is_earliest_first_observed_at_per_os(self, tmp_path: Path):
+        payload = _run_writer(tmp_path)
+        # linux has two history rows; earliest wins.
+        assert payload["os"]["linux"]["tracked_since"] == "2025-06-15T00:00:00Z"
+        # windows only one history row.
+        assert payload["os"]["windows"]["tracked_since"] == "2026-02-01T00:00:00Z"
+
+    def test_last_updated_is_max_across_updates_for_that_os(self, tmp_path: Path):
+        payload = _run_writer(tmp_path)
+        assert payload["os"]["linux"]["last_updated"] == "2026-03-27T00:00:00Z"
+        assert payload["os"]["windows"]["last_updated"] == "2026-03-27T00:00:00Z"
+
+    def test_depot_count_unions_updates_and_history(self, tmp_path: Path):
+        payload = _run_writer(tmp_path)
+        # Depot ids are unique per OS in the fixtures -- linux=1, windows=1.
+        assert payload["os"]["linux"]["depots"] == 1
+        assert payload["os"]["windows"]["depots"] == 1
+
+    def test_manifests_array_carries_every_observation_row(self, tmp_path: Path):
+        payload = _run_writer(tmp_path)
+        linux_manifests = payload["os"]["linux"]["manifests"]
+        # Two rows in HISTORY for linux -> two entries.
+        assert len(linux_manifests) == 2
+        assert {m["manifest_id"] for m in linux_manifests} == {"0", "1"}
+
+    def test_raw_pics_is_persisted_verbatim(self, tmp_path: Path):
+        payload = _run_writer(tmp_path)
+        assert payload["raw_pics"]["branches"]["public"]["buildid"] == "12345"
+        assert payload["raw_pics"]["367521"]["config"]["oslist"] == "linux"
+
+    def test_missing_credentials_short_circuits(self, tmp_path: Path):
+        with patch.object(wdf, "_supabase_url", return_value=None):
+            assert wdf.write_depot_files(tmp_path) == 0
+        assert not any(tmp_path.iterdir())
+
+    def test_empty_supabase_writes_nothing(self, tmp_path: Path):
+        with patch.object(wdf, "_supabase_url", return_value="https://x"), \
+             patch.object(wdf, "_service_key", return_value="k"), \
+             patch.object(wdf, "_fetch_all", side_effect=[[], [], []]):
+            assert wdf.write_depot_files(tmp_path) == 0
+        assert not any(tmp_path.iterdir())
+
+    def test_app_with_only_history_still_emits(self, tmp_path: Path):
+        # Simulate an app we've observed but not yet current-updated.
+        with patch.object(wdf, "_supabase_url", return_value="https://x"), \
+             patch.object(wdf, "_service_key", return_value="k"), \
+             patch.object(wdf, "_fetch_all", side_effect=[[], HISTORY, []]):
+            n = wdf.write_depot_files(tmp_path)
+        assert n == 1
+        payload = json.loads((tmp_path / "367520" / "depots.json").read_text())
+        assert payload["os"]["linux"]["tracked_since"] == "2025-06-15T00:00:00Z"
+        assert payload["os"]["linux"]["last_updated"] is None

--- a/tests/workflowDispatchInputs.test.js
+++ b/tests/workflowDispatchInputs.test.js
@@ -1,0 +1,134 @@
+/**
+ * #218: standardized workflow_dispatch inputs across every dispatchable
+ * pipeline workflow so a single-issue fix can be spot-verified via a
+ * one-click dispatch that back-comments the result on the target issue.
+ *
+ * Contract:
+ *  - Every workflow with a `workflow_dispatch` trigger declares `issue_id`
+ *    and `dry_run` inputs.
+ *  - Every such workflow ends with a `back-comment-run` step so the target
+ *    issue gets a paper trail when the dispatch specified issue_id.
+ *  - The shared composite action lives at `.github/actions/back-comment-run/`
+ *    so all workflows call it via `uses: ./.github/actions/back-comment-run`.
+ *  - Workflows that write to Supabase / commit to gh-pages guard their write
+ *    steps behind `if: inputs.dry_run != true` so a preview dispatch reads
+ *    but never mutates.
+ */
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const ROOT = path.join(__dirname, '..');
+const WORKFLOWS_DIR = path.join(ROOT, '.github', 'workflows');
+
+// Workflows where standardization applies. Deploy/webhook/CI helpers that
+// exist purely to reflect other events (retry-pages-build, discord-*,
+// sync-staging-main, deploy-on-merge) don't take app_id / issue_id inputs and
+// wouldn't benefit from the back-comment -- explicitly excluded so this test
+// doesn't false-positive on infrastructure workflows.
+const PIPELINE_WORKFLOWS = [
+  'update-data.yml',
+  'steam-metadata-fetch.yml',
+  'content-moderation.yml',
+  'backup.yml',
+  'update-epic-catalog.yml',
+  'update-gog-catalog.yml',
+];
+
+function loadWorkflow(name) {
+  return yaml.load(fs.readFileSync(path.join(WORKFLOWS_DIR, name), 'utf8'));
+}
+
+describe('#218: shared back-comment-run composite action', () => {
+  const action = yaml.load(fs.readFileSync(
+    path.join(ROOT, '.github', 'actions', 'back-comment-run', 'action.yml'),
+    'utf8',
+  ));
+
+  test('declares issue_id, status, workflow_name, app_ids, dry_run inputs', () => {
+    expect(action.inputs).toBeDefined();
+    for (const key of ['issue_id', 'status', 'workflow_name', 'app_ids', 'dry_run']) {
+      expect(action.inputs[key]).toBeDefined();
+    }
+  });
+
+  test('is a composite action (not a JS/Docker action)', () => {
+    expect(action.runs.using).toBe('composite');
+  });
+
+  test('no-ops when issue_id is empty so unconditional callers are safe', () => {
+    const step = action.runs.steps.find((s) => s.if && s.if.includes('issue_id'));
+    expect(step).toBeDefined();
+    expect(step.if).toContain("inputs.issue_id != ''");
+  });
+});
+
+describe.each(PIPELINE_WORKFLOWS)('#218: %s standardization', (fileName) => {
+  const wf = loadWorkflow(fileName);
+  // 'on' can be a string or object; workflow_dispatch definition lives under
+  // wf.on.workflow_dispatch when present. YAML parses `on:` as `true` in some
+  // parser versions (bool-yes), so accept either key.
+  const onBlock = wf.on || wf.true;
+  const dispatch = onBlock && onBlock.workflow_dispatch;
+
+  test('has a workflow_dispatch trigger', () => {
+    expect(dispatch).toBeDefined();
+  });
+
+  test('declares issue_id + dry_run inputs (standard #218 shape)', () => {
+    expect(dispatch.inputs).toBeDefined();
+    expect(dispatch.inputs.issue_id).toBeDefined();
+    expect(dispatch.inputs.dry_run).toBeDefined();
+    expect(dispatch.inputs.dry_run.type).toBe('boolean');
+  });
+
+  test('calls the shared back-comment-run composite action at the end of a job', () => {
+    const allSteps = Object.values(wf.jobs).flatMap((j) => j.steps || []);
+    const backComment = allSteps.find(
+      (s) => s.uses && s.uses.includes('.github/actions/back-comment-run'),
+    );
+    expect(backComment).toBeDefined();
+    // Runs on always() so a failed job still posts the summary before the
+    // fail step flips the run red.
+    expect(backComment.if).toContain('always()');
+    // Passes issue_id + status + workflow_name at minimum.
+    expect(backComment.with).toBeDefined();
+    expect(backComment.with.issue_id).toBeDefined();
+    expect(backComment.with.status).toBeDefined();
+    expect(backComment.with.workflow_name).toBeTruthy();
+  });
+
+  test('the job that calls back-comment-run grants issues:write permission', () => {
+    // Without this, gh CLI 403s and the composite action can't post.
+    const jobsWithBackComment = Object.values(wf.jobs).filter((j) =>
+      (j.steps || []).some((s) => s.uses && s.uses.includes('.github/actions/back-comment-run')),
+    );
+    for (const job of jobsWithBackComment) {
+      const perms = job.permissions;
+      // permissions can be 'read-all', 'write-all', or an object -- accept
+      // any shape that lets `issues: write` through.
+      expect(perms).toBeDefined();
+      if (typeof perms === 'object') {
+        expect(perms.issues).toBe('write');
+      }
+    }
+  });
+});
+
+describe('#218: content-moderation standardized on plural app_ids', () => {
+  const wf = loadWorkflow('content-moderation.yml');
+  const dispatch = (wf.on || wf.true).workflow_dispatch;
+
+  test('input is app_ids (plural), not the legacy app_id (singular)', () => {
+    expect(dispatch.inputs.app_ids).toBeDefined();
+    expect(dispatch.inputs.app_id).toBeUndefined();
+  });
+
+  test('passes APP_IDS env to the moderation script', () => {
+    const scriptStep = wf.jobs.moderate.steps.find(
+      (s) => s.name && s.name.toLowerCase().includes('moderation'),
+    );
+    expect(scriptStep).toBeDefined();
+    expect(scriptStep.env.APP_IDS).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

- **#219** ProtonDB tier aggregates always visible: auto-fetch summary, use `MAX(mirror, live total)` for the effective count, one-line "ProtonDB rating + N reports" note above the 5-bar stack, stats page now surfaces a live-summary block when no mirror reports exist.
- **Runtime Type rename**: submit form label "Run type" -> "Runtime Type"; Runtime Version field moved to sit directly under it. Same rename in the game-page filter modal and stats-page dimension label.
- **Validator loosening**: proton pattern now accepts Experimental / Next / Hotfix; proton-ge accepts alphanumeric suffixes (rc1, beta); proton-experimental / proton-cachyos / proton-tkg accept bare "Experimental" / "CachyOS" / "TKG". False-positive warnings gone.
- **#221** Steam library API Explorer: three keyed Steam Web API endpoints (GetOwnedGames, GetRecentlyPlayedGames, ResolveVanityURL) added to the Explorer, gated on `manage_admins`. New `steam-library-lookup` edge fn verifies JWT + permission before attaching STEAM_WEB_API_KEY, redacts the key from the response envelope.

All 1518 tests pass. Verified on https://mdeguzis.github.io/proton-pulse-web-staging/ at `v1.5.0 · fa4d754`.

## Test plan

- [ ] Hollow Knight (367520) game page shows the ProtonDB rating + count note above the 5-bar stack
- [ ] Submit form shows "Runtime Type *" with the Runtime Version field directly below
- [ ] Typing "Proton Experimental" under Run type=Proton does NOT show the validator warning
- [ ] Signed-in admin with manage_admins sees the three new keyed endpoints in the Steam tab of API Explorer
- [ ] Signed-in admin WITHOUT manage_admins does not see them
- [ ] After setting STEAM_WEB_API_KEY as a Supabase secret, GetOwnedGames returns a library

Once merged, run `make gh-pages-only` to deploy to prod.

Closes #219, closes #221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)