### PR TITLE
Promote staging: v1.6.0 bump + security scan workflow

### DIFF
--- a/.github/scripts/scan-attachments-lib.mjs
+++ b/.github/scripts/scan-attachments-lib.mjs
@@ -1,0 +1,58 @@
+// Pure helpers for scan-attachments.mjs (#228). Split out so the tests can
+// import them without hitting `import.meta.url` (which babel-jest cannot
+// transform for a CJS-loaded test file). Zero side effects, no I/O.
+
+// Attachment URLs GitHub renders inline. `objects.githubusercontent.com`
+// is the CDN backing github.com/user-attachments/ redirects.
+export const ATTACHMENT_URL_RE =
+  /https?:\/\/(?:github\.com\/user-attachments|(?:private-)?user-images\.githubusercontent\.com|objects\.githubusercontent\.com)\/\S+/gi;
+
+// Extensions we treat as inherently high-risk when uploaded by a non-owner.
+// A hit here alone is enough to hide the comment (VT lookup is a bonus).
+export const EXECUTABLE_EXTENSIONS = new Set([
+  'exe', 'msi', 'scr', 'com', 'bat', 'cmd',
+  'ps1', 'psm1', 'vbs', 'vbe', 'wsf', 'wsh',
+  'jar', 'apk', 'dmg', 'pkg', 'appimage',
+  'sh', 'bin', 'run',                     // linux native binaries + install scripts
+  'iso', 'img',                           // large payload wrappers
+]);
+
+/** Extract every attachment URL from a body of text. */
+export function extractAttachmentUrls(body) {
+  if (!body || typeof body !== 'string') return [];
+  const raw = body.match(ATTACHMENT_URL_RE) || [];
+  // Strip trailing ')' or '.' from markdown wrapping.
+  return [...new Set(raw.map((u) => u.replace(/[)\].,]+$/g, '')))];
+}
+
+/** Best-effort extension pull from a URL or a filename. Returns lowercase. */
+export function extensionOf(urlOrName) {
+  const s = String(urlOrName || '').toLowerCase();
+  // Ignore query strings + fragments.
+  const clean = s.split(/[?#]/)[0];
+  const m = clean.match(/\.([a-z0-9]{1,10})$/);
+  return m ? m[1] : '';
+}
+
+/** Would we hide this attachment on extension alone? */
+export function isSuspiciousExtension(ext) {
+  return EXECUTABLE_EXTENSIONS.has(String(ext || '').toLowerCase());
+}
+
+/**
+ * Map a VirusTotal /files/{hash} response to a { known, malicious, suspicious, engines } tuple.
+ * The public v3 shape:
+ *   { data: { attributes: { last_analysis_stats: { malicious, suspicious, ... } } } }
+ * A single malicious engine hit is enough to escalate -- false positives on
+ * Windows PE binaries are rare in aggregate and the hide is reversible.
+ */
+export function summarizeVirusTotal(response) {
+  const stats = response?.data?.attributes?.last_analysis_stats;
+  if (!stats) return { known: false, malicious: 0, suspicious: 0, engines: 0 };
+  const malicious = Number(stats.malicious || 0);
+  const suspicious = Number(stats.suspicious || 0);
+  const engines = malicious + suspicious + Number(stats.undetected || 0)
+                + Number(stats.harmless || 0) + Number(stats.timeout || 0)
+                + Number(stats.failure || 0);
+  return { known: true, malicious, suspicious, engines };
+}

--- a/.github/scripts/scan-attachments.mjs
+++ b/.github/scripts/scan-attachments.mjs
@@ -1,0 +1,282 @@
+#!/usr/bin/env node
+/**
+ * Scan issue / PR-comment attachments for malware (#228).
+ *
+ * Called by .github/workflows/scan-issue-attachments.yml. Reads the event
+ * payload from $GITHUB_EVENT_PATH, extracts every user-attachment URL
+ * from the body, HEADs and hashes any that look suspicious, then queries
+ * VirusTotal by SHA256. On a hit (or on a plain executable extension from
+ * a non-owner), hides the comment via GraphQL minimizeComment, applies
+ * the `security-review` label, and pings the repo owner.
+ *
+ * Env:
+ *   GH_TOKEN          - workflow-scoped token (issues:write)
+ *   GITHUB_EVENT_NAME - issues | issue_comment | pull_request_review_comment
+ *   GITHUB_EVENT_PATH - path to the JSON event payload (github-provided)
+ *   VT_API_KEY        - optional; when unset we fall back to extension-only policy
+ *   REPO_OWNER        - github.repository_owner (used for owner-exempt check)
+ *   REPO_NAME         - github.event.repository.name
+ *
+ * Never uploads content anywhere. Only sends SHA256s to VirusTotal.
+ */
+
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+
+import {
+  extractAttachmentUrls,
+  extensionOf,
+  isSuspiciousExtension,
+  summarizeVirusTotal,
+} from './scan-attachments-lib.mjs';
+
+// Cap attachment download size. Even the wapebacoko sample was 2.9 MB;
+// legitimate report screenshots are <2 MB. 16 MB is a generous ceiling
+// that still fits GitHub Actions memory comfortably.
+const MAX_DOWNLOAD_BYTES = 16 * 1024 * 1024;
+
+const HIDE_CLASSIFIER = 'ABUSE'; // GraphQL minimizeComment classifier
+const REVIEW_LABEL   = 'security-review';
+
+// ----- Runtime helpers (require env / GitHub API) -----
+
+async function ghApi(path, init = {}) {
+  const res = await fetch(`https://api.github.com${path}`, {
+    ...init,
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${process.env.GH_TOKEN}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+      ...(init.headers || {}),
+    },
+  });
+  if (!res.ok) {
+    const txt = await res.text().catch(() => '');
+    throw new Error(`GH ${init.method || 'GET'} ${path} -> ${res.status}: ${txt.slice(0, 400)}`);
+  }
+  return res.json().catch(() => ({}));
+}
+
+async function ghGraphQL(query, variables) {
+  const res = await fetch('https://api.github.com/graphql', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.GH_TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  const body = await res.json();
+  if (body.errors) throw new Error(`GraphQL: ${JSON.stringify(body.errors).slice(0, 400)}`);
+  return body.data;
+}
+
+async function ensureLabel(owner, name, label) {
+  try {
+    await ghApi(`/repos/${owner}/${name}/labels/${encodeURIComponent(label)}`);
+    return;
+  } catch { /* fall through to create */ }
+  try {
+    await ghApi(`/repos/${owner}/${name}/labels`, {
+      method: 'POST',
+      body: JSON.stringify({
+        name: label,
+        color: 'b60205',
+        description: 'Comment / attachment flagged by scan-issue-attachments (#228)',
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (e) { console.warn(`ensureLabel: ${e.message}`); }
+}
+
+async function applyLabelToIssue(owner, name, issueNumber, label) {
+  await ghApi(`/repos/${owner}/${name}/issues/${issueNumber}/labels`, {
+    method: 'POST',
+    body: JSON.stringify({ labels: [label] }),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+async function hideCommentByNodeId(nodeId) {
+  await ghGraphQL(
+    `mutation($id: ID!, $classifier: ReportedContentClassifiers!) {
+       minimizeComment(input: { subjectId: $id, classifier: $classifier }) {
+         minimizedComment { isMinimized }
+       }
+     }`,
+    { id: nodeId, classifier: HIDE_CLASSIFIER },
+  );
+}
+
+async function postSummary(owner, name, issueNumber, summary) {
+  await ghApi(`/repos/${owner}/${name}/issues/${issueNumber}/comments`, {
+    method: 'POST',
+    body: JSON.stringify({ body: summary }),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+async function fetchAttachmentHash(url) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 20000);
+  try {
+    const head = await fetch(url, { method: 'HEAD', redirect: 'follow', signal: controller.signal });
+    const size = Number(head.headers.get('content-length') || 0);
+    if (size && size > MAX_DOWNLOAD_BYTES) {
+      return { skipped: true, reason: `size ${size} exceeds cap` };
+    }
+    const full = await fetch(url, { redirect: 'follow', signal: controller.signal });
+    const buf = Buffer.from(await full.arrayBuffer());
+    if (buf.length > MAX_DOWNLOAD_BYTES) return { skipped: true, reason: 'runtime size cap' };
+    const sha256 = crypto.createHash('sha256').update(buf).digest('hex');
+    // Sniff the file magic so a `.png` masquerading a PE gets caught too.
+    // MZ header (Windows PE) is the only signature we lock down today; expand
+    // to ELF / Mach-O when we see attempts in those formats.
+    const magic = buf.slice(0, 2).toString('binary');
+    return { sha256, size: buf.length, isPeMagic: magic === 'MZ' };
+  } catch (e) {
+    return { skipped: true, reason: `network: ${e.message}` };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function lookupVirusTotal(sha256) {
+  const key = process.env.VT_API_KEY;
+  if (!key) return { unavailable: true };
+  try {
+    const res = await fetch(`https://www.virustotal.com/api/v3/files/${sha256}`, {
+      headers: { 'x-apikey': key },
+    });
+    if (res.status === 404) return { known: false };
+    if (!res.ok) return { unavailable: true, reason: `HTTP ${res.status}` };
+    return summarizeVirusTotal(await res.json());
+  } catch (e) {
+    return { unavailable: true, reason: e.message };
+  }
+}
+
+// ----- Event routing -----
+
+async function extractContext() {
+  const payload = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
+  const eventName = process.env.GITHUB_EVENT_NAME;
+  const repo = payload.repository;
+  const author = payload.sender?.login;
+  let body = '';
+  let issueNumber = 0;
+  let commentNodeId = null;
+
+  if (eventName === 'issues') {
+    body = payload.issue?.body || '';
+    issueNumber = payload.issue?.number;
+  } else if (eventName === 'issue_comment') {
+    body = payload.comment?.body || '';
+    issueNumber = payload.issue?.number;
+    commentNodeId = payload.comment?.node_id;
+  } else if (eventName === 'pull_request_review_comment') {
+    body = payload.comment?.body || '';
+    issueNumber = payload.pull_request?.number;
+    commentNodeId = payload.comment?.node_id;
+  }
+
+  return {
+    eventName, body, author, issueNumber, commentNodeId,
+    owner: repo?.owner?.login,
+    name: repo?.name,
+  };
+}
+
+async function main() {
+  const ctx = await extractContext();
+  if (!ctx.issueNumber || !ctx.body) {
+    console.log('scan-attachments: no body / issue context, nothing to do');
+    return;
+  }
+
+  const urls = extractAttachmentUrls(ctx.body);
+  if (urls.length === 0) {
+    console.log('scan-attachments: no attachment URLs in body');
+    return;
+  }
+
+  console.log(`scan-attachments: found ${urls.length} attachment(s) source=body author=${ctx.author}`);
+
+  const findings = [];
+  for (const url of urls) {
+    const ext = extensionOf(url);
+    const suspiciousExt = isSuspiciousExtension(ext);
+    let hash = null;
+    let vt = null;
+    let peMagic = false;
+
+    // Hash + VT lookup even for benign-extension files if VT is available.
+    // A masqueraded .png that carries an MZ header will still get flagged.
+    const meta = await fetchAttachmentHash(url);
+    if (!meta.skipped) {
+      hash = meta.sha256;
+      peMagic = meta.isPeMagic;
+      vt = await lookupVirusTotal(meta.sha256);
+    }
+
+    const flagged =
+      suspiciousExt ||
+      peMagic ||
+      (vt && vt.known && vt.malicious > 0);
+    findings.push({ url, ext, suspiciousExt, hash, peMagic, vt, flagged });
+  }
+
+  const flagged = findings.filter((f) => f.flagged);
+  if (flagged.length === 0) {
+    console.log('scan-attachments: no findings flagged');
+    return;
+  }
+
+  // Hide the offending comment (issue_comment / PR review comment only) and
+  // label the parent issue. Owner's own posts are already exempt via the
+  // workflow `if:` -- this is a belt-and-braces check.
+  if (ctx.commentNodeId && ctx.author !== ctx.owner) {
+    try { await hideCommentByNodeId(ctx.commentNodeId); }
+    catch (e) { console.warn(`hide failed: ${e.message}`); }
+  }
+
+  await ensureLabel(ctx.owner, ctx.name, REVIEW_LABEL);
+  try { await applyLabelToIssue(ctx.owner, ctx.name, ctx.issueNumber, REVIEW_LABEL); }
+  catch (e) { console.warn(`label failed: ${e.message}`); }
+
+  const lines = flagged.map((f) => {
+    const bits = [];
+    if (f.suspiciousExt) bits.push(`suspicious ext .${f.ext}`);
+    if (f.peMagic) bits.push('Windows PE header');
+    if (f.vt?.known && f.vt.malicious > 0) {
+      bits.push(`VirusTotal flagged (${f.vt.malicious}/${f.vt.engines} engines)`);
+    } else if (f.vt?.unavailable) {
+      bits.push('VirusTotal unavailable');
+    }
+    return `- ${f.url} (${bits.join(', ')})${f.hash ? ` \`sha256:${f.hash}\`` : ''}`;
+  }).join('\n');
+
+  const summary = [
+    `Attachment scanner flagged this post -- hidden pending review.`,
+    ``,
+    `Author: @${ctx.author}`,
+    `Event: ${ctx.eventName}`,
+    `Findings:`,
+    lines,
+    ``,
+    `If this is a false positive, unhide via the comment menu and remove the` +
+    ` \`${REVIEW_LABEL}\` label. See \`Security-Guardrails\` in the wiki for` +
+    ` the policy and how to expand the allowlist.`,
+    ``,
+    `cc @${ctx.owner}`,
+  ].join('\n');
+
+  await postSummary(ctx.owner, ctx.name, ctx.issueNumber, summary);
+  console.log(`scan-attachments: hid comment + labeled + pinged @${ctx.owner} findings=${flagged.length} source=scan-issue-attachments`);
+}
+
+// Only run when the script is invoked directly (skip during unit tests).
+const isDirectRun = import.meta.url === `file://${process.argv[1]}`;
+if (isDirectRun) {
+  main().catch((e) => { console.error(e); process.exit(1); });
+}

--- a/.github/workflows/scan-issue-attachments.yml
+++ b/.github/workflows/scan-issue-attachments.yml
@@ -1,0 +1,62 @@
+name: Scan issue attachments
+
+# Passive guardrail against malicious attachments in issues + PR comments.
+# Triggered by #228 -- see wiki/Security-Guardrails for the rationale.
+#
+# What it does per event:
+#   1. Extract every user-attachment URL from the body.
+#   2. Extract every suspicious file extension mentioned inline.
+#   3. HEAD each attachment. If the size is under the cap, hash the bytes.
+#   4. Look up the SHA256 in VirusTotal (hash-only, no upload).
+#   5. Apply a policy: hide the comment via minimizeComment + label
+#      `security-review` if VT flags it OR the attachment ends in a known
+#      executable extension AND the author isn't the repo owner.
+#   6. Ping the repo owner on the issue with a summary so they can decide.
+#
+# Non-goals:
+#   - We never download and never execute anything for "analysis".
+#   - We never upload private issue content to VirusTotal -- only the hash.
+#   - The owner's own attachments are always left alone (avoid self-blocks).
+
+on:
+  issues:
+    types: [opened, edited]
+  issue_comment:
+    types: [created, edited]
+  pull_request_review_comment:
+    types: [created, edited]
+
+permissions:
+  # Needed to hide comments, add labels, and post an admin ping.
+  issues: write
+  pull-requests: write
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    # Skip bot-authored events and the repo owner's own posts. The owner
+    # audits their own attachments; this workflow is for everyone else.
+    if: >-
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'github-actions[bot]' &&
+      github.actor != github.repository_owner
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Run attachment scanner
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          # VirusTotal free tier: 500 lookups/day. Optional -- when unset the
+          # scanner falls back to extension-only policy (still blocks .exe /
+          # .msi / .scr / .ps1 etc. from non-owners).
+          VT_API_KEY: ${{ secrets.VT_API_KEY }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: node .github/scripts/scan-attachments.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Proton Pulse (web) should be recorded here.
 
+## v1.6.0
+
+- My Library view: deep-linking from the profile "View my games" now lands on a clearly labeled My Library page. Every owned Steam appid appears, not just games that intersect with recent reports (was capped at ~12 to ~65 on real libraries)
+- Numbered pagination on the browse grid with Prev/Next arrows, a "Page X of Y" label, and a bottom-of-grid mirror so long lists do not require scrolling back up to turn a page
+- Sort dropdown gains A-Z and Z-A options with locale-aware base-sensitivity comparison
+- Search input gets a clear (X) button and a placeholder that matches actual behavior (searches all titles, not only visible ones)
+- Card tier strip anchors to the card bottom edge so entries with no reports subtitle line up with rated neighbors
+- About page report-approval copy corrected: a daily pipeline auto-approves clean reports and admins can approve on demand, edits re-enter the same flow
+- Admin analytics "most viewed games" links now work on staging (were hardcoded to the domain root)
+- Fix: click handlers on numbered pagination were stacking on every filter change so a click could fire ten times after enough re-renders
+
 ## v1.5.0
 
 - Card layout: a new bottom-bar tier strip is the site default, with the store badge sitting next to the rating as a brand-colored pill or round logo (Steam, GOG, Epic). Five placement options for the store badge (right, artwork, card corner, on bar next to rating, on bar split) and a separate text-or-icon display toggle

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.5.0",
+  "version": "1.6.0",
   "scripts": {
     "test": "jest",
     "dev": "vite --host --port 5173",

--- a/tests/scanAttachments.test.js
+++ b/tests/scanAttachments.test.js
@@ -1,0 +1,176 @@
+/**
+ * #228: scan-issue-attachments.yml + its scanner (.github/scripts/scan-attachments.mjs).
+ * Pins the pure helper contracts + guards against regressions in URL extraction,
+ * extension policy, and VirusTotal response parsing. The workflow YAML has its
+ * own static tests so a future edit can't silently drop the permission or
+ * trigger blocks that the guardrail depends on.
+ */
+const fs = require('fs');
+const path = require('path');
+
+let extractAttachmentUrls, extensionOf, isSuspiciousExtension, summarizeVirusTotal, EXECUTABLE_EXTENSIONS;
+
+beforeAll(async () => {
+  // Pure helpers live in a side-effect-free lib (no import.meta), so babel-jest
+  // can transform them cleanly for a CommonJS test runner.
+  const mod = await import(path.join(__dirname, '..', '.github', 'scripts', 'scan-attachments-lib.mjs'));
+  ({ extractAttachmentUrls, extensionOf, isSuspiciousExtension, summarizeVirusTotal, EXECUTABLE_EXTENSIONS } = mod);
+});
+
+describe('extractAttachmentUrls', () => {
+  test('finds github user-attachment URLs in a plain body', () => {
+    const body = 'here is the file: https://github.com/user-attachments/files/12345/thing.exe';
+    expect(extractAttachmentUrls(body)).toEqual([
+      'https://github.com/user-attachments/files/12345/thing.exe',
+    ]);
+  });
+
+  test('finds githubusercontent image URLs', () => {
+    const body = '![](https://user-images.githubusercontent.com/1/2.png)';
+    expect(extractAttachmentUrls(body)).toEqual([
+      'https://user-images.githubusercontent.com/1/2.png',
+    ]);
+  });
+
+  test('finds private-user-images URLs (CDN redirect target)', () => {
+    const body = 'redirected: https://private-user-images.githubusercontent.com/abc/def.png?jwt=xxx';
+    expect(extractAttachmentUrls(body)).toContain(
+      'https://private-user-images.githubusercontent.com/abc/def.png?jwt=xxx'
+    );
+  });
+
+  test('strips trailing markdown punctuation', () => {
+    // GitHub renders attachments inside parens like [file](url)
+    const body = 'see [my file](https://github.com/user-attachments/files/1/x.exe).';
+    expect(extractAttachmentUrls(body)).toEqual([
+      'https://github.com/user-attachments/files/1/x.exe',
+    ]);
+  });
+
+  test('dedupes repeated URLs so the scanner does not double-hash', () => {
+    const body = [
+      'https://github.com/user-attachments/files/1/dup.exe',
+      'https://github.com/user-attachments/files/1/dup.exe',
+    ].join('\n');
+    expect(extractAttachmentUrls(body)).toEqual([
+      'https://github.com/user-attachments/files/1/dup.exe',
+    ]);
+  });
+
+  test('returns [] for empty / non-string bodies without throwing', () => {
+    expect(extractAttachmentUrls('')).toEqual([]);
+    expect(extractAttachmentUrls(null)).toEqual([]);
+    expect(extractAttachmentUrls(undefined)).toEqual([]);
+    expect(extractAttachmentUrls(1234)).toEqual([]);
+  });
+
+  test('ignores non-github URLs', () => {
+    const body = 'my blog https://example.com/thing.exe and pastebin http://pastebin.com/x';
+    expect(extractAttachmentUrls(body)).toEqual([]);
+  });
+});
+
+describe('extensionOf', () => {
+  test('pulls the trailing extension', () => {
+    expect(extensionOf('https://x/y.exe')).toBe('exe');
+    expect(extensionOf('foo.tar.gz')).toBe('gz');
+    expect(extensionOf('BIG.PNG')).toBe('png');
+  });
+
+  test('ignores query strings + fragments', () => {
+    expect(extensionOf('https://x/y.msi?jwt=abc')).toBe('msi');
+    expect(extensionOf('https://x/y.msi#frag')).toBe('msi');
+  });
+
+  test('returns empty string when there is no extension', () => {
+    expect(extensionOf('https://x/y')).toBe('');
+    expect(extensionOf('')).toBe('');
+    expect(extensionOf(null)).toBe('');
+  });
+});
+
+describe('isSuspiciousExtension', () => {
+  test('flags the classic Windows executable set', () => {
+    for (const ext of ['exe', 'msi', 'scr', 'com', 'bat', 'cmd', 'ps1', 'vbs']) {
+      expect(isSuspiciousExtension(ext)).toBe(true);
+    }
+  });
+
+  test('flags cross-platform payload wrappers', () => {
+    for (const ext of ['jar', 'apk', 'dmg', 'pkg', 'appimage', 'sh', 'iso']) {
+      expect(isSuspiciousExtension(ext)).toBe(true);
+    }
+  });
+
+  test('leaves images / docs / archives alone by default', () => {
+    for (const ext of ['png', 'jpg', 'gif', 'pdf', 'txt', 'md', 'zip']) {
+      expect(isSuspiciousExtension(ext)).toBe(false);
+    }
+  });
+
+  test('is case-insensitive', () => {
+    expect(isSuspiciousExtension('EXE')).toBe(true);
+    expect(isSuspiciousExtension('Msi')).toBe(true);
+  });
+});
+
+describe('summarizeVirusTotal', () => {
+  test('extracts malicious + engine counts from v3 shape', () => {
+    const resp = {
+      data: { attributes: { last_analysis_stats: {
+        malicious: 12, suspicious: 3, undetected: 55, harmless: 0, timeout: 0, failure: 0,
+      } } },
+    };
+    const s = summarizeVirusTotal(resp);
+    expect(s).toEqual({ known: true, malicious: 12, suspicious: 3, engines: 70 });
+  });
+
+  test('handles unknown hashes (missing attributes)', () => {
+    expect(summarizeVirusTotal({})).toEqual({ known: false, malicious: 0, suspicious: 0, engines: 0 });
+    expect(summarizeVirusTotal(null)).toEqual({ known: false, malicious: 0, suspicious: 0, engines: 0 });
+  });
+
+  test('tolerates missing counters', () => {
+    const resp = { data: { attributes: { last_analysis_stats: { malicious: 1 } } } };
+    expect(summarizeVirusTotal(resp).malicious).toBe(1);
+    expect(summarizeVirusTotal(resp).engines).toBe(1);
+  });
+});
+
+describe('EXECUTABLE_EXTENSIONS invariants', () => {
+  test('is a non-trivial set (guards against accidental empty)', () => {
+    expect(EXECUTABLE_EXTENSIONS.size).toBeGreaterThanOrEqual(15);
+  });
+});
+
+describe('workflow YAML', () => {
+  const yamlPath = path.join(__dirname, '..', '.github', 'workflows', 'scan-issue-attachments.yml');
+  const src = fs.readFileSync(yamlPath, 'utf8');
+
+  test('fires on the three body-carrying event types', () => {
+    // Removing any of these breaks the guardrail silently.
+    expect(src).toMatch(/on:\s*[\s\S]*?issues:\s*\n\s*types: \[opened, edited\]/);
+    expect(src).toMatch(/issue_comment:\s*\n\s*types: \[created, edited\]/);
+    expect(src).toMatch(/pull_request_review_comment:\s*\n\s*types: \[created, edited\]/);
+  });
+
+  test('grants issues + PR write so hide + label + comment succeed', () => {
+    expect(src).toContain('issues: write');
+    expect(src).toContain('pull-requests: write');
+  });
+
+  test('exempts the repo owner + known bots from scanning', () => {
+    expect(src).toContain("github.actor != github.repository_owner");
+    expect(src).toContain("github.actor != 'dependabot[bot]'");
+    expect(src).toContain("github.actor != 'github-actions[bot]'");
+  });
+
+  test('threads VT_API_KEY through to the script env', () => {
+    // Optional secret -- when unset the scanner falls back to extension policy.
+    expect(src).toContain('VT_API_KEY: ${{ secrets.VT_API_KEY }}');
+  });
+
+  test('invokes the scanner via node .github/scripts/scan-attachments.mjs', () => {
+    expect(src).toContain('node .github/scripts/scan-attachments.mjs');
+  });
+});


### PR DESCRIPTION
Follow-up promotion. Two things ahead of main after #248 merged:

- Version bump to 1.6.0 with a CHANGELOG entry for the My Library + windowed pagination cut. This should have ridden with #248 but I bumped the version after the merge, so it landed on staging alone.
- Security guardrails workflow that scans issue and PR-comment attachments for malware (closes #228). Ran through its own review on staging.

Test plan:
- [ ] About page reads v1.6.0 after prod deploy.