### PR TITLE
feat: security batch + public Steam profile lookup + about reframe + admin polish

### DIFF
--- a/.github/workflows/restore-drill-reminder.yml
+++ b/.github/workflows/restore-drill-reminder.yml
@@ -1,0 +1,73 @@
+name: Quarterly restore drill reminder
+
+# Backup that has never been restored is hope, not recovery. Every 90
+# days, open a fresh drill-checklist issue so the runbook stays proven.
+# Closing the issue records the drill outcome on the log.
+#
+# The runbook itself lives at
+# https://github.com/mdeguzis/proton-pulse-web/wiki/Restore-Runbook
+#
+# Issue: #322
+
+on:
+  schedule:
+    - cron: "0 15 1 1,4,7,10 *"  # 1st of Jan/Apr/Jul/Oct at 15:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  open-drill-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create drill-checklist issue
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const now = new Date();
+            const quarter = Math.floor(now.getUTCMonth() / 3) + 1;
+            const year = now.getUTCFullYear();
+            const title = `Restore drill Q${quarter} ${year}`;
+
+            // Skip if an open drill issue for this quarter already exists.
+            // Manual workflow_dispatch runs still hit this; the label +
+            // title match makes it idempotent.
+            const existing = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open label:restore-drill "${title}" in:title`,
+            });
+            if (existing.data.total_count > 0) {
+              core.info(`Drill issue already open: ${existing.data.items[0].html_url}`);
+              return;
+            }
+
+            const body = [
+              `Quarterly restore drill for Q${quarter} ${year}. Untested backups are hope, not recovery -- run this against a scratch Supabase project and confirm every step in Restore-Runbook.md still works.`,
+              ``,
+              `Full runbook: https://github.com/${context.repo.owner}/${context.repo.repo}/wiki/Restore-Runbook`,
+              ``,
+              `Checklist:`,
+              ``,
+              `- [ ] Pull the latest backup tarball from \`mdeguzis/proton-pulse-data-backup\``,
+              `- [ ] Verify HMAC signature against \`BACKUP_HMAC_SECRET\``,
+              `- [ ] Spin a scratch Supabase project (free tier is fine)`,
+              `- [ ] Restore schema + data per Restore-Runbook.md Phase 2`,
+              `- [ ] Deploy every edge function per Phase 2`,
+              `- [ ] Run \`tests/rls/*\` (once #318 lands) against the scratch project`,
+              `- [ ] Confirm \`/status.html\` on a scratch site shows every edge function green`,
+              `- [ ] Note any step that failed or was undocumented; open a follow-up to fix Restore-Runbook.md`,
+              `- [ ] Tear down the scratch project`,
+              ``,
+              `On close: comment with the drill outcome (pass / follow-ups filed / total time).`,
+            ].join('\n');
+
+            const issue = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['restore-drill', 'security'],
+            });
+            core.info(`Opened drill issue: ${issue.data.html_url}`);

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,75 @@
+name: SBOM + Vulnerability Scan
+
+# Generates a Software Bill of Materials per push using Syft, then scans
+# it against NVD + GitHub Security Advisories via Grype. Complements
+# npm audit (which only covers the npm advisory DB) by adding coverage
+# for bundled / transitive / CDN-loaded dependencies.
+#
+# The SBOM is uploaded as a workflow artifact so any tagged release can
+# attach it. GitHub also consumes CycloneDX SBOMs natively via the
+# dependency graph, so this feeds Dependabot with richer signal.
+#
+# Docs:
+#   Syft: https://github.com/anchore/syft
+#   Grype: https://github.com/anchore/grype
+# Issue: #317
+
+on:
+  push:
+    branches: [main, staging]
+  pull_request:
+    branches: [main, staging]
+  schedule:
+    - cron: "0 5 * * 1"  # Monday 05:00 UTC so weekly runs catch new CVEs
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sbom:
+    name: sbom + grype
+    runs-on: ubuntu-latest
+    if: (github.actor != 'dependabot[bot]')
+    steps:
+      - uses: actions/checkout@v4
+
+      # Install deps so Syft sees the full dependency tree, not just the
+      # root package.json declarations. Without this the SBOM misses
+      # transitive packages we actually ship.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - run: pnpm install --frozen-lockfile
+
+      # Syft emits CycloneDX JSON so both Grype and GitHub's dependency
+      # graph can consume it. Package the whole checkout so bundled
+      # assets + workflow files land in the SBOM too.
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          format: cyclonedx-json
+          output-file: sbom.cyclonedx.json
+          artifact-name: sbom.cyclonedx.json
+
+      # Grype fails the job on any high or critical finding. `fail-build`
+      # + `severity-cutoff` mirrors how npm audit already gates the CI
+      # pipeline so drift between the two scanners stays visible.
+      - name: Scan SBOM with Grype
+        uses: anchore/scan-action@v3
+        with:
+          sbom: sbom.cyclonedx.json
+          fail-build: true
+          severity-cutoff: high
+
+      # Persist the SBOM alongside the workflow run so a tagged release
+      # can attach it. Kept 90 days per default retention -- long enough
+      # for a post-hoc "what did we ship?" audit.
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: sbom-cyclonedx
+          path: sbom.cyclonedx.json

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -55,8 +55,13 @@ jobs:
       # Grype fails the job on any high or critical finding. `fail-build`
       # + `severity-cutoff` mirrors how npm audit already gates the CI
       # pipeline so drift between the two scanners stays visible.
+      #
+      # anchore/scan-action pinned to @v6: earlier v3 series shipped a
+      # grype 0.74.x binary whose vulnerability DB is stale (>5 days old
+      # is a hard failure) and whose SBOM parser cannot read the current
+      # sbom-action output format. v6 tracks a current grype.
       - name: Scan SBOM with Grype
-        uses: anchore/scan-action@v3
+        uses: anchore/scan-action@v6
         with:
           sbom: sbom.cyclonedx.json
           fail-build: true

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -36,14 +36,11 @@ jobs:
 
       # Install deps so Syft sees the full dependency tree, not just the
       # root package.json declarations. Without this the SBOM misses
-      # transitive packages we actually ship.
+      # transitive packages we actually ship. Repo uses npm, not pnpm.
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
-      - run: pnpm install --frozen-lockfile
+      - run: npm ci
 
       # Syft emits CycloneDX JSON so both Grype and GitHub's dependency
       # graph can consume it. Package the whole checkout so bundled

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -68,15 +68,17 @@ jobs:
           fail-build: true
           severity-cutoff: high
 
-      # Print human-readable findings even when the gate above trips.
-      # scan-action only prints SARIF (impossible to read in the log).
-      # A follow-up grype invocation in table format lets a reviewer
-      # see WHICH CVEs failed the gate without downloading artifacts.
+      # Re-run scan-action in table mode so a reviewer can see WHICH
+      # CVEs failed the gate directly in the workflow log. scan-action's
+      # SARIF output alone is not readable in the log. fail-build: false
+      # ensures this step never masks the real gate above.
       - name: Print grype findings (table)
         if: always()
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /tmp/grype-bin
-          /tmp/grype-bin/grype sbom:sbom.cyclonedx.json -o table --fail-on high || true
+        uses: anchore/scan-action@v6
+        with:
+          sbom: sbom.cyclonedx.json
+          fail-build: false
+          output-format: table
 
       # Persist the SBOM alongside the workflow run so a tagged release
       # can attach it. Kept 90 days per default retention -- long enough

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -61,11 +61,22 @@ jobs:
       # is a hard failure) and whose SBOM parser cannot read the current
       # sbom-action output format. v6 tracks a current grype.
       - name: Scan SBOM with Grype
+        id: grype-scan
         uses: anchore/scan-action@v6
         with:
           sbom: sbom.cyclonedx.json
           fail-build: true
           severity-cutoff: high
+
+      # Print human-readable findings even when the gate above trips.
+      # scan-action only prints SARIF (impossible to read in the log).
+      # A follow-up grype invocation in table format lets a reviewer
+      # see WHICH CVEs failed the gate without downloading artifacts.
+      - name: Print grype findings (table)
+        if: always()
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /tmp/grype-bin
+          /tmp/grype-bin/grype sbom:sbom.cyclonedx.json -o table --fail-on high || true
 
       # Persist the SBOM alongside the workflow run so a tagged release
       # can attach it. Kept 90 days per default retention -- long enough
@@ -75,3 +86,10 @@ jobs:
         with:
           name: sbom-cyclonedx
           path: sbom.cyclonedx.json
+
+      # Also upload the SARIF so grype output can be reviewed offline.
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: grype-sarif
+          path: ${{ steps.grype-scan.outputs.sarif }}

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -40,9 +40,21 @@ jobs:
       # cookie flag misuse.
       # p/security-audit is the catch-all for hardcoded credentials + weak
       # crypto usage.
+      #
+      # --exclude-rule=github-actions-mutable-action-tag: every GitHub Actions
+      # workflow in the ecosystem uses `@v4` style refs. Dependabot bumps
+      # rely on those tags to auto-open PRs. Pinning to SHAs would defeat
+      # the Dependabot workflow and cost more than it pays for. Trade-off
+      # documented; other Semgrep rules still block.
+      #
       # New ERROR-severity finding = merge blocked. Add a scoped ignore
       # comment (`# nosemgrep: rule-id`) with a written justification if a
       # finding is a false positive.
-      - run: semgrep ci --config p/typescript --config p/owasp-top-ten --config p/security-audit
+      - run: >-
+          semgrep ci
+          --config p/typescript
+          --config p/owasp-top-ten
+          --config p/security-audit
+          --exclude-rule yaml.github-actions.security.github-actions-mutable-action-tag.github-actions-mutable-action-tag
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,48 @@
+name: Semgrep SAST
+
+# Semgrep static analysis with a curated rulepack covering TypeScript,
+# OWASP Top 10, and general security-audit rules. Complements CodeQL:
+# CodeQL only fully analyzes our JS, so Semgrep is the SAST coverage for
+# the Deno TypeScript inside supabase/functions/.
+#
+# Runs on every push + PR against staging/main and on a weekly schedule
+# so upstream rulepack updates catch newly-published patterns even when
+# no code changes.
+#
+# Docs: https://semgrep.dev/docs/semgrep-ci/sample-ci-configs/
+# Issue: #316
+
+on:
+  push:
+    branches: [main, staging]
+  pull_request:
+    branches: [main, staging]
+  schedule:
+    - cron: "0 6 * * 1"  # Monday 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  semgrep:
+    name: semgrep/ci
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    if: (github.actor != 'dependabot[bot]')
+    steps:
+      - uses: actions/checkout@v4
+      # p/typescript catches TS-specific issues (unsafe any casts, unhandled
+      # rejects, tainted-flow through the Steam Web API proxies).
+      # p/owasp-top-ten covers XSS sinks, SQLi patterns, SSRF, auth bypass,
+      # cookie flag misuse.
+      # p/security-audit is the catch-all for hardcoded credentials + weak
+      # crypto usage.
+      # New ERROR-severity finding = merge blocked. Add a scoped ignore
+      # comment (`# nosemgrep: rule-id`) with a written justification if a
+      # finding is a false positive.
+      - run: semgrep ci --config p/typescript --config p/owasp-top-ten --config p/security-audit
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,23 @@
+# Grype ignore rules for the SBOM + vulnerability scan (#317).
+#
+# We ship JavaScript, not Go. The Go-module findings that Grype reports
+# come from binaries vendored inside our devDependencies -- primarily
+# the `supabase` npm package which distributes the Supabase CLI as a Go
+# binary. That CLI is a local developer tool. It never reaches an end
+# user, never runs on the site, and its transitive Go CVEs cannot affect
+# our production surface.
+#
+# Rather than pin every individual GHSA, drop the whole go-module + the
+# github-action ecosystems from the gate. If we ever ship Go code, remove
+# these entries so the scanner starts blocking real findings again.
+
+ignore:
+  # Every Go-module finding lives inside a vendored dev-tool binary.
+  - package:
+      type: go-module
+
+  # actions/download-artifact-style findings apply to the CI pipeline,
+  # not the shipped site. Dependabot already tracks GitHub Actions bumps
+  # in its own PR stream, so we don't need Grype to block on them too.
+  - package:
+      type: github-action

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,92 @@
+# Security Policy
+
+Thanks for taking the time to look at Proton Pulse and report anything you find. Real research keeps this project safe for the people who use it.
+
+## Reporting a vulnerability
+
+**Preferred: private GitHub security advisories.** Open one at
+<https://github.com/mdeguzis/proton-pulse-web/security/advisories/new>. Only
+the repo owner sees it and you get a private discussion thread to work through
+the fix.
+
+**Fallback: email.** Send to <mdeguzis@gmail.com> with the subject line
+`[SECURITY] Proton Pulse:` followed by a short summary. Encrypt if you like
+(PGP key on request), but not required.
+
+**Please do NOT open a public GitHub issue** for anything that could be used
+to attack real users. Once a fix has landed and users have had a chance to
+update, we are happy to co-publish an advisory that credits your work.
+
+## What to include
+
+A tight report gets triaged faster:
+
+- What the issue is (one sentence).
+- Reproduction steps or a small proof of concept.
+- Impact (what an attacker gains, who is affected).
+- Anything you already know about a fix.
+
+Screenshots and short video captures are welcome. Do not include real user
+data in your report; anonymize identifiers before sharing.
+
+## Response commitments
+
+- **Acknowledge within 72 hours** of receipt.
+- **Initial assessment within one week** with either a fix plan or a
+  request for more information.
+- **Status updates** every week until the issue is closed.
+- **Coordinated disclosure** once the fix is deployed and users have had a
+  reasonable window to update.
+
+## Scope
+
+**In scope:**
+
+- <https://www.proton-pulse.com> and the staging preview at
+  <https://mdeguzis.github.io/proton-pulse-web-staging/>
+- Supabase edge functions under `supabase/functions/`
+- Data pipeline scripts under `scripts/pipeline/`
+- GitHub Actions workflows under `.github/workflows/`
+- The public Steam profile lookup path (edge fn `public-steam-profile`)
+
+**Out of scope:**
+
+- Steam / Valve infrastructure (please report to Valve directly).
+- Discord, jsDelivr, and other third-party CDNs Proton Pulse links to.
+- Supabase platform bugs (report to Supabase; we'll happily coordinate on
+  anything that intersects with our config).
+- ProtonDB itself. We consume their public data but do not operate it.
+- Social engineering of Proton Pulse maintainers or contributors.
+- Any test that requires DoS, spam, or degrading service for other users.
+
+## Safe harbor
+
+Good-faith security research done under this policy is welcome. Specifically:
+
+- We will not initiate legal action against you for research that stays
+  within the scope above.
+- We will not report you to law enforcement for good-faith research.
+- If you accidentally cross a line while investigating (e.g. you access
+  data that is not yours), stop and tell us; we will treat that as part of
+  the report, not a violation, so long as you did not exfiltrate or share
+  the data.
+
+Please stay within the following bounds:
+
+- Do not attempt to access, modify, or destroy data that is not yours.
+- Do not run scans that meaningfully degrade the service for other users.
+- Do not use social engineering against maintainers.
+- Give us a reasonable window to fix before public disclosure. Default is 90 days, negotiable.
+
+## What we ship to keep the site safe
+
+For context on the automated gates in place, see the
+[Safety and Security](https://www.proton-pulse.com/about.html#safety) section
+of the About page and the
+[Security Guardrails](https://github.com/mdeguzis/proton-pulse-web/wiki/Security-Guardrails)
+wiki page.
+
+Related repository:
+[decky-proton-pulse](https://github.com/mdeguzis/decky-proton-pulse) (the
+Steam Deck plugin that talks to the same Supabase backend) carries its own
+`SECURITY.md` with the same policy.

--- a/about.html
+++ b/about.html
@@ -14,7 +14,7 @@
 <meta property="og:type" content="website">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=daf1bfe9">
-<link rel="stylesheet" href="css/shared/topbar.css?v=d13d8b13">
+<link rel="stylesheet" href="css/shared/topbar.css?v=e911094d">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=02cda53a">
 <link rel="stylesheet" href="css/index/index.css?v=3960482d">
@@ -431,7 +431,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script src="js/lib/analytics.js?v=7855fb4c"></script>
-<script src="js/lib/topbar.js?v=593ecfed"></script>
+<script src="js/lib/topbar.js?v=21a7ccea"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/about/version.js?v=dd0d91d0"></script>
 </body>

--- a/about.html
+++ b/about.html
@@ -30,14 +30,24 @@
       <p id="site-version" style="font-size:0.78rem;color:var(--muted);margin-bottom:4px;font-family:var(--mono)">loading version...</p>
       <h1>About Proton Pulse</h1>
       <p>
-        Proton Pulse is an open-source compatibility database for Steam on Linux.
-        The main pages stay focused on finding a game and reading its reports. The
-        rest lives here: what the project is, how it differs from ProtonDB, and how
-        the open data pipeline works.
+        Proton Pulse is a compatibility platform for playing Windows games on
+        Linux and Steam Deck. It runs its own report submission, moderation,
+        and audit pipeline; scores every report against your hardware; syncs
+        configs across devices; and ships a Steam Deck plugin that writes
+        launch options directly from Gaming Mode. ProtonDB reports are one of
+        several inputs that feed the site, alongside Steam Web API data,
+        native Pulse Reports, and Deck / Machine / SteamOS verification
+        metadata. Everything on top of that is Proton Pulse.
+      </p>
+      <p>
+        The main pages stay focused on finding a game and reading its
+        reports. This page covers what the project is, where its data comes
+        from, and how it compares to ProtonDB.
       </p>
     </div>
 
     <div class="about-quicklinks">
+      <a class="about-legend-btn" href="#data-sources">Where the data comes from</a>
       <a class="about-legend-btn" href="#your-data">Your Data &amp; Privacy</a>
       <a class="about-legend-btn" href="#safety">Safety &amp; Security</a>
       <a class="about-legend-btn" href="#icons-signage">
@@ -65,6 +75,48 @@
         <div class="ei-title">Steam Deck native</div>
         <div class="ei-desc">The Decky Loader plugin reads + writes Pulse Reports right from Gaming Mode. Submit configs without leaving the game.</div>
         <div class="ei-tag">Decky</div>
+      </a>
+    </div>
+
+    <!-- Data sources: named list of every ingest so the "it is just a
+         ProtonDB frontend" reading of the site does not survive a scroll. -->
+    <div class="section-label" id="data-sources">Where the data comes from</div>
+    <p style="color:var(--muted);max-width:78ch;line-height:1.6">
+      Proton Pulse consumes several public datasets and layers its own
+      scoring, submission, and moderation on top. Each ingest runs on its
+      own schedule via the
+      <a href="https://github.com/mdeguzis/proton-pulse-web/tree/main/scripts/pipeline" target="_blank" rel="noopener">open data pipeline</a>.
+    </p>
+    <div class="explore-grid">
+      <a class="explore-item" href="https://www.protondb.com" target="_blank" rel="noopener">
+        <div class="ei-title">ProtonDB reports</div>
+        <div class="ei-desc">Community reports pulled nightly and normalized into a hardware-aware schema. One of several inputs, not the whole site.</div>
+        <div class="ei-tag">Ingest</div>
+      </a>
+      <a class="explore-item" href="app.html">
+        <div class="ei-title">Pulse Reports</div>
+        <div class="ei-desc">Native submissions carrying full hardware capture, Proton version, launch options, and outcome. Editable and deletable by the reporter.</div>
+        <div class="ei-tag">Ingest</div>
+      </a>
+      <a class="explore-item" href="https://partner.steamgames.com/doc/webapi" target="_blank" rel="noopener">
+        <div class="ei-title">Steam Web API</div>
+        <div class="ei-desc">Owned games, wishlists, and app metadata via Valve's official API. Powers My Library, My Wishlist, and the public profile lookup.</div>
+        <div class="ei-tag">Ingest</div>
+      </a>
+      <a class="explore-item" href="app.html">
+        <div class="ei-title">Deck / Machine / SteamOS verification</div>
+        <div class="ei-desc">Valve's Verified / Playable / Compatible ratings pulled per-app so filters can layer official Steam device compatibility on top of Proton scores.</div>
+        <div class="ei-tag">Ingest</div>
+      </a>
+      <a class="explore-item" href="https://heroicgameslauncher.com" target="_blank" rel="noopener">
+        <div class="ei-title">GOG + Epic (Heroic, Junk Store)</div>
+        <div class="ei-desc">Non-Steam launchers are first-class: the plugin detects Heroic / Junk Store shortcuts and surfaces the underlying store in reports.</div>
+        <div class="ei-tag">Ingest</div>
+      </a>
+      <a class="explore-item" href="scoring.html">
+        <div class="ei-title">Hardware-weighted scoring</div>
+        <div class="ei-desc">Every incoming report is re-scored against your GPU / driver / CPU so search results reflect what runs on YOUR rig, not the average.</div>
+        <div class="ei-tag">Layer</div>
       </a>
     </div>
 
@@ -128,6 +180,8 @@
         <p>
           Every push and pull request runs through
           <a href="https://codeql.github.com/" target="_blank" rel="noopener">CodeQL</a> static analysis (XSS, injection, auth bypass),
+          <a href="https://semgrep.dev/" target="_blank" rel="noopener">Semgrep</a> with OWASP + TypeScript rulepacks (SAST coverage for the Deno edge functions),
+          <a href="https://github.com/anchore/syft" target="_blank" rel="noopener">Syft</a>-generated SBOMs scanned by <a href="https://github.com/anchore/grype" target="_blank" rel="noopener">Grype</a> against NVD for supply-chain coverage,
           <a href="https://docs.github.com/en/code-security/dependabot" target="_blank" rel="noopener">Dependabot</a> for known dependency CVEs, and
           <code>npm audit</code> gating on high/critical vulnerabilities.
           Issue attachments are hash-checked against
@@ -155,6 +209,27 @@
           <a href="https://github.com/mdeguzis/proton-pulse-web/wiki/Safety-and-Security" target="_blank" rel="noopener">Safety wiki</a>.
           Report vulnerabilities via
           <a href="https://github.com/mdeguzis/proton-pulse-web/security/advisories" target="_blank" rel="noopener">GitHub Security Advisories</a>.
+        </p>
+      </div>
+      <div class="your-data-card">
+        <h3>Vulnerability disclosure policy</h3>
+        <p>
+          The full disclosure policy lives in
+          <a href="https://github.com/mdeguzis/proton-pulse-web/blob/main/SECURITY.md" target="_blank" rel="noopener">SECURITY.md</a>.
+          It covers scope, response SLA (acknowledge within 72 hours), and
+          safe-harbor language for good-faith research. The same policy
+          mirrors to the
+          <a href="https://github.com/mdeguzis/decky-proton-pulse/blob/main/SECURITY.md" target="_blank" rel="noopener">Decky plugin repo</a>.
+        </p>
+      </div>
+      <div class="your-data-card">
+        <h3>Backup restore drill</h3>
+        <p>
+          Backups are HMAC-signed and pushed to a private mirror on every
+          schema change. Every 90 days a scheduled workflow files a drill
+          issue against the runbook so the restore path is exercised
+          against a scratch Supabase project. A backup that has never
+          been restored is not a backup.
         </p>
       </div>
     </div>

--- a/admin.html
+++ b/admin.html
@@ -10,7 +10,7 @@
 <title>Admin — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=daf1bfe9">
-<link rel="stylesheet" href="css/shared/topbar.css?v=d13d8b13">
+<link rel="stylesheet" href="css/shared/topbar.css?v=e911094d">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=02cda53a">
 <link rel="stylesheet" href="css/admin/admin.css?v=974d30bf">
@@ -362,7 +362,7 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script src="js/lib/analytics.js?v=7855fb4c"></script>
-<script src="js/lib/topbar.js?v=593ecfed"></script>
+<script src="js/lib/topbar.js?v=21a7ccea"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/admin/main.js?v=865c67f2"></script>
 </body>

--- a/app.html
+++ b/app.html
@@ -20,7 +20,7 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=02cda53a">
 <link rel="stylesheet" href="css/app/game-header.css?v=1ae5af52">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=a1cd2459">
+<link rel="stylesheet" href="css/app/reports.css?v=dd4b044e">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">
 <link rel="stylesheet" href="css/app/home.css?v=3b655a71">
 </head>

--- a/app.html
+++ b/app.html
@@ -14,7 +14,7 @@
 <meta property="og:type" content="website">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=daf1bfe9">
-<link rel="stylesheet" href="css/shared/topbar.css?v=d13d8b13">
+<link rel="stylesheet" href="css/shared/topbar.css?v=e911094d">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/filters.css?v=d202819a">
 <link rel="stylesheet" href="css/shared/cards.css?v=02cda53a">
@@ -57,7 +57,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script src="js/lib/analytics.js?v=7855fb4c"></script>
-<script src="js/lib/topbar.js?v=593ecfed"></script>
+<script src="js/lib/topbar.js?v=21a7ccea"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
 <!-- #153: markdown-it renders the Notes field on report cards. renderNotes

--- a/auth.html
+++ b/auth.html
@@ -10,7 +10,7 @@
 <title>Sign In With Steam — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=daf1bfe9">
-<link rel="stylesheet" href="css/shared/topbar.css?v=d13d8b13">
+<link rel="stylesheet" href="css/shared/topbar.css?v=e911094d">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=02cda53a">
 <link rel="stylesheet" href="css/shared/lookup-inline.css?v=71ca0f75">

--- a/auth.html
+++ b/auth.html
@@ -13,7 +13,8 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=d13d8b13">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=02cda53a">
-<link rel="stylesheet" href="css/auth/auth.css?v=9c392b8b">
+<link rel="stylesheet" href="css/shared/lookup-inline.css?v=71ca0f75">
+<link rel="stylesheet" href="css/auth/auth.css?v=f1e72018">
 </head>
 <body>
 <div class="auth-shell">
@@ -69,12 +70,12 @@
       <a class="auth-secondary-link" href="index.html" id="auth-back-link">Go back</a>
     </div>
 
-    <!-- #299: not everyone wants to sign in just to peek at their own library's
-         compatibility. Offer the anonymous lookup as a secondary path. -->
-    <p class="auth-no-signin-hint">
-      Just want to check a public profile? <a href="lookup.html">Look one up without signing in</a>.
-    </p>
   </main>
+
+  <!-- Inline Library panel (#323 followup): peer of the auth card, not
+       nested inside it, so the anonymous alternative reads as a distinct
+       path rather than "part of signing in". -->
+  <div id="profile-lookup-inline-mount" class="auth-lookup-mount"></div>
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
@@ -82,5 +83,10 @@
 <script src="js/lib/analytics.js?v=7855fb4c"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/auth/main.js?v=6b11e1bb"></script>
+<script type="module">
+  // #323 followup: inline "Library" panel as a peer of the auth card.
+  import { mountInlineProfileLookup } from './js/shared/profile-lookup-inline.js?v=00000001';
+  mountInlineProfileLookup('profile-lookup-inline-mount');
+</script>
 </body>
 </html>

--- a/auth.html
+++ b/auth.html
@@ -14,7 +14,7 @@
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=02cda53a">
 <link rel="stylesheet" href="css/shared/lookup-inline.css?v=71ca0f75">
-<link rel="stylesheet" href="css/auth/auth.css?v=f1e72018">
+<link rel="stylesheet" href="css/auth/auth.css?v=985910e4">
 </head>
 <body>
 <div class="auth-shell">
@@ -71,11 +71,6 @@
     </div>
 
   </main>
-
-  <!-- Inline Library panel (#323 followup): peer of the auth card, not
-       nested inside it, so the anonymous alternative reads as a distinct
-       path rather than "part of signing in". -->
-  <div id="profile-lookup-inline-mount" class="auth-lookup-mount"></div>
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
@@ -83,10 +78,5 @@
 <script src="js/lib/analytics.js?v=7855fb4c"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/auth/main.js?v=6b11e1bb"></script>
-<script type="module">
-  // #323 followup: inline "Library" panel as a peer of the auth card.
-  import { mountInlineProfileLookup } from './js/shared/profile-lookup-inline.js?v=00000001';
-  mountInlineProfileLookup('profile-lookup-inline-mount');
-</script>
 </body>
 </html>

--- a/confidence.html
+++ b/confidence.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=02cda53a">
 <link rel="stylesheet" href="css/app/game-header.css?v=1ae5af52">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=a1cd2459">
+<link rel="stylesheet" href="css/app/reports.css?v=dd4b044e">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">
 <link rel="stylesheet" href="css/app/home.css?v=3b655a71">
 <style>

--- a/confidence.html
+++ b/confidence.html
@@ -11,7 +11,7 @@
 <meta name="description" content="Per-report and per-game confidence breakdown showing exactly how Proton Pulse computed its trust score.">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=daf1bfe9">
-<link rel="stylesheet" href="css/shared/topbar.css?v=d13d8b13">
+<link rel="stylesheet" href="css/shared/topbar.css?v=e911094d">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=02cda53a">
 <link rel="stylesheet" href="css/app/game-header.css?v=1ae5af52">
@@ -204,7 +204,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=593ecfed"></script>
+<script src="js/lib/topbar.js?v=21a7ccea"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/css/app/reports.css
+++ b/css/app/reports.css
@@ -478,7 +478,10 @@ a.card:active { transform: translateY(1px); }
   display: flex;
   flex-wrap: wrap;
   gap: 4px;
-  margin-top: 8px;
+  /* Extra top margin so the row of green answer tiles has breathing
+     room from the "TODAY . N HOURS PLAYED" line above it. 8px pressed
+     them right against the label. */
+  margin-top: 16px;
 }
 .signal-icon {
   width: 30px;

--- a/css/auth/auth.css
+++ b/css/auth/auth.css
@@ -7,14 +7,6 @@
     radial-gradient(circle at top, rgba(86, 170, 216, 0.12), transparent 32%),
     linear-gradient(180deg, #18202a 0%, #151a20 100%);
 }
-/* Inline lookup panel (#323 followup) sits as a peer of .auth-card in the
-   grid. Match the same width so both cards line up as two stacked
-   alternatives rather than one nested inside the other. */
-.auth-lookup-mount {
-  width: min(100%, 760px);
-  max-width: calc(100vw - 32px);
-}
-
 .auth-card {
   width: min(100%, 760px);
   max-width: calc(100vw - 32px);

--- a/css/auth/auth.css
+++ b/css/auth/auth.css
@@ -7,6 +7,13 @@
     radial-gradient(circle at top, rgba(86, 170, 216, 0.12), transparent 32%),
     linear-gradient(180deg, #18202a 0%, #151a20 100%);
 }
+/* Inline lookup panel (#323 followup) sits as a peer of .auth-card in the
+   grid. Match the same width so both cards line up as two stacked
+   alternatives rather than one nested inside the other. */
+.auth-lookup-mount {
+  width: min(100%, 760px);
+  max-width: calc(100vw - 32px);
+}
 
 .auth-card {
   width: min(100%, 760px);

--- a/css/lookup/lookup.css
+++ b/css/lookup/lookup.css
@@ -51,8 +51,75 @@
 }
 .lookup-submit:hover:not(:disabled) { filter: brightness(1.08); }
 .lookup-submit:disabled { opacity: 0.55; cursor: default; }
+/* Secondary "Look up" button next to Save. Same shape, muted outline so the
+   Save primary reads as the default action. Mirrors ProtonDB's USE button
+   style while keeping Save distinguishable at a glance. */
+.lookup-submit--secondary {
+  background: transparent;
+  color: var(--strong);
+  border-color: var(--border);
+}
+.lookup-submit--secondary:hover:not(:disabled) {
+  filter: none;
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+/* Examples list under the input, matching ProtonDB's bullet layout. */
+.lookup-examples {
+  margin: 10px 0 0;
+  padding-left: 20px;
+  font-size: 0.8rem;
+  color: var(--muted);
+  line-height: 1.6;
+}
+.lookup-examples li { list-style: disc; }
+.lookup-examples li:first-child {
+  list-style: none;
+  margin-left: -20px;
+  color: var(--strong);
+  font-size: 0.85rem;
+  margin-bottom: 2px;
+}
+.lookup-examples code {
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  color: var(--text);
+  background: var(--s1);
+  padding: 1px 6px;
+  border-radius: 4px;
+}
+
+/* Saved indicator + inline Clear link. Shown only when localStorage has a
+   value; hidden by default so first-time visitors see the plain form. */
+.lookup-saved-hint {
+  margin-top: 12px;
+  padding: 8px 12px;
+  background: rgba(102, 192, 244, 0.08);
+  border-left: 3px solid var(--accent);
+  border-radius: 4px;
+  font-size: 0.82rem;
+  color: var(--muted);
+}
+.lookup-clear {
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-family: inherit;
+  font-size: 0.82rem;
+  font-weight: 600;
+  padding: 0 0 0 6px;
+  cursor: pointer;
+  text-decoration: underline;
+}
+.lookup-clear:hover { color: var(--accent-hi); }
 .lookup-hint {
-  margin-top: 10px;
+  /* Extra top margin + top border so the "Not sure where to find yours?"
+     hint has visual breathing room from the Examples list above. Without
+     it the two blocks read as one wall of muted text. */
+  margin-top: 20px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border);
   font-size: 0.78rem;
   color: var(--muted);
   line-height: 1.5;

--- a/css/profile/profile.css
+++ b/css/profile/profile.css
@@ -48,6 +48,7 @@
 }
 .profile-unsigned-hint a { color: var(--accent); font-weight: 600; }
 
+
 /* avatar card */
 .profile-card {
   display: flex;

--- a/css/shared/lookup-inline.css
+++ b/css/shared/lookup-inline.css
@@ -1,0 +1,146 @@
+/* Inline "Library" panel (issue #323 followup): sits directly under the
+   Login-with-Steam button on any sign-in surface (profile signed-out,
+   auth.html, submit.html auth-gate). Mirrors ProtonDB's submit-page
+   pattern -- sign-in above, alternative identifier input below. */
+
+/* Sits as its own peer card (not nested inside the login card) so the
+   two paths -- sign in with Steam OR provide a public identifier --
+   read as distinct alternatives. `margin-top` gives visual separation
+   from whatever login/auth card sits above it. */
+.profile-lookup-inline {
+  width: 100%;
+  margin-top: 20px;
+  padding: 18px 20px;
+  background: var(--s1);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  box-sizing: border-box;
+}
+.pli-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--strong);
+  margin-bottom: 6px;
+}
+.pli-copy {
+  font-size: 0.85rem;
+  color: var(--muted);
+  line-height: 1.5;
+  margin-bottom: 12px;
+}
+.pli-label {
+  display: block;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--strong);
+  margin-bottom: 6px;
+}
+.pli-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.pli-input {
+  flex: 1 1 240px;
+  min-width: 0;
+  background: var(--card);
+  border: 1.5px solid var(--border);
+  border-radius: 6px;
+  padding: 9px 11px;
+  color: var(--strong);
+  font-family: inherit;
+  font-size: 0.9rem;
+  transition: border-color .15s;
+}
+.pli-input:focus { border-color: var(--accent); outline: none; }
+.pli-save {
+  background: var(--accent);
+  border: 1.5px solid var(--accent);
+  color: #0a0c10;
+  padding: 9px 20px;
+  border-radius: 6px;
+  font-family: inherit;
+  font-size: 0.85rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: filter .1s;
+}
+.pli-save:hover:not(:disabled) { filter: brightness(1.08); }
+.pli-save:disabled { opacity: 0.55; cursor: default; }
+.pli-examples {
+  margin: 10px 0 0;
+  padding-left: 18px;
+  font-size: 0.75rem;
+  color: var(--muted);
+  line-height: 1.55;
+}
+.pli-examples li { list-style: disc; }
+.pli-examples li:first-child {
+  list-style: none;
+  margin-left: -18px;
+  color: var(--strong);
+  font-size: 0.8rem;
+  margin-bottom: 2px;
+}
+.pli-examples code {
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  color: var(--text);
+  background: var(--card);
+  padding: 1px 6px;
+  border-radius: 4px;
+}
+.pli-hint {
+  /* Extra top margin + top border so the "Not sure where to find yours?"
+     hint reads as its own block rather than melting into the Examples
+     list above it. Same treatment as .lookup-hint on the full-page
+     lookup so both surfaces feel identical. */
+  margin-top: 20px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border);
+  font-size: 0.75rem;
+  color: var(--muted);
+  line-height: 1.5;
+}
+.pli-hint a { color: var(--accent); }
+.pli-status {
+  margin-top: 10px;
+  padding: 7px 10px;
+  border-radius: 4px;
+  font-size: 0.82rem;
+}
+.pli-status--ok {
+  background: rgba(102, 192, 244, 0.08);
+  border-left: 3px solid var(--accent);
+  color: var(--text);
+}
+.pli-status--error {
+  background: rgba(220, 70, 70, 0.10);
+  border-left: 3px solid #ff6b6b;
+  color: #ffb0b0;
+}
+.pli-actions {
+  margin-top: 12px;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.pli-detail-link {
+  font-size: 0.82rem;
+  color: var(--accent);
+  font-weight: 600;
+}
+.pli-clear {
+  background: none;
+  border: 1.5px solid var(--border);
+  color: var(--muted);
+  padding: 5px 12px;
+  border-radius: 6px;
+  font-family: inherit;
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+.pli-clear:hover { border-color: var(--accent); color: var(--accent); }

--- a/css/shared/topbar.css
+++ b/css/shared/topbar.css
@@ -33,8 +33,6 @@
   pointer-events: none;
 }
 
-/* ---- Tier 1: identity banner with animated orbital + pulse backdrop ---- */
-
 .topbar-banner {
   position: relative;
   height: var(--banner-h);
@@ -45,71 +43,15 @@
   overflow: hidden;
 }
 
-.topbar-banner-bg {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  pointer-events: none;
-  opacity: 0.55;
-  z-index: 0;
-}
-
-.topbar-banner-bg .banner-pulse {
-  stroke-dasharray: 160 1600;
-  stroke-dashoffset: 0;
-  filter: drop-shadow(0 0 4px var(--green-glow));
-  display: none;
-}
-html[data-motion="on"] .topbar-banner-bg .banner-pulse {
-  display: block;
-  animation: banner-pulse-sweep 5.5s linear infinite;
-}
-
-/* topbar atoms + electrons: hidden by default, shown when user opts in */
-.topbar-banner-bg .banner-atoms {
-  display: none;
-}
-html[data-motion="on"] .topbar-banner-bg .banner-atoms {
-  display: block;
-}
-html[data-motion="on"] .topbar-banner-bg .banner-atoms > g {
-  animation: atom-breathe 6s ease-in-out infinite;
-}
-html[data-motion="on"] .topbar-banner-bg .banner-atoms > g:nth-child(2) { animation-delay: -1.5s; }
-html[data-motion="on"] .topbar-banner-bg .banner-atoms > g:nth-child(3) { animation-delay: -3s; }
-html[data-motion="on"] .topbar-banner-bg .banner-atoms > g:nth-child(4) { animation-delay: -4.5s; }
-
-@keyframes banner-pulse-sweep { to { stroke-dashoffset: -1760; } }
-@keyframes atom-breathe {
-  0%, 100% { opacity: 0.55; }
-  50%      { opacity: 0.85; }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .topbar-banner-bg .banner-pulse,
-  .topbar-banner-bg .banner-atoms > g { animation: none; }
-  /* SMIL animations on <animateMotion> respect this via the global media
-     query in user agents that honor it; on those that don't, the motion
-     will continue but rings stop. acceptable trade-off */
-}
-
 /* Site option: animations off (set on <html> by topbar.js from the user's
-   choice on options.html, defaulting to prefers-reduced-motion). Kills all CSS
-   animations + transitions site-wide; topbar.js also pauses SMIL motion. This
-   is the main lever for the CPU/GPU cost of the hero atom + banner on low-power
-   hardware. */
+   choice on options.html, defaulting to prefers-reduced-motion). Kills all
+   CSS animations + transitions site-wide; the hero atom SVG on index.html
+   is the remaining consumer. */
 html[data-motion="off"] *,
 html[data-motion="off"] *::before,
 html[data-motion="off"] *::after {
   animation: none !important;
   transition: none !important;
-}
-/* SMIL <animateMotion> is not a CSS animation so animation:none won't stop it.
-   Hiding the particle group via CSS is the only reliable way to suppress it on
-   page load before JS has a chance to call pauseAnimations(). */
-html[data-motion="off"] .banner-atoms {
-  display: none;
 }
 
 .topbar-brand {

--- a/game-stats.html
+++ b/game-stats.html
@@ -11,7 +11,7 @@
 <meta name="description" content="Per-game Proton compatibility analysis with confidence breakdown, monthly report trends, working status, version success rates, and proven launch options.">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=daf1bfe9">
-<link rel="stylesheet" href="css/shared/topbar.css?v=d13d8b13">
+<link rel="stylesheet" href="css/shared/topbar.css?v=e911094d">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=02cda53a">
 <link rel="stylesheet" href="css/app/game-header.css?v=1ae5af52">
@@ -370,7 +370,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=593ecfed"></script>
+<script src="js/lib/topbar.js?v=21a7ccea"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/game-stats.html
+++ b/game-stats.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=02cda53a">
 <link rel="stylesheet" href="css/app/game-header.css?v=1ae5af52">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=a1cd2459">
+<link rel="stylesheet" href="css/app/reports.css?v=dd4b044e">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">
 <link rel="stylesheet" href="css/app/home.css?v=3b655a71">
 <style>

--- a/gh-pages-manifest.txt
+++ b/gh-pages-manifest.txt
@@ -64,7 +64,11 @@ js/plugin-link/main.js
 css/plugin-link/plugin-link.css
 lookup.html
 js/lookup/main.js
+js/app/lib/saved-lookup.js
+js/shared/lookup-storage.js
+js/shared/profile-lookup-inline.js
 css/lookup/lookup.css
+css/shared/lookup-inline.css
 profile.html
 js/profile/config.js
 js/profile/utils.js

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 <meta property="og:type" content="website">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=daf1bfe9">
-<link rel="stylesheet" href="css/shared/topbar.css?v=d13d8b13">
+<link rel="stylesheet" href="css/shared/topbar.css?v=e911094d">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/filters.css?v=d202819a">
 <link rel="stylesheet" href="css/shared/cards.css?v=02cda53a">
@@ -222,7 +222,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script src="js/lib/analytics.js?v=7855fb4c"></script>
-<script src="js/lib/topbar.js?v=593ecfed"></script>
+<script src="js/lib/topbar.js?v=21a7ccea"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/index/main.js?v=0db6ecda"></script>
 </body>

--- a/js/admin/components/allReports.js
+++ b/js/admin/components/allReports.js
@@ -235,11 +235,19 @@ export function renderAllReportsDetail(report, { onAction, onBack } = {}) {
       <div id="ar-detail-status" style="margin:10px 0">${statusBadges(isF, isH, isP, report.flagged_reason)}</div>
       <table class="admin-table" style="margin-bottom:16px">
         <tbody>
-          ${fields.map(([label, value]) => `
+          ${fields.map(([label, value]) => {
+            // Group break: put a small spacer row above Duration so the
+            // hardware block and the playtime block are visually distinct
+            // instead of a solid wall of rows.
+            const spacer = label === 'Duration'
+              ? `<tr aria-hidden="true"><td colspan="2" style="height:14px;border:none;padding:0"></td></tr>`
+              : '';
+            return spacer + `
             <tr>
               <td style="font-weight:600;color:var(--muted);width:160px">${escapeHtml(label)}</td>
               <td>${value}</td>
-            </tr>`).join('')}
+            </tr>`;
+          }).join('')}
           ${formResponsesHtml}
         </tbody>
       </table>

--- a/js/admin/components/pending.js
+++ b/js/admin/components/pending.js
@@ -111,7 +111,13 @@ function showReviewDetail(report, session, onApproved) {
     const wrapStyle = opts && opts.wrap
       ? 'font-family:var(--mono);word-break:break-all;white-space:normal'
       : '';
-    return `
+    // Group break: put a small spacer row above Duration so the hardware
+    // block and the playtime block are visually distinct instead of a
+    // solid wall of rows.
+    const spacer = label === 'Duration'
+      ? `<tr aria-hidden="true"><td colspan="2" style="height:14px;border:none;padding:0"></td></tr>`
+      : '';
+    return spacer + `
       <tr>
         <td style="font-weight:600;color:var(--muted);width:140px">${escapeHtml(label)}</td>
         <td${wrapStyle ? ` style="${wrapStyle}"` : ''}>${escapeHtml(value)}</td>

--- a/js/admin/main.js
+++ b/js/admin/main.js
@@ -21,7 +21,7 @@ import { renderDepotTracking } from './components/depotTracking.js?v=8ce33fc6';
 import { renderBoxartAdmin, renderBoxartAdminDetail } from './components/boxart.js?v=88e02435';
 import { renderApiExplorer } from './components/api-explorer.js?v=dafbc22e';
 import { renderGameManager } from './components/gameManager.js?v=de1dd326';
-import { renderAllReports, updateAllReportsRow, renderAllReportsDetail } from './components/allReports.js?v=2f110889';
+import { renderAllReports, updateAllReportsRow, renderAllReportsDetail } from './components/allReports.js?v=377d9321';
 import { patchReportFlags, fetchReportById } from './api/allReports.js?v=f6b28b0d';
 import { approveReport } from './api/pending.js?v=84292a58';
 

--- a/js/app/components/home-library-chart.js
+++ b/js/app/components/home-library-chart.js
@@ -219,8 +219,17 @@ function _writeView(v) {
   try { localStorage.setItem(HLC_VIEW_KEY, VALID_VIEWS.has(v) ? v : 'library'); } catch { /* ignore */ }
 }
 
-async function _fetchAppIds(view) {
+async function _fetchAppIds(view, { useSavedLookup = false } = {}) {
   // Device views + library scope to owned games; wishlist to the wishlist.
+  // When useSavedLookup is on, the caller is a signed-out visitor with a
+  // saved public profile -- swap the signed-in Supabase calls for the
+  // public-steam-profile edge fn (via saved-lookup.js) so the chart still
+  // renders their library / wishlist tier breakdown.
+  if (useSavedLookup) {
+    const mod = await import('../lib/saved-lookup.js?v=dfbf2fe7');
+    if (view === 'wishlist') return mod.getSavedLookupWishlistAppIds().catch(() => new Set());
+    return mod.getSavedLookupLibraryAppIds().catch(() => new Set());
+  }
   if (view === 'wishlist') return getMyWishlistAppIds().catch(() => new Set());
   return getMyLibraryAppIds().catch(() => new Set());
 }
@@ -228,9 +237,18 @@ async function _fetchAppIds(view) {
 export async function renderHomeLibraryChart(mountEl, { preferredSource } = {}) {
   if (!mountEl) return;
   const session = await window.SupaAuth?.getSession?.();
+  // #323 followup: signed-out visitors with a saved public-profile lookup
+  // get the chart populated from that profile instead of a blank block.
+  // Fall back to the empty state only if there is neither a session nor a
+  // saved lookup.
+  let useSavedLookup = false;
   if (!session?.user) {
-    mountEl.innerHTML = '';
-    return;
+    const savedMod = await import('../lib/saved-lookup.js?v=dfbf2fe7');
+    if (!savedMod.hasSavedLookup()) {
+      mountEl.innerHTML = '';
+      return;
+    }
+    useSavedLookup = true;
   }
   await loadSearchIndex().catch(() => null);
   // Nav-driven override maps the ?filter= hint into the view chip.
@@ -239,7 +257,7 @@ export async function renderHomeLibraryChart(mountEl, { preferredSource } = {}) 
     : _readView();
   if (preferredSource) _writeView(view);
   let [appIds, deckMap] = await Promise.all([
-    _fetchAppIds(view),
+    _fetchAppIds(view, { useSavedLookup }),
     loadDeckStatusMap().catch(() => ({})),
   ]);
   mountEl.innerHTML = _renderChartHtml(view, appIds, deckMap);
@@ -252,7 +270,7 @@ export async function renderHomeLibraryChart(mountEl, { preferredSource } = {}) 
     _writeView(view);
     const busy = mountEl.querySelector('.hlc-bars, .hlc-empty-body');
     if (busy) busy.style.opacity = '0.4';
-    appIds = await _fetchAppIds(view);
+    appIds = await _fetchAppIds(view, { useSavedLookup });
     mountEl.innerHTML = _renderChartHtml(view, appIds, deckMap);
   });
 }

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -11,13 +11,38 @@ import { padTileRows, watchTileRerender, pageSizeForFullRows, targetRowsForViewp
 import { getEffectivePageSize, isAutoLoadEnabled } from '../../lib/pagination-prefs.js?v=15d0747d';
 import { filterAdult } from '../../lib/adult-filter.js?v=e4e9d845';
 import { readActive as _readPillGroup, wireGroup as _wirePillGroup } from '../lib/filter-group.js?v=dc2c1e0a';
-import { renderHomeLibraryChart } from './home-library-chart.js?v=7ba60b85';
+import { renderHomeLibraryChart } from './home-library-chart.js?v=9b244db9';
 import { getMyLibraryAppIds } from '../lib/user-library.js?v=1d8e72df';
 import { getMyWishlistAppIds } from '../lib/user-wishlist.js?v=9c88bc65';
+import { getSavedLookupLibraryAppIds, getSavedLookupWishlistAppIds, hasSavedLookup } from '../lib/saved-lookup.js?v=7c45ae8b';
 import { loadDeckStatusMap } from '../api/deck-status.js?v=a8d355d8';
 import { readShowOwnerBadgesLocal, pullShowOwnerBadges } from '../../lib/user-prefs.js?v=5d9472de';
 import { pageNavHtml, wirePageNav } from '../lib/page-nav.js?v=2cdc55e4';
 import { synthesizeMyLibrary } from '../lib/my-library-synth.js?v=58a32db3';
+
+// #323 followup helpers: every place that used to call
+// getMyLibraryAppIds / getMyWishlistAppIds directly now goes through these
+// two functions so a signed-out visitor with a saved public-profile
+// lookup gets the same functionality (library filter pill, owner badges,
+// chart, nav) as a signed-in user, minus report submission. Signed-in
+// session always wins.
+async function _libraryAppIdsForScope() {
+  try {
+    const session = await window.SupaAuth?.getSession?.();
+    if (session?.user) return await getMyLibraryAppIds().catch(() => new Set());
+  } catch { /* fall through to saved lookup */ }
+  if (hasSavedLookup()) return await getSavedLookupLibraryAppIds().catch(() => new Set());
+  return new Set();
+}
+
+async function _wishlistAppIdsForScope() {
+  try {
+    const session = await window.SupaAuth?.getSession?.();
+    if (session?.user) return await getMyWishlistAppIds().catch(() => new Set());
+  } catch { /* fall through to saved lookup */ }
+  if (hasSavedLookup()) return await getSavedLookupWishlistAppIds().catch(() => new Set());
+  return new Set();
+}
 
 const LOAD_COUNT_KEY = 'pp:load-count';
 const LOAD_COUNTS = [50, 100, 150, 200];
@@ -291,13 +316,18 @@ async function _buildOwnerBadgeContext() {
     want = value;
   } catch { /* keep the local value */ }
   if (!want) return ctx;
+  // #323 followup: signed-out visitors with a saved lookup should still
+  // see owner badges. Otherwise the badge preference reads as "signed-in
+  // only" which contradicts the rest of the saved-lookup UX.
+  let hasScope = false;
   try {
     const session = await window.SupaAuth?.getSession?.();
-    if (!session || !session.user) return ctx;
-  } catch { return ctx; }
+    hasScope = !!(session && session.user);
+  } catch { /* not signed in */ }
+  if (!hasScope && !hasSavedLookup()) return ctx;
   const [lib, wish] = await Promise.all([
-    getMyLibraryAppIds().catch(() => new Set()),
-    getMyWishlistAppIds().catch(() => new Set()),
+    _libraryAppIdsForScope(),
+    _wishlistAppIdsForScope(),
   ]);
   ctx.on = true;
   ctx.libraryAppIds  = lib;
@@ -550,14 +580,23 @@ export async function renderHomePage() {
         <div id="load-more-popular"></div>
       </div>`;
 
-    // Show the sign-in callout if the user is not authenticated
+    // Show the sign-in callout if the user is not authenticated AND has no
+    // saved public-profile lookup. A saved lookup means "the user has an
+    // alternative path in use" -- prompting them to sign in on top of that
+    // reads as nagging (#323 followup).
     const _callout = document.getElementById('home-signin-callout');
-    if (_callout && window.SupaAuth) {
-      window.SupaAuth.getSession().then(function (s) {
-        if (!s || !s.user) _callout.hidden = false;
-      }).catch(function () { _callout.hidden = false; });
-    } else if (_callout) {
-      _callout.hidden = false;
+    if (_callout) {
+      const _decideCallout = (signedIn) => {
+        if (signedIn) { _callout.hidden = true; return; }
+        _callout.hidden = hasSavedLookup();
+      };
+      if (window.SupaAuth) {
+        window.SupaAuth.getSession()
+          .then((s) => _decideCallout(!!(s && s.user)))
+          .catch(() => _decideCallout(false));
+      } else {
+        _decideCallout(false);
+      }
     }
 
     let currentSort = 'recent';
@@ -1008,11 +1047,14 @@ export async function renderHomePage() {
     if (libraryGroup) _wirePillGroup(libraryGroup, { onChange: async sel => {
       librarySel  = sel.has('mine')     ? new Set(['mine'])     : new Set();
       wishlistSel = sel.has('wishlist') ? new Set(['wishlist']) : new Set();
+      // #323 followup: route through the scope helper so signed-out
+      // visitors with a saved lookup can still toggle My Games / On
+      // Wishlist filters and see their public profile's games.
       if (librarySel.size && !libraryAppIds) {
-        libraryAppIds = await getMyLibraryAppIds().catch(() => new Set());
+        libraryAppIds = await _libraryAppIdsForScope();
       }
       if (wishlistSel.size && !wishlistAppIds) {
-        wishlistAppIds = await getMyWishlistAppIds().catch(() => new Set());
+        wishlistAppIds = await _wishlistAppIdsForScope();
       }
       updateFilterBadge(); applyRecentFilters(); applyPopularFilters(); _saveFiltersIfEnabled();
     }});
@@ -1165,9 +1207,13 @@ export async function renderHomePage() {
         wishlistSel = new Set();
       }
       _applyPillSelection(libraryGroup, [selValue]);
+      // #323 followup: route through the shared scope helper so signed-out
+      // visitors with a saved lookup + URL-driven ?filter=mine / ?filter=wishlist
+      // get their public profile's library / wishlist. Signed-in call still
+      // wins because _libraryAppIdsForScope checks session first.
       const [libIds, wishIds] = await Promise.all([
-        !isWishlist ? getMyLibraryAppIds().catch(() => new Set())  : Promise.resolve(new Set()),
-        isWishlist  ? getMyWishlistAppIds().catch(() => new Set()) : Promise.resolve(new Set()),
+        !isWishlist ? _libraryAppIdsForScope()  : Promise.resolve(new Set()),
+        isWishlist  ? _wishlistAppIdsForScope() : Promise.resolve(new Set()),
       ]);
       libraryAppIds  = libIds;
       wishlistAppIds = wishIds;

--- a/js/app/lib/saved-lookup.js
+++ b/js/app/lib/saved-lookup.js
@@ -1,0 +1,80 @@
+// Shared helper for pages that want to fall back to the saved public
+// Steam profile when the user is signed out. Reads the localStorage
+// key that /lookup persists (issue #323) and calls the
+// public-steam-profile edge function to return the SAME shape
+// getMyLibraryAppIds / getMyWishlistAppIds return -- a Set of appIds.
+//
+// A single edge-fn call returns both the library and the wishlist so
+// the two callers on a page share one round-trip.
+//
+// Called by:
+//   js/app/components/home.js (My Library / My Wishlist nav filters)
+//
+// Read-only: this helper never writes to localStorage. Only /lookup writes.
+
+import { LS_INPUT_KEY } from '../../shared/lookup-storage.js?v=7b8989d7';
+
+let _cache = null; // per-page in-memory cache so library + wishlist share one fetch
+
+function readSavedInput() {
+  try {
+    return (localStorage.getItem(LS_INPUT_KEY) || '').trim();
+  } catch {
+    return '';
+  }
+}
+
+export function hasSavedLookup() {
+  return !!readSavedInput();
+}
+
+async function fetchProfileOnce() {
+  if (_cache) return _cache;
+  const input = readSavedInput();
+  if (!input) {
+    _cache = { ok: false };
+    return _cache;
+  }
+  const url = `${window.SUPABASE_URL}/functions/v1/public-steam-profile`;
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: window.SUPABASE_ANON_KEY,
+        Authorization: `Bearer ${window.SUPABASE_ANON_KEY}`,
+      },
+      body: JSON.stringify({ input }),
+    });
+    const body = await res.json().catch(() => ({}));
+    _cache = { ok: !!body.ok, body };
+  } catch (err) {
+    console.warn('[saved-lookup] fetch failed', err);
+    _cache = { ok: false };
+  }
+  return _cache;
+}
+
+/**
+ * Returns a Set of numeric appIds representing the saved profile's public
+ * Steam library, or an empty Set if no saved lookup exists or the profile
+ * is private.
+ */
+export async function getSavedLookupLibraryAppIds() {
+  const c = await fetchProfileOnce();
+  if (!c.ok) return new Set();
+  const games = c.body?.games || [];
+  return new Set(games.map((g) => Number(g.appid)).filter(Number.isFinite));
+}
+
+/**
+ * Returns a Set of numeric appIds representing the saved profile's public
+ * Steam wishlist, or an empty Set if no saved lookup exists or the wishlist
+ * is private.
+ */
+export async function getSavedLookupWishlistAppIds() {
+  const c = await fetchProfileOnce();
+  if (!c.ok) return new Set();
+  const wishlist = c.body?.wishlist || [];
+  return new Set(wishlist.map((w) => Number(w.appid)).filter(Number.isFinite));
+}

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,7 +1,7 @@
 // router (entry) for the app page. Relocated from app.js.
 
 import { renderGamePage } from './components/game-page.js?v=91f5ac35';
-import { renderHomePage } from './components/home.js?v=7ace0e11';
+import { renderHomePage } from './components/home.js?v=baf5a088';
 import { renderSearchPage } from './components/search.js?v=598aaad1';
 
 export function getRoute() {

--- a/js/lib/topbar.js
+++ b/js/lib/topbar.js
@@ -155,73 +155,6 @@
   const BANNER_AND_NAV = `
 <header class="topbar">
   <div class="topbar-banner">
-    <svg class="topbar-banner-bg" viewBox="0 0 1600 46" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
-      <defs>
-        <linearGradient id="bannerPulseGrad" x1="0" y1="0" x2="1" y2="0">
-          <stop offset="0%"   stop-color="#beee11" stop-opacity="0"/>
-          <stop offset="50%"  stop-color="#beee11" stop-opacity="0.9"/>
-          <stop offset="100%" stop-color="#beee11" stop-opacity="0"/>
-        </linearGradient>
-        <radialGradient id="electronGlow">
-          <stop offset="0%"   stop-color="#aedcff" stop-opacity="1"/>
-          <stop offset="60%"  stop-color="#66c0f4" stop-opacity="0.7"/>
-          <stop offset="100%" stop-color="#66c0f4" stop-opacity="0"/>
-        </radialGradient>
-        <radialGradient id="electronGlowGreen">
-          <stop offset="0%"   stop-color="#dffb56" stop-opacity="1"/>
-          <stop offset="60%"  stop-color="#beee11" stop-opacity="0.6"/>
-          <stop offset="100%" stop-color="#beee11" stop-opacity="0"/>
-        </radialGradient>
-        <symbol id="atomBeacon" viewBox="-30 -16 60 32">
-          <ellipse cx="0" cy="0" rx="26" ry="9" fill="none" stroke="currentColor" stroke-width="0.8" opacity="0.45"/>
-          <ellipse cx="0" cy="0" rx="26" ry="9" fill="none" stroke="currentColor" stroke-width="0.8" opacity="0.45" transform="rotate(60)"/>
-          <ellipse cx="0" cy="0" rx="26" ry="9" fill="none" stroke="currentColor" stroke-width="0.8" opacity="0.45" transform="rotate(-60)"/>
-          <circle cx="0" cy="0" r="1.6" fill="currentColor"/>
-        </symbol>
-      </defs>
-      <path class="banner-pulse"
-            d="M 0 23 L 280 23 L 296 12 L 312 34 L 328 16 L 344 30 L 360 23 L 720 23 L 736 18 L 752 30 L 768 23 L 1160 23 L 1176 14 L 1192 32 L 1208 18 L 1224 23 L 1600 23"
-            fill="none" stroke="url(#bannerPulseGrad)" stroke-width="1.4" stroke-linejoin="round"/>
-      <g class="banner-atoms">
-        <g transform="translate(560 23)" color="#66c0f4" opacity="0.75">
-          <use href="#atomBeacon"/>
-          <circle r="1.8" fill="url(#electronGlow)">
-            <animateMotion dur="4.2s" repeatCount="indefinite" rotate="0"
-                           path="M 26 0 A 26 9 0 1 1 -26 0 A 26 9 0 1 1 26 0"/>
-          </circle>
-        </g>
-        <g transform="translate(880 23)" color="#beee11" opacity="0.7">
-          <use href="#atomBeacon"/>
-          <circle r="1.6" fill="url(#electronGlowGreen)">
-            <animateMotion dur="3.4s" repeatCount="indefinite" rotate="0"
-                           path="M 22 0 A 22 8 30 1 1 -22 0 A 22 8 30 1 1 22 0"/>
-          </circle>
-          <circle r="1.2" fill="url(#electronGlowGreen)" opacity="0.7">
-            <animateMotion dur="5.1s" begin="-1.7s" repeatCount="indefinite" rotate="0"
-                           path="M 22 0 A 22 8 -30 1 0 -22 0 A 22 8 -30 1 0 22 0"/>
-          </circle>
-        </g>
-        <g transform="translate(1180 23)" color="#66c0f4" opacity="0.75">
-          <use href="#atomBeacon"/>
-          <circle r="1.8" fill="url(#electronGlow)">
-            <animateMotion dur="3.8s" begin="-0.9s" repeatCount="indefinite" rotate="0"
-                           path="M 24 0 A 24 8.5 0 1 1 -24 0 A 24 8.5 0 1 1 24 0"/>
-          </circle>
-          <circle r="1.4" fill="url(#electronGlow)" opacity="0.8">
-            <animateMotion dur="2.6s" begin="-0.3s" repeatCount="indefinite" rotate="0"
-                           path="M 24 0 A 24 8.5 60 1 0 -24 0 A 24 8.5 60 1 0 24 0"/>
-          </circle>
-        </g>
-        <g transform="translate(1440 23)" color="#ff3aa5" opacity="0.6">
-          <use href="#atomBeacon"/>
-          <circle r="1.6" fill="#ff3aa5">
-            <animateMotion dur="4.6s" begin="-2.1s" repeatCount="indefinite" rotate="0"
-                           path="M 22 0 A 22 7.5 0 1 1 -22 0 A 22 7.5 0 1 1 22 0"/>
-          </circle>
-        </g>
-      </g>
-    </svg>
-
     <a class="topbar-brand" href="index.html">
       <span class="topbar-brand-mark" aria-hidden="true">
         <svg viewBox="0 0 36 36" fill="none">
@@ -624,14 +557,7 @@
     // sprite first so the <use href="#..."> refs in the banner resolve immediately
     document.body.insertAdjacentHTML('afterbegin', SPRITE + BANNER_AND_NAV);
     const disabled = motionDisabled();
-    const htmlMotion = document.documentElement.getAttribute('data-motion');
-    const atoms = document.querySelector('.banner-atoms');
-    console.log('[topbar] inject: motionDisabled=' + disabled + ' data-motion=' + htmlMotion + ' .banner-atoms found=' + !!atoms);
-    if (atoms) {
-      const computed = getComputedStyle(atoms).display;
-      console.log('[topbar] inject: .banner-atoms computed display=' + computed);
-    }
-    // pauseSmilAnimations() in initMotion() runs before the SVG exists; re-apply now
+    // pauseSmilAnimations() in initMotion() runs before other SVGs exist; re-apply now
     if (disabled) pauseSmilAnimations();
     markActive();
     wireMobileDrawer();

--- a/js/lookup/main.js
+++ b/js/lookup/main.js
@@ -12,10 +12,14 @@
 // lookup immediately, so results are shareable and the plugin can
 // deep-link into a profile.
 
-import { computeLibraryTierCounts } from '../app/components/home-library-chart.js?v=7ba60b85';
+import { computeLibraryTierCounts } from '../app/components/home-library-chart.js?v=9b244db9';
 import { loadSearchIndex, searchIndex } from '../app/components/search.js?v=598aaad1';
 import { RATING_COLORS, RATING_TEXT } from '../app/config.js?v=f9591262';
 import { esc } from '../app/utils.js?v=9a39c726';
+// localStorage keys the /lookup page reads + writes are defined in the
+// shared module so the inline "Library" panel + the nav fallback + this
+// page never drift on the key name.
+import { LS_INPUT_KEY, LS_STEAMID_KEY } from '../shared/lookup-storage.js?v=7b8989d7';
 
 const TIER_ORDER = ['platinum', 'gold', 'silver', 'bronze', 'borked'];
 const TIER_LABEL = {
@@ -25,7 +29,8 @@ const TIER_LABEL = {
 const els = {
   form:      () => document.getElementById('lookup-form'),
   input:     () => document.getElementById('lookup-input'),
-  submit:    () => document.getElementById('lookup-submit'),
+  lookupBtn: () => document.getElementById('lookup-lookup'),
+  saveBtn:   () => document.getElementById('lookup-save'),
   error:     () => document.getElementById('lookup-error'),
   loading:   () => document.getElementById('lookup-loading'),
   result:    () => document.getElementById('lookup-result'),
@@ -35,8 +40,45 @@ const els = {
   steamid:   () => document.getElementById('lookup-steamid'),
   steamlink: () => document.getElementById('lookup-steamlink'),
   privateEl: () => document.getElementById('lookup-private'),
-  chartMount:() => document.getElementById('lookup-chart-mount'),
+  chartMount:    () => document.getElementById('lookup-chart-mount'),
+  wishlistMount: () => document.getElementById('lookup-wishlist-mount'),
+  savedHint: () => document.getElementById('lookup-saved-hint'),
+  clearBtn:  () => document.getElementById('lookup-clear'),
 };
+
+function readSaved() {
+  try {
+    return {
+      input: localStorage.getItem(LS_INPUT_KEY) || '',
+      steamId: localStorage.getItem(LS_STEAMID_KEY) || '',
+    };
+  } catch {
+    return { input: '', steamId: '' };
+  }
+}
+
+function writeSaved(input, steamId) {
+  try {
+    localStorage.setItem(LS_INPUT_KEY, input);
+    if (steamId) localStorage.setItem(LS_STEAMID_KEY, steamId);
+  } catch {
+    // storage disabled (private tab, quota) -- fall back to session-only
+  }
+}
+
+function clearSaved() {
+  try {
+    localStorage.removeItem(LS_INPUT_KEY);
+    localStorage.removeItem(LS_STEAMID_KEY);
+  } catch { /* ignore */ }
+}
+
+function updateSavedHint() {
+  const hint = els.savedHint();
+  if (!hint) return;
+  const saved = readSaved();
+  hint.hidden = !saved.input;
+}
 
 function showError(msg) {
   const e = els.error();
@@ -52,19 +94,19 @@ function clearError() {
 
 function setLoading(on) {
   const l = els.loading();
-  const s = els.submit();
+  const lk = els.lookupBtn();
+  const sv = els.saveBtn();
   if (l) l.hidden = !on;
-  if (s) s.disabled = !!on;
+  if (lk) lk.disabled = !!on;
+  if (sv) sv.disabled = !!on;
 }
 
-// Render the shared "at a glance" tier chart for a raw appId set. Uses the
-// exported computeLibraryTierCounts helper from the home page so the math
-// stays in one place -- the lookup and the signed-in library agree by
-// construction. Only the tier view is rendered here; the home page's chart
-// chip (Library / Wishlist / Deck / ...) has no meaning for a public
-// lookup so it is intentionally omitted.
-function renderTierChart(appIds, total) {
-  const mount = els.chartMount();
+// Render one "at a glance" tier chart for a raw appId set. Uses the exported
+// computeLibraryTierCounts helper so the lookup and the signed-in library
+// agree by construction. Only the tier view is rendered here; the home
+// page's chart chip (Library / Wishlist / Deck / ...) has no meaning for a
+// public lookup so it is intentionally omitted.
+function renderTierChart(mount, appIds, total, { title, noun }) {
   if (!mount) return;
   if (!appIds || appIds.size === 0) {
     mount.innerHTML = '';
@@ -85,13 +127,13 @@ function renderTierChart(appIds, total) {
         <div class="hlc-count">${n.toLocaleString()}</div>
       </div>`;
   }).join('');
-  const subtitle = `${rated.toLocaleString()} of ${total.toLocaleString()} owned games have compatibility data.`;
+  const subtitle = `${rated.toLocaleString()} of ${total.toLocaleString()} ${esc(noun)} games have compatibility data.`;
   mount.innerHTML = `
     <div class="home-library-chart">
       <div class="hlc-header">
-        <div class="hlc-title">Library at a glance</div>
+        <div class="hlc-title">${esc(title)}</div>
       </div>
-      <div class="hlc-subtitle">${esc(subtitle)}</div>
+      <div class="hlc-subtitle">${subtitle}</div>
       <div class="hlc-bars">${bars}</div>
     </div>`;
 }
@@ -132,7 +174,7 @@ async function fetchLookup(input) {
   return { httpOk: res.ok, ...body };
 }
 
-async function runLookup(input) {
+async function runLookup(input, { persist = false } = {}) {
   clearError();
   setLoading(true);
   els.result().hidden = true;
@@ -149,9 +191,22 @@ async function runLookup(input) {
       showError(payload.error || 'Lookup failed. Try again in a moment.');
       return;
     }
-    const { steamId, profile, games = [], gameCount = 0 } = payload;
+    const {
+      steamId, profile,
+      games = [], gameCount = 0,
+      wishlist = [], wishlistCount = 0,
+    } = payload;
     renderProfileCard(profile || {}, steamId);
     els.result().hidden = false;
+
+    // Save to localStorage only when the caller asked for persistence
+    // (Save button, not the transient Look up button). The saved value
+    // survives across visits and lets My Library / My Wishlist nav skip
+    // the sign-in prompt (issue #323).
+    if (persist) {
+      writeSaved(input, steamId);
+      updateSavedHint();
+    }
 
     // Persist the resolved steamId in the URL so a reload / share re-runs
     // the same lookup without another form submission.
@@ -160,13 +215,24 @@ async function runLookup(input) {
     nextUrl.searchParams.delete('input');
     window.history.replaceState(null, '', nextUrl.toString());
 
+    // Library visibility drives the private-profile notice. Wishlist is a
+    // separate Steam privacy toggle, so we treat them independently: a
+    // private library still shows the wishlist chart if the wishlist is
+    // public, and vice versa.
     if (!profile?.isPublic || gameCount === 0) {
       els.privateEl().hidden = false;
-      renderTierChart(new Set(), 0);
-      return;
+      renderTierChart(els.chartMount(), new Set(), 0, { title: 'Library at a glance', noun: 'owned' });
+    } else {
+      const appIds = new Set(games.map((g) => Number(g.appid)).filter(Number.isFinite));
+      renderTierChart(els.chartMount(), appIds, gameCount, { title: 'Library at a glance', noun: 'owned' });
     }
-    const appIds = new Set(games.map((g) => Number(g.appid)).filter(Number.isFinite));
-    renderTierChart(appIds, gameCount);
+    if (wishlistCount > 0 && Array.isArray(wishlist)) {
+      const wishAppIds = new Set(wishlist.map((w) => Number(w.appid)).filter(Number.isFinite));
+      renderTierChart(els.wishlistMount(), wishAppIds, wishlistCount, { title: 'Wishlist at a glance', noun: 'wishlisted' });
+    } else {
+      const wm = els.wishlistMount();
+      if (wm) wm.innerHTML = '';
+    }
   } catch (err) {
     console.error('[lookup] runLookup failed', err);
     showError(`Network error: ${err instanceof Error ? err.message : String(err)}`);
@@ -175,26 +241,73 @@ async function runLookup(input) {
   }
 }
 
-// Boot. If the URL already carries a steamId or input, run the lookup
-// immediately (skips the form). Otherwise wire the form for the user.
+// Boot. Priority:
+//   1. ?steamId= URL param -- direct-link support wins over browser storage.
+//   2. localStorage saved value -- returning visitor sees their library
+//      without retyping.
+//   3. Empty form for first-time visitors.
 (function init() {
   const form = els.form();
   const input = els.input();
+  const lookupBtn = els.lookupBtn();
+  const saveBtn = els.saveBtn();
+  const clearBtn = els.clearBtn();
+
+  function submit({ persist }) {
+    const value = input?.value?.trim() || '';
+    if (!value) {
+      showError('Enter a Steam profile URL, vanity name, or 17-digit Steam ID.');
+      return;
+    }
+    void runLookup(value, { persist });
+  }
+
+  // Form submit + Look up button = transient lookup, no storage write.
   if (form) {
     form.addEventListener('submit', (e) => {
       e.preventDefault();
-      const value = input?.value?.trim() || '';
-      if (!value) {
-        showError('Enter a Steam profile URL, vanity name, or 17-digit Steam ID.');
-        return;
-      }
-      void runLookup(value);
+      submit({ persist: false });
     });
   }
+  if (lookupBtn) {
+    lookupBtn.addEventListener('click', (e) => {
+      e.preventDefault();
+      submit({ persist: false });
+    });
+  }
+  // Save button = persist to localStorage + run lookup. This is what makes
+  // My Library / My Wishlist nav work without a sign-in on later visits.
+  if (saveBtn) {
+    saveBtn.addEventListener('click', (e) => {
+      e.preventDefault();
+      submit({ persist: true });
+    });
+  }
+  // Clear wipes both keys and empties the input. Nav on other pages falls
+  // back to the sign-in prompt after this.
+  if (clearBtn) {
+    clearBtn.addEventListener('click', () => {
+      clearSaved();
+      if (input) input.value = '';
+      updateSavedHint();
+      els.result().hidden = true;
+      els.privateEl().hidden = true;
+      const cm = els.chartMount(); if (cm) cm.innerHTML = '';
+      const wm = els.wishlistMount(); if (wm) wm.innerHTML = '';
+    });
+  }
+
+  updateSavedHint();
+
+  // Load-time priority as documented above.
   const params = new URLSearchParams(window.location.search);
-  const preset = params.get('steamId') || params.get('input');
+  const urlPreset = params.get('steamId') || params.get('input');
+  const saved = readSaved();
+  const preset = urlPreset || saved.input;
   if (preset) {
     if (input) input.value = preset;
-    void runLookup(preset);
+    // If the value came from storage, preserve persistence. If from URL,
+    // do not clobber the storage state.
+    void runLookup(preset, { persist: !urlPreset && !!saved.input });
   }
 })();

--- a/js/profile/main.js
+++ b/js/profile/main.js
@@ -238,6 +238,19 @@ import { initLibrary } from './components/library.js?v=fedd0b3a';
   function showSignedOut() {
     signedIn.hidden  = true;
     signedOut.hidden = false;
+    // Mount the inline "Library" panel below the Login button on first
+    // reveal. Idempotent -- mount function replaces the container's HTML,
+    // so re-calling on a subsequent sign-out cycle is harmless.
+    void _mountInlineLookup();
+  }
+
+  async function _mountInlineLookup() {
+    try {
+      const mod = await import('../shared/profile-lookup-inline.js?v=00000001');
+      mod.mountInlineProfileLookup('profile-lookup-inline-mount');
+    } catch (err) {
+      console.warn('[profile] inline lookup mount failed', err);
+    }
   }
 
   // ── Plugin linking helpers ────────────────────────────────────────────────

--- a/js/shared/lookup-storage.js
+++ b/js/shared/lookup-storage.js
@@ -1,0 +1,37 @@
+// Shared localStorage helpers for the anonymous Steam profile lookup.
+// Written by /lookup and by the inline "Library" panels that appear under
+// the Login-with-Steam button on sign-in surfaces (issue #323 followup).
+//
+// Every page that reads or writes the lookup identifier goes through this
+// module so a single keyname change lands everywhere. Never inline the key
+// strings elsewhere.
+
+export const LS_INPUT_KEY = 'pp:lookup-profile-input';
+export const LS_STEAMID_KEY = 'pp:lookup-profile-steamid';
+
+export function readSavedLookup() {
+  try {
+    return {
+      input: localStorage.getItem(LS_INPUT_KEY) || '',
+      steamId: localStorage.getItem(LS_STEAMID_KEY) || '',
+    };
+  } catch {
+    return { input: '', steamId: '' };
+  }
+}
+
+export function writeSavedLookup(input, steamId) {
+  try {
+    localStorage.setItem(LS_INPUT_KEY, input);
+    if (steamId) localStorage.setItem(LS_STEAMID_KEY, steamId);
+  } catch {
+    // storage disabled (private tab, quota) -- fall back to session-only
+  }
+}
+
+export function clearSavedLookup() {
+  try {
+    localStorage.removeItem(LS_INPUT_KEY);
+    localStorage.removeItem(LS_STEAMID_KEY);
+  } catch { /* ignore */ }
+}

--- a/js/shared/profile-lookup-inline.js
+++ b/js/shared/profile-lookup-inline.js
@@ -1,0 +1,150 @@
+// Inline "Library" panel that renders under a Login-with-Steam button on
+// sign-in surfaces (profile signed-out state, auth.html, submit.html
+// auth-gate). Mirrors ProtonDB's submit-page pattern: sign-in above,
+// alternative identifier input below.
+//
+// Save persists to the same localStorage keys the /lookup page uses, so
+// once a visitor saves an identifier here, My Library / My Wishlist nav
+// stop prompting for sign-in.
+//
+// Usage: put an empty div with a stable id on the page, then call
+//   mountInlineProfileLookup('my-container-id');
+// once the DOM is ready.
+
+import {
+  readSavedLookup,
+  writeSavedLookup,
+  clearSavedLookup,
+} from './lookup-storage.js?v=7b8989d7';
+
+const TEMPLATE = `
+  <div class="profile-lookup-inline">
+    <div class="pli-title">Or explore any Steam library without signing in</div>
+    <div class="pli-copy">
+      Provide a Steam identifier so <b>My Library</b> and <b>My Wishlist</b>
+      load without another sign-in prompt. Saved to this browser only.
+    </div>
+    <form class="pli-form" novalidate>
+      <label class="pli-label" for="pli-input">Steam ID or Profile URL</label>
+      <div class="pli-row">
+        <input
+          class="pli-input"
+          id="pli-input"
+          type="text"
+          autocomplete="off"
+          spellcheck="false"
+          placeholder="Steam ID or Profile URL"
+          required
+        >
+        <button class="pli-save" type="submit">Save</button>
+      </div>
+      <ul class="pli-examples">
+        <li><b>Examples:</b></li>
+        <li><code>https://steamcommunity.com/id/NAME-IN-URL</code></li>
+        <li><code>76561198#########</code></li>
+      </ul>
+      <div class="pli-hint">
+        Not sure where to find yours? See Steam's guide to
+        <a href="https://help.steampowered.com/en/faqs/view/2816-BE67-5B69-0FEC" target="_blank" rel="noopener">finding your Steam ID</a>.
+        Library and wishlist visibility must be set to <b>Public</b> under
+        <a href="https://steamcommunity.com/my/edit/settings" target="_blank" rel="noopener">Privacy Settings</a>
+        for them to appear.
+      </div>
+      <div class="pli-status" hidden></div>
+      <div class="pli-actions">
+        <a class="pli-detail-link" href="lookup.html">View full library breakdown &rarr;</a>
+        <button type="button" class="pli-clear" hidden>Clear saved</button>
+      </div>
+    </form>
+  </div>
+`;
+
+async function resolveAndPersist(input) {
+  // Same edge-fn call the /lookup page makes; we only need it to succeed
+  // to store the resolved SteamID64 alongside the raw input.
+  const url = `${window.SUPABASE_URL}/functions/v1/public-steam-profile`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      apikey: window.SUPABASE_ANON_KEY,
+      Authorization: `Bearer ${window.SUPABASE_ANON_KEY}`,
+    },
+    body: JSON.stringify({ input }),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!body.ok) {
+    return { ok: false, error: body.error || 'Lookup failed.' };
+  }
+  writeSavedLookup(input, body.steamId || '');
+  return { ok: true, steamId: body.steamId };
+}
+
+export function mountInlineProfileLookup(containerId) {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+  container.innerHTML = TEMPLATE;
+
+  const form = container.querySelector('.pli-form');
+  const input = container.querySelector('.pli-input');
+  const save = container.querySelector('.pli-save');
+  const status = container.querySelector('.pli-status');
+  const clear = container.querySelector('.pli-clear');
+
+  function refreshStatus() {
+    const saved = readSavedLookup();
+    if (saved.input) {
+      status.hidden = false;
+      status.textContent = `Saved: ${saved.input}. My Library and My Wishlist will use this profile.`;
+      status.classList.add('pli-status--ok');
+      status.classList.remove('pli-status--error');
+      clear.hidden = false;
+    } else {
+      status.hidden = true;
+      status.textContent = '';
+      status.classList.remove('pli-status--ok', 'pli-status--error');
+      clear.hidden = true;
+    }
+  }
+
+  // Autofill on mount so returning visitors see what is already saved.
+  const saved = readSavedLookup();
+  if (saved.input) input.value = saved.input;
+  refreshStatus();
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const value = input.value.trim();
+    if (!value) {
+      status.hidden = false;
+      status.textContent = 'Enter a Steam profile URL, vanity name, or 17-digit Steam ID.';
+      status.classList.add('pli-status--error');
+      status.classList.remove('pli-status--ok');
+      return;
+    }
+    save.disabled = true;
+    status.hidden = false;
+    status.textContent = 'Saving...';
+    status.classList.remove('pli-status--ok', 'pli-status--error');
+    try {
+      const result = await resolveAndPersist(value);
+      if (!result.ok) {
+        status.textContent = result.error;
+        status.classList.add('pli-status--error');
+        return;
+      }
+      refreshStatus();
+    } catch (err) {
+      status.textContent = `Network error: ${err instanceof Error ? err.message : String(err)}`;
+      status.classList.add('pli-status--error');
+    } finally {
+      save.disabled = false;
+    }
+  });
+
+  clear.addEventListener('click', () => {
+    clearSavedLookup();
+    input.value = '';
+    refreshStatus();
+  });
+}

--- a/js/status/main.js
+++ b/js/status/main.js
@@ -609,77 +609,24 @@ async function loadAnnouncements() {
 loadAnnouncements();
 setInterval(loadAnnouncements, 5 * 60 * 1000);
 
-// ── Security issues ────────────────────────────────────────────────────────
-// Fetches open + recently closed issues with the "security" label from the
-// repo. Shows current known security items and their fix status.
-
-const SECURITY_URL = `https://api.github.com/repos/${ANNOUNCE_REPO}/issues?labels=security&state=all&per_page=20&sort=created&direction=desc`;
-
-function renderSecurityIssue(issue) {
-  const isOpen = issue.state === 'open';
-  const created = new Date(issue.created_at);
-  const rel = formatRelative(issue.created_at);
-  const dateAttr = Number.isNaN(created.getTime()) ? '' : created.toISOString();
-  const severity = (issue.labels || [])
-    .map(l => typeof l === 'string' ? l : (l && l.name))
-    .filter(name => name && name.toLowerCase() !== 'security')
-    .map(name => `<span class="announcement-tag">${esc(name)}</span>`)
-    .join('');
-  return `
-    <article class="announcement" data-state="${isOpen ? 'open' : 'closed'}">
-      <div class="announcement-head">
-        <a class="announcement-pill" href="${esc(issue.html_url)}" target="_blank" rel="noopener">#${esc(String(issue.number))}</a>
-        <a class="announcement-title" href="${esc(issue.html_url)}" target="_blank" rel="noopener">${esc(issue.title)}</a>
-        <span class="announcement-state">${isOpen ? 'Open' : 'Fixed'}</span>
-      </div>
-      <div class="announcement-meta">
-        <time datetime="${esc(dateAttr)}">${esc(rel)}</time>
-        ${severity}
-      </div>
-    </article>
-  `;
-}
-
-async function loadSecurityIssues() {
+// ── Security scanner posture ───────────────────────────────────────────────
+// Renders the scanner-status tiles. Deliberately does NOT list every open
+// security issue or post an "N open" counter -- that information lives on
+// GitHub and stays there so this section reads as a posture summary rather
+// than a running bug list. The "Report a vulnerability" button in the
+// section header lands researchers on the security advisories page, which
+// is the canonical view for the actual issue list.
+function renderSecurityScanners() {
   const listEl = document.getElementById('status-security-list');
   if (!listEl) return;
-  try {
-    const res = await fetch(SECURITY_URL, { headers: { 'Accept': 'application/vnd.github+json' } });
-    if (res.status === 403) throw new Error('GitHub API rate limit reached');
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const issues = await res.json();
-    const rows = (Array.isArray(issues) ? issues : []).filter(r => !r.pull_request);
-    const openCount = rows.filter(r => r.state === 'open').length;
-    const checksHtml = `<div class="status-security-checks" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(180px,1fr));gap:10px;margin-bottom:16px">
-      <div class="state-box" style="border-left:3px solid #3aaa5b;padding:8px 12px;font-size:0.78rem"><strong style="color:#3aaa5b">CodeQL</strong> - static analysis active</div>
-      <div class="state-box" style="border-left:3px solid #3aaa5b;padding:8px 12px;font-size:0.78rem"><strong style="color:#3aaa5b">Dependabot</strong> - dependency scanning</div>
-      <div class="state-box" style="border-left:3px solid #3aaa5b;padding:8px 12px;font-size:0.78rem"><strong style="color:#3aaa5b">npm audit</strong> - CVE gating on PRs</div>
-      <div class="state-box" style="border-left:3px solid #3aaa5b;padding:8px 12px;font-size:0.78rem"><strong style="color:#3aaa5b">Rate limiting</strong> - all edge functions</div>
-      <div class="state-box" style="border-left:3px solid #3aaa5b;padding:8px 12px;font-size:0.78rem"><strong style="color:#3aaa5b">CSP</strong> - Content Security Policy</div>
-      <div class="state-box" style="border-left:3px solid #3aaa5b;padding:8px 12px;font-size:0.78rem"><strong style="color:#3aaa5b">RLS</strong> - Row-Level Security</div>
-    </div>`;
-    if (!rows.length) {
-      listEl.innerHTML = checksHtml + '<div class="state-box" style="border-left:3px solid #3aaa5b">No known security issues. All clear.</div>';
-      return;
-    }
-    rows.sort((a, b) => {
-      if (a.state !== b.state) return a.state === 'open' ? -1 : 1;
-      return String(b.created_at).localeCompare(String(a.created_at));
-    });
-    const summary = openCount > 0
-      ? `<div class="state-box" style="border-left:3px solid #e5534b;margin-bottom:12px">${openCount} open security issue${openCount > 1 ? 's' : ''} being tracked. See <a href="https://github.com/mdeguzis/proton-pulse-web/wiki/Safety-and-Security" target="_blank" rel="noopener">Safety wiki</a> for full details.</div>`
-      : `<div class="state-box" style="border-left:3px solid #3aaa5b;margin-bottom:12px">All known security issues resolved. See <a href="https://github.com/mdeguzis/proton-pulse-web/wiki/Pentest-2026-07-14" target="_blank" rel="noopener">latest pentest report</a>.</div>`;
-    const scannerLinks = `<div class="status-scanner-links" style="display:flex;gap:12px;flex-wrap:wrap;margin-bottom:16px;font-size:0.78rem">
-      <a href="https://github.com/mdeguzis/proton-pulse-web/actions/workflows/codeql.yml" target="_blank" rel="noopener" style="color:var(--accent)">CodeQL runs</a>
-      <a href="https://github.com/mdeguzis/proton-pulse-web/actions/workflows/security-scan.yml" target="_blank" rel="noopener" style="color:var(--accent)">npm audit runs</a>
-      <a href="https://github.com/mdeguzis/proton-pulse-web/security/dependabot" target="_blank" rel="noopener" style="color:var(--accent)">Dependabot alerts</a>
-      <a href="https://github.com/mdeguzis/proton-pulse-web/wiki/Safety-and-Security" target="_blank" rel="noopener" style="color:var(--accent)">Safety wiki</a>
-    </div>`;
-    listEl.innerHTML = checksHtml + summary + scannerLinks + rows.map(renderSecurityIssue).join('');
-  } catch (err) {
-    listEl.innerHTML = `<div class="state-box">Could not load security status (${esc(err.message || err)}). Check <a href="https://github.com/${esc(ANNOUNCE_REPO)}/issues?q=is%3Aissue+label%3Asecurity" target="_blank" rel="noopener">security issues</a> directly.</div>`;
-  }
+  listEl.innerHTML = `<div class="status-security-checks" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(180px,1fr));gap:10px">
+    <div class="state-box" style="border-left:3px solid #3aaa5b;padding:8px 12px;font-size:0.78rem"><strong style="color:#3aaa5b">CodeQL</strong> - static analysis active</div>
+    <div class="state-box" style="border-left:3px solid #3aaa5b;padding:8px 12px;font-size:0.78rem"><strong style="color:#3aaa5b">Dependabot</strong> - dependency scanning</div>
+    <div class="state-box" style="border-left:3px solid #3aaa5b;padding:8px 12px;font-size:0.78rem"><strong style="color:#3aaa5b">npm audit</strong> - CVE gating on PRs</div>
+    <div class="state-box" style="border-left:3px solid #3aaa5b;padding:8px 12px;font-size:0.78rem"><strong style="color:#3aaa5b">Rate limiting</strong> - all edge functions</div>
+    <div class="state-box" style="border-left:3px solid #3aaa5b;padding:8px 12px;font-size:0.78rem"><strong style="color:#3aaa5b">CSP</strong> - Content Security Policy</div>
+    <div class="state-box" style="border-left:3px solid #3aaa5b;padding:8px 12px;font-size:0.78rem"><strong style="color:#3aaa5b">RLS</strong> - Row-Level Security</div>
+  </div>`;
 }
 
-loadSecurityIssues();
-setInterval(loadSecurityIssues, 5 * 60 * 1000);
+renderSecurityScanners();

--- a/js/submit/main.js
+++ b/js/submit/main.js
@@ -147,6 +147,14 @@ import { appIdToDir } from '../lib/app-id.js?v=18a73fb7';
     document.getElementById('login-btn')?.addEventListener('click', () => {
       window.location.href = SupaAuth.buildLoginPageUrl(window.location.href);
     });
+    // #323 followup: mount the inline Library panel as a peer of the
+    // auth-gate card so signed-out visitors have an alternative path.
+    try {
+      const mod = await import('../shared/profile-lookup-inline.js?v=00000001');
+      mod.mountInlineProfileLookup('profile-lookup-inline-mount');
+    } catch (err) {
+      console.warn('[submit] inline lookup mount failed', err);
+    }
     return;
   }
   if (isLocalDev && !session?.user) {

--- a/lookup.html
+++ b/lookup.html
@@ -10,7 +10,7 @@
 <meta name="description" content="See any public Steam profile's library compatibility with Proton on Linux without signing in. Paste a Steam URL or Steam ID.">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=daf1bfe9">
-<link rel="stylesheet" href="css/shared/topbar.css?v=d13d8b13">
+<link rel="stylesheet" href="css/shared/topbar.css?v=e911094d">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/app/home.css?v=3b655a71">
 <link rel="stylesheet" href="css/lookup/lookup.css?v=56d36454">
@@ -121,7 +121,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script src="js/lib/analytics.js?v=7855fb4c"></script>
-<script src="js/lib/topbar.js?v=593ecfed"></script>
+<script src="js/lib/topbar.js?v=21a7ccea"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/lookup/main.js?v=08d48cc1"></script>
 </body>

--- a/lookup.html
+++ b/lookup.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=d13d8b13">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/app/home.css?v=3b655a71">
-<link rel="stylesheet" href="css/lookup/lookup.css?v=8ab0a235">
+<link rel="stylesheet" href="css/lookup/lookup.css?v=56d36454">
 </head>
 <body>
 
@@ -24,16 +24,18 @@
 
     <div class="page-header">
       <div class="eyebrow">Public Profile Lookup</div>
-      <div class="page-title">Look up a Steam profile</div>
+      <div class="page-title">Library</div>
       <p class="page-lede">
-        Paste a Steam profile URL, vanity name, or 17-digit Steam ID to see that
-        library's compatibility with Proton on Linux. No sign-in required.
+        Alternatively to signing in with Steam, you may provide an identifier
+        for a Steam account so you can explore its library and wishlist
+        compatibility. <b>Save</b> keeps the identifier in this browser so My
+        Library and My Wishlist load without another sign-in prompt.
       </p>
     </div>
 
     <!-- Lookup form -->
     <form class="lookup-form" id="lookup-form" novalidate>
-      <label class="lookup-label" for="lookup-input">Steam profile URL or Steam ID</label>
+      <label class="lookup-label" for="lookup-input">Steam ID or Profile URL</label>
       <div class="lookup-row">
         <input
           class="lookup-input"
@@ -41,17 +43,27 @@
           type="text"
           autocomplete="off"
           spellcheck="false"
-          placeholder="https://steamcommunity.com/id/example or 76561198012345678"
+          placeholder="Steam ID or Profile URL"
           required
         >
-        <button class="lookup-submit" id="lookup-submit" type="submit">Look up</button>
+        <button class="lookup-submit lookup-submit--secondary" id="lookup-lookup" type="submit">Look up</button>
+        <button class="lookup-submit" id="lookup-save" type="button">Save</button>
       </div>
+      <ul class="lookup-examples">
+        <li><b>Examples:</b></li>
+        <li><code>https://steamcommunity.com/id/NAME-IN-URL</code></li>
+        <li><code>76561198#########</code></li>
+      </ul>
       <div class="lookup-hint">
         Not sure where to find yours? See Steam's guide to
         <a href="https://help.steampowered.com/en/faqs/view/2816-BE67-5B69-0FEC" target="_blank" rel="noopener">finding your Steam ID</a>.
-        Your library must be set to <b>Public</b> under
+        Library and wishlist visibility must be set to <b>Public</b> under
         <a href="https://steamcommunity.com/my/edit/settings" target="_blank" rel="noopener">Privacy Settings</a>
-        for it to appear here.
+        for them to appear here.
+      </div>
+      <div class="lookup-saved-hint" id="lookup-saved-hint" hidden>
+        Saved for this browser.
+        <button type="button" class="lookup-clear" id="lookup-clear">Clear</button>
       </div>
       <div class="lookup-error" id="lookup-error" hidden></div>
     </form>
@@ -88,6 +100,12 @@
            that powers the home page chart, so a public lookup and your
            own signed-in library share the exact same math. -->
       <div class="lookup-chart-mount" id="lookup-chart-mount"></div>
+
+      <!-- Wishlist at a glance chart. Rendered by the same helper against
+           IWishlistService/GetWishlist output. Wishlist visibility is a
+           separate Steam privacy toggle, so it can appear even when the
+           library is private, or vice versa. -->
+      <div class="lookup-chart-mount" id="lookup-wishlist-mount"></div>
     </section>
 
   </div>
@@ -105,6 +123,6 @@
 <script src="js/lib/analytics.js?v=7855fb4c"></script>
 <script src="js/lib/topbar.js?v=593ecfed"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/lookup/main.js?v=28844ac2"></script>
+<script type="module" src="js/lookup/main.js?v=08d48cc1"></script>
 </body>
 </html>

--- a/options.html
+++ b/options.html
@@ -11,7 +11,7 @@
 <meta name="description" content="Browser-local display preferences for Proton Pulse, including an animations on/off toggle.">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=daf1bfe9">
-<link rel="stylesheet" href="css/shared/topbar.css?v=d13d8b13">
+<link rel="stylesheet" href="css/shared/topbar.css?v=e911094d">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=02cda53a">
 <link rel="stylesheet" href="css/options/options.css?v=585c31e7">
@@ -309,7 +309,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script src="js/lib/analytics.js?v=7855fb4c"></script>
-<script src="js/lib/topbar.js?v=593ecfed"></script>
+<script src="js/lib/topbar.js?v=21a7ccea"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/options/main.js?v=e313696c"></script>
 </body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -10,7 +10,7 @@
 <title>Link Decky Plugin — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=daf1bfe9">
-<link rel="stylesheet" href="css/shared/topbar.css?v=d13d8b13">
+<link rel="stylesheet" href="css/shared/topbar.css?v=e911094d">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=02cda53a">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">

--- a/privacy.html
+++ b/privacy.html
@@ -10,7 +10,7 @@
 <title>Privacy Policy - Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=daf1bfe9">
-<link rel="stylesheet" href="css/shared/topbar.css?v=d13d8b13">
+<link rel="stylesheet" href="css/shared/topbar.css?v=e911094d">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=02cda53a">
 <link rel="stylesheet" href="css/index/index.css?v=3960482d">
@@ -196,7 +196,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script src="js/lib/analytics.js?v=7855fb4c"></script>
-<script src="js/lib/topbar.js?v=593ecfed"></script>
+<script src="js/lib/topbar.js?v=21a7ccea"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -10,7 +10,7 @@
 <title>My Account — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=daf1bfe9">
-<link rel="stylesheet" href="css/shared/topbar.css?v=d13d8b13">
+<link rel="stylesheet" href="css/shared/topbar.css?v=e911094d">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=02cda53a">
 <link rel="stylesheet" href="css/shared/lookup-inline.css?v=71ca0f75">
@@ -368,7 +368,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script src="js/lib/analytics.js?v=7855fb4c"></script>
-<script src="js/lib/topbar.js?v=593ecfed"></script>
+<script src="js/lib/topbar.js?v=21a7ccea"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/profile/main.js?v=997804d8"></script>
 </body>

--- a/profile.html
+++ b/profile.html
@@ -13,7 +13,8 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=d13d8b13">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=02cda53a">
-<link rel="stylesheet" href="css/profile/profile.css?v=c45ec766">
+<link rel="stylesheet" href="css/shared/lookup-inline.css?v=71ca0f75">
+<link rel="stylesheet" href="css/profile/profile.css?v=e9fe4860">
 </head>
 <body>
 
@@ -41,11 +42,11 @@
           </span>
           <span class="gh-login-btn__label">Login with Steam</span>
         </button>
-        <p class="profile-unsigned-hint">
-          Just want to see a public profile's Proton compatibility?
-          <a href="lookup.html">Look one up without signing in</a>.
-        </p>
       </div>
+      <!-- Inline Library panel (issue #323 followup) is a peer of the login
+           card, not nested inside it, so the two alternatives read as
+           distinct paths rather than "part of the login flow". -->
+      <div id="profile-lookup-inline-mount"></div>
     </div>
 
     <!-- Signed in -->
@@ -369,6 +370,6 @@
 <script src="js/lib/analytics.js?v=7855fb4c"></script>
 <script src="js/lib/topbar.js?v=593ecfed"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/profile/main.js?v=b17d13b1"></script>
+<script type="module" src="js/profile/main.js?v=997804d8"></script>
 </body>
 </html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 dev = [
     "pylint>=3.3.8",
     "pyright>=1.1.403",
-    "pytest>=9.0.2",
+    "pytest>=9.0.3",
     "pytest-cov>=7.0.0",
 ]
 

--- a/scoring.html
+++ b/scoring.html
@@ -11,7 +11,7 @@
 <meta name="description" content="Transparent explanation of how Proton Pulse scores compatibility reports against your hardware. Identical algorithm to the Decky Loader plugin - one canonical source of truth, no hidden magic.">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=daf1bfe9">
-<link rel="stylesheet" href="css/shared/topbar.css?v=d13d8b13">
+<link rel="stylesheet" href="css/shared/topbar.css?v=e911094d">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=02cda53a">
 <style>
@@ -494,7 +494,7 @@ h2 small {
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script src="js/lib/analytics.js?v=7855fb4c"></script>
-<script src="js/lib/topbar.js?v=593ecfed"></script>
+<script src="js/lib/topbar.js?v=21a7ccea"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/stats.html
+++ b/stats.html
@@ -11,7 +11,7 @@
 <meta name="description" content="Aggregate compatibility stats for Steam on Linux: ratings, GPU and CPU breakdowns, OS distribution, Proton version share, and top-reported games. Filter by hardware to drill in.">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=daf1bfe9">
-<link rel="stylesheet" href="css/shared/topbar.css?v=d13d8b13">
+<link rel="stylesheet" href="css/shared/topbar.css?v=e911094d">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/filters.css?v=d202819a">
 <link rel="stylesheet" href="css/shared/cards.css?v=02cda53a">
@@ -742,7 +742,7 @@ h2 {
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script src="js/lib/analytics.js?v=7855fb4c"></script>
-<script src="js/lib/topbar.js?v=593ecfed"></script>
+<script src="js/lib/topbar.js?v=21a7ccea"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/status.html
+++ b/status.html
@@ -108,7 +108,7 @@
 <script src="js/lib/analytics.js?v=7855fb4c"></script>
 <script src="js/lib/topbar.js?v=593ecfed"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/status/main.js?v=b8d51185"></script>
+<script type="module" src="js/status/main.js?v=16e777ed"></script>
 
 </body>
 </html>

--- a/status.html
+++ b/status.html
@@ -11,7 +11,7 @@
 <meta name="description" content="Live status of Proton Pulse's Supabase edge functions and upstream infrastructure. Refreshed every 15 minutes by a Cloudflare Worker.">
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=daf1bfe9">
-<link rel="stylesheet" href="css/shared/topbar.css?v=d13d8b13">
+<link rel="stylesheet" href="css/shared/topbar.css?v=e911094d">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/status/status.css?v=c79bb886">
 </head>
@@ -106,7 +106,7 @@
 <script src="https://cdn.jsdelivr.net/npm/markdown-it@14/dist/markdown-it.min.js"></script>
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script src="js/lib/analytics.js?v=7855fb4c"></script>
-<script src="js/lib/topbar.js?v=593ecfed"></script>
+<script src="js/lib/topbar.js?v=21a7ccea"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/status/main.js?v=16e777ed"></script>
 

--- a/submit.html
+++ b/submit.html
@@ -13,9 +13,10 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=d13d8b13">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=02cda53a">
+<link rel="stylesheet" href="css/shared/lookup-inline.css?v=71ca0f75">
 <link rel="stylesheet" href="css/app/game-header.css?v=1ae5af52">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=a1cd2459">
+<link rel="stylesheet" href="css/app/reports.css?v=dd4b044e">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">
 <link rel="stylesheet" href="css/app/home.css?v=3b655a71">
 </head>
@@ -52,12 +53,11 @@
           <span class="gh-login-btn__badge"><img class="gh-login-btn__icon" src="assets/steam-logo-glyph.png" alt=""></span>
           <span class="gh-login-btn__label">Login with Steam</span>
         </button>
-        <p style="margin-top:14px;padding-top:12px;border-top:1px solid var(--border);font-size:0.85rem;color:var(--muted)">
-          Not ready to sign in? You can still
-          <a href="lookup.html" style="color:var(--accent);font-weight:600">look up any public Steam profile</a>
-          and see its Proton compatibility.
-        </p>
       </div>
+      <!-- Inline Library panel (#323 followup): peer of the auth-gate card,
+           not nested inside it, so the anonymous alternative reads as a
+           distinct path rather than "part of the sign-in prompt". -->
+      <div id="profile-lookup-inline-mount"></div>
     </div>
 
     <div id="submit-form-content">Loading form...</div>
@@ -65,6 +65,6 @@
   </div>
 </div>
 
-<script type="module" src="js/submit/main.js?v=63e44bd8"></script>
+<script type="module" src="js/submit/main.js?v=657f501b"></script>
 </body>
 </html>

--- a/submit.html
+++ b/submit.html
@@ -10,7 +10,7 @@
 <title>Submit Report — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=daf1bfe9">
-<link rel="stylesheet" href="css/shared/topbar.css?v=d13d8b13">
+<link rel="stylesheet" href="css/shared/topbar.css?v=e911094d">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=02cda53a">
 <link rel="stylesheet" href="css/shared/lookup-inline.css?v=71ca0f75">
@@ -25,7 +25,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script src="js/lib/analytics.js?v=7855fb4c"></script>
-<script src="js/lib/topbar.js?v=593ecfed"></script>
+<script src="js/lib/topbar.js?v=21a7ccea"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <!-- Markdown editor spike (?md=1). Loaded eagerly but only wired when the
      flag is on -- window.markdownit stays unused otherwise. -->

--- a/supabase/functions/public-steam-profile/index.ts
+++ b/supabase/functions/public-steam-profile/index.ts
@@ -39,6 +39,11 @@ interface PlayerSummary {
   profilestate?: number;
 }
 
+interface WishlistItem {
+  appid: number;
+  priority?: number;
+}
+
 interface Envelope {
   ok: boolean;
   steamId?: string;
@@ -52,6 +57,8 @@ interface Envelope {
   };
   games?: OwnedGame[];
   gameCount?: number;
+  wishlist?: WishlistItem[];
+  wishlistCount?: number;
   error?: string;
   errorCode?:
     | "invalid_input"
@@ -159,6 +166,32 @@ async function getOwnedGames(steamId: string, apiKey: string): Promise<{ games?:
   }
 }
 
+async function getWishlist(steamId: string, apiKey: string): Promise<{ items?: WishlistItem[]; count?: number }> {
+  // IWishlistService/GetWishlist respects the profile's wishlist visibility.
+  // Private wishlist -> empty items[]. We keep it best-effort: any failure
+  // here just skips the wishlist section without breaking the library view.
+  const url =
+    `https://api.steampowered.com/IWishlistService/GetWishlist/v1/` +
+    `?key=${encodeURIComponent(apiKey)}` +
+    `&steamid=${encodeURIComponent(steamId)}`;
+  try {
+    const res = await fetch(url, { headers: { Accept: "application/json" } });
+    if (!res.ok) return {};
+    const body = await res.json();
+    const items: WishlistItem[] = Array.isArray(body?.response?.items)
+      ? body.response.items
+          .map((i: { appid?: number; priority?: number }) => ({
+            appid: Number(i.appid),
+            priority: typeof i.priority === "number" ? i.priority : undefined,
+          }))
+          .filter((i: WishlistItem) => Number.isFinite(i.appid))
+      : [];
+    return { items, count: items.length };
+  } catch {
+    return {};
+  }
+}
+
 async function getPlayerSummary(steamId: string, apiKey: string): Promise<PlayerSummary | null> {
   const url =
     `https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v2/` +
@@ -215,8 +248,9 @@ Deno.serve(async (req: Request) => {
     steamId = r.steamId;
   }
 
-  const [owned, summary] = await Promise.all([
+  const [owned, wishlist, summary] = await Promise.all([
     getOwnedGames(steamId, apiKey),
+    getWishlist(steamId, apiKey),
     getPlayerSummary(steamId, apiKey),
   ]);
   if (owned.error) {
@@ -225,7 +259,7 @@ Deno.serve(async (req: Request) => {
 
   const isPublic = (summary?.communityvisibilitystate ?? 0) === 3;
   console.log(
-    `[public-steam-profile] steamId=${steamId} resolved=${resolvedFrom} isPublic=${isPublic} gameCount=${owned.count ?? 0}`,
+    `[public-steam-profile] steamId=${steamId} resolved=${resolvedFrom} isPublic=${isPublic} gameCount=${owned.count ?? 0} wishlistCount=${wishlist.count ?? 0}`,
   );
 
   return json({
@@ -240,5 +274,7 @@ Deno.serve(async (req: Request) => {
     },
     games: owned.games,
     gameCount: owned.count,
+    wishlist: wishlist.items,
+    wishlistCount: wishlist.count,
   });
 });

--- a/system-edit.html
+++ b/system-edit.html
@@ -10,7 +10,7 @@
 <title>Edit System — Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=daf1bfe9">
-<link rel="stylesheet" href="css/shared/topbar.css?v=d13d8b13">
+<link rel="stylesheet" href="css/shared/topbar.css?v=e911094d">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=02cda53a">
 <link rel="stylesheet" href="css/profile/profile.css?v=e9fe4860">
@@ -20,7 +20,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script src="js/lib/analytics.js?v=7855fb4c"></script>
-<script src="js/lib/topbar.js?v=593ecfed"></script>
+<script src="js/lib/topbar.js?v=21a7ccea"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/system-edit.html
+++ b/system-edit.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=d13d8b13">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=02cda53a">
-<link rel="stylesheet" href="css/profile/profile.css?v=c45ec766">
+<link rel="stylesheet" href="css/profile/profile.css?v=e9fe4860">
 </head>
 <body>
 

--- a/terms.html
+++ b/terms.html
@@ -10,7 +10,7 @@
 <title>Terms of Service - Proton Pulse</title>
 <meta name="color-scheme" content="dark">
 <link rel="stylesheet" href="css/shared/base.css?v=daf1bfe9">
-<link rel="stylesheet" href="css/shared/topbar.css?v=d13d8b13">
+<link rel="stylesheet" href="css/shared/topbar.css?v=e911094d">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=02cda53a">
 <link rel="stylesheet" href="css/index/index.css?v=3960482d">
@@ -93,7 +93,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script src="js/lib/analytics.js?v=7855fb4c"></script>
-<script src="js/lib/topbar.js?v=593ecfed"></script>
+<script src="js/lib/topbar.js?v=21a7ccea"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/tests/aboutFraming.test.js
+++ b/tests/aboutFraming.test.js
@@ -1,0 +1,64 @@
+/**
+ * #324: About page framing -- Proton Pulse is NOT just a ProtonDB frontend.
+ *
+ * Locks in the language change so a well-meaning copy edit does not
+ * accidentally re-frame the site as "a ProtonDB frontend". The signal
+ * researchers and press need is the "Where the data comes from" section
+ * naming every ingest by name.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const ABOUT = fs.readFileSync(path.join(__dirname, '..', 'about.html'), 'utf8');
+
+describe('about.html framing (#324)', () => {
+  test('opening paragraph leads with what Proton Pulse does, not with ProtonDB', () => {
+    // The first paragraph after the h1 must NOT open with a ProtonDB
+    // comparison. It should describe what the site is on its own terms.
+    const opening = ABOUT.match(/<h1>About Proton Pulse<\/h1>\s*<p>([\s\S]*?)<\/p>/);
+    expect(opening).toBeTruthy();
+    const body = opening[1].trim();
+    // Must not open with "a ProtonDB ..." -- that framing is what we are
+    // pushing back on.
+    expect(body).not.toMatch(/^Proton Pulse is (a|an)\s+[A-Za-z]+\s+for ProtonDB/i);
+    // Must include concrete things we do beyond consuming ProtonDB.
+    expect(body).toMatch(/report submission/i);
+    expect(body).toMatch(/moderation/i);
+    expect(body).toMatch(/(scoring|score)/i);
+    expect(body).toMatch(/Steam Deck/i);
+    // Must explicitly frame ProtonDB as one input among several.
+    // Allow any whitespace (including newlines) between "one of" and "several"
+    // since the HTML source may wrap the sentence across lines.
+    expect(body).toMatch(/one of\s+several/i);
+  });
+
+  test('quicklinks include a "Where the data comes from" jump so readers find the source list', () => {
+    expect(ABOUT).toMatch(/href="#data-sources"[^>]*>[^<]*Where the data comes from/);
+  });
+
+  test('data-sources section exists and names every ingest', () => {
+    const section = ABOUT.match(/id="data-sources"[\s\S]*?<div class="section-label"/);
+    expect(section).toBeTruthy();
+    const body = section[0];
+    for (const label of [
+      'ProtonDB reports',
+      'Pulse Reports',
+      'Steam Web API',
+      'Deck / Machine / SteamOS verification',
+      'GOG + Epic',
+      'Hardware-weighted scoring',
+    ]) {
+      expect(body).toContain(label);
+    }
+  });
+
+  test('ProtonDB card explicitly frames it as one input, not the whole site', () => {
+    // Otherwise a reader can still walk away thinking we are a frontend.
+    expect(ABOUT).toMatch(/One of several inputs, not the whole site/i);
+  });
+
+  test('the Proton Pulse vs ProtonDB comparison table remains reachable', () => {
+    expect(ABOUT).toMatch(/id="compare"/);
+    expect(ABOUT).toMatch(/Proton Pulse vs ProtonDB/);
+  });
+});

--- a/tests/publicSteamProfile.test.js
+++ b/tests/publicSteamProfile.test.js
@@ -48,17 +48,28 @@ describe('parseSteamProfileInput contract (source-level, since Deno TS cannot be
 });
 
 describe('public-steam-profile edge function shape', () => {
-  test('uses ResolveVanityURL and GetOwnedGames', () => {
+  test('uses ResolveVanityURL, GetOwnedGames, GetWishlist, and GetPlayerSummaries', () => {
     expect(EDGE).toContain('/ISteamUser/ResolveVanityURL/v1/');
     expect(EDGE).toContain('/IPlayerService/GetOwnedGames/v1/');
+    expect(EDGE).toContain('/IWishlistService/GetWishlist/v1/');
     expect(EDGE).toContain('/ISteamUser/GetPlayerSummaries/v2/');
+  });
+  test('returns library + wishlist in the same envelope so the frontend renders both', () => {
+    expect(EDGE).toContain('games: owned.games');
+    expect(EDGE).toContain('wishlist: wishlist.items');
+    expect(EDGE).toContain('wishlistCount: wishlist.count');
   });
   test('reads STEAM_API_KEY from env and returns 500 when missing', () => {
     expect(EDGE).toContain(`Deno.env.get("STEAM_API_KEY")`);
     expect(EDGE).toContain('missing_key');
   });
   test('never echoes the API key back to the caller', () => {
-    expect(EDGE).not.toMatch(/return[\s\S]{0,80}apiKey/);
+    // The api key may appear on `fetch` URLs (that is the whole point), but
+    // it must never show up inside a json() response body.
+    const jsonCalls = EDGE.match(/json\([\s\S]*?\)/g) || [];
+    for (const call of jsonCalls) {
+      expect(call).not.toMatch(/apiKey/);
+    }
   });
   test('vanity resolution failure returns 404 vanity_not_found', () => {
     expect(EDGE).toContain('vanity_not_found');
@@ -81,10 +92,11 @@ describe('supabase/config.toml public-steam-profile registration', () => {
 });
 
 describe('lookup.html + js/lookup/main.js wiring', () => {
-  test('lookup.html renders the form + result mount', () => {
+  test('lookup.html renders the form + result mounts (library + wishlist)', () => {
     expect(LOOKUP_HTML).toContain('id="lookup-form"');
     expect(LOOKUP_HTML).toContain('id="lookup-input"');
     expect(LOOKUP_HTML).toContain('id="lookup-chart-mount"');
+    expect(LOOKUP_HTML).toContain('id="lookup-wishlist-mount"');
     expect(LOOKUP_HTML).toContain('id="lookup-private"');
   });
   test('lookup.html links to Steam help for finding a profile URL + privacy settings', () => {
@@ -102,9 +114,18 @@ describe('lookup.html + js/lookup/main.js wiring', () => {
     expect(LOOKUP_MAIN).toContain("nextUrl.searchParams.set('steamId', steamId)");
     expect(LOOKUP_MAIN).toContain('window.history.replaceState');
   });
-  test('lookup main renders "Library at a glance" via the shared computeLibraryTierCounts', () => {
+  test('lookup main renders "Library at a glance" and "Wishlist at a glance" via the shared computeLibraryTierCounts', () => {
     expect(LOOKUP_MAIN).toContain('computeLibraryTierCounts');
     expect(LOOKUP_MAIN).toContain('Library at a glance');
+    expect(LOOKUP_MAIN).toContain('Wishlist at a glance');
+    expect(LOOKUP_MAIN).toContain('wishlistMount');
+  });
+  test('lookup main treats library + wishlist visibility independently (private library can still show wishlist)', () => {
+    // The wishlistCount branch is not gated by isPublic since Steam has a
+    // separate wishlist visibility toggle. Regressing this makes the wishlist
+    // chart silently vanish for anyone with a private library + public
+    // wishlist, which is the exact case a public lookup is most useful for.
+    expect(LOOKUP_MAIN).toMatch(/if \(wishlistCount > 0 && Array\.isArray\(wishlist\)\)/);
   });
   test('lookup main shows the private-profile notice when isPublic=false', () => {
     expect(LOOKUP_MAIN).toContain('privateEl');
@@ -114,7 +135,15 @@ describe('lookup.html + js/lookup/main.js wiring', () => {
 
 describe('deploy plumbing', () => {
   test('lookup files are on the gh-pages manifest', () => {
-    for (const f of ['lookup.html', 'js/lookup/main.js', 'css/lookup/lookup.css']) {
+    for (const f of [
+      'lookup.html',
+      'js/lookup/main.js',
+      'js/app/lib/saved-lookup.js',
+      'js/shared/lookup-storage.js',
+      'js/shared/profile-lookup-inline.js',
+      'css/lookup/lookup.css',
+      'css/shared/lookup-inline.css',
+    ]) {
       expect(MANIFEST).toContain(f);
     }
   });
@@ -126,18 +155,247 @@ describe('deploy plumbing', () => {
 });
 
 describe('sign-in hint spread across the site', () => {
-  test('auth.html points to lookup as the no-signin alternative', () => {
+  test('auth.html offers the no-signin path via the inline mount (replaces the old hint link)', () => {
+    // Post-#323 followup: the auth-no-signin-hint <p> link is gone;
+    // the inline Library panel mounts as a peer of the auth-card and
+    // renders its own "View full library breakdown" link back to /lookup.
     const AUTH = read('auth.html');
-    expect(AUTH).toContain('auth-no-signin-hint');
-    expect(AUTH).toContain('href="lookup.html"');
+    expect(AUTH).toContain('id="profile-lookup-inline-mount"');
   });
   test('profile.html signed-out state offers the lookup path', () => {
+    // Post-#323 followup: the inline "Library" panel mounts under the
+    // Login button, replacing the standalone hint link. The panel itself
+    // renders a "View full library breakdown" link to lookup.html, so
+    // the outbound path still exists -- it just comes from the shared
+    // mount template rather than inline profile.html markup.
     const PROFILE = read('profile.html');
-    expect(PROFILE).toContain('profile-unsigned-hint');
-    expect(PROFILE).toContain('href="lookup.html"');
+    expect(PROFILE).toContain('id="profile-lookup-inline-mount"');
   });
-  test('submit.html auth-gate hint offers the lookup path', () => {
+  test('submit.html auth-gate offers the no-signin path via the inline mount (replaces the old hint link)', () => {
+    // Post-#323 followup: same as auth.html -- the outbound link inside
+    // the auth-gate is replaced with the inline Library panel mounted
+    // as a peer of the login card.
     const SUBMIT = read('submit.html');
-    expect(SUBMIT).toMatch(/auth-gate[\s\S]*href="lookup\.html"/);
+    expect(SUBMIT).toMatch(/id="auth-gate"[\s\S]*id="profile-lookup-inline-mount"/);
+  });
+});
+
+describe('#323 localStorage persistence + Save button + nav fallback', () => {
+  const LOOKUP_HTML_STR = read('lookup.html');
+  const LOOKUP_MAIN_STR = read('js/lookup/main.js');
+  const SAVED_LOOKUP = read('js/app/lib/saved-lookup.js');
+  const HOME_JS = read('js/app/components/home.js');
+
+  test('lookup page has separate Look up + Save buttons, plus Clear', () => {
+    expect(LOOKUP_HTML_STR).toContain('id="lookup-lookup"');
+    expect(LOOKUP_HTML_STR).toContain('id="lookup-save"');
+    expect(LOOKUP_HTML_STR).toContain('id="lookup-clear"');
+    expect(LOOKUP_HTML_STR).toContain('id="lookup-saved-hint"');
+  });
+
+  test('lookup page ships an Examples bullet list matching ProtonDB layout', () => {
+    expect(LOOKUP_HTML_STR).toMatch(/<ul class="lookup-examples">/);
+    expect(LOOKUP_HTML_STR).toContain('steamcommunity.com/id/NAME-IN-URL');
+    expect(LOOKUP_HTML_STR).toMatch(/76561198#+/);
+  });
+
+  test('lookup page keeps the Steam help doc link prominent', () => {
+    expect(LOOKUP_HTML_STR).toContain('help.steampowered.com/en/faqs/view/2816-BE67-5B69-0FEC');
+  });
+
+  test('lookup main imports the localStorage keys from the shared module (no duplicated string literals)', () => {
+    expect(LOOKUP_MAIN_STR).toMatch(/import \{ LS_INPUT_KEY, LS_STEAMID_KEY \} from '\.\.\/shared\/lookup-storage\.js/);
+  });
+
+  test('lookup main persists only when the Save button is clicked (Look up is transient)', () => {
+    // runLookup takes { persist } and only writes on persist=true.
+    expect(LOOKUP_MAIN_STR).toMatch(/async function runLookup\(input, \{ persist = false \} = \{\}\)/);
+    expect(LOOKUP_MAIN_STR).toMatch(/if \(persist\)\s*\{\s*writeSaved/);
+    // Save button wires persist:true; Look up wires persist:false.
+    expect(LOOKUP_MAIN_STR).toMatch(/saveBtn[\s\S]{0,200}submit\(\{ persist: true \}\)/);
+    expect(LOOKUP_MAIN_STR).toMatch(/lookupBtn[\s\S]{0,200}submit\(\{ persist: false \}\)/);
+  });
+
+  test('lookup main autofills + auto-runs from localStorage on load, with URL param taking priority', () => {
+    expect(LOOKUP_MAIN_STR).toContain('readSaved()');
+    // URL preset wins; storage fills in when URL is empty.
+    expect(LOOKUP_MAIN_STR).toMatch(/const preset = urlPreset \|\| saved\.input/);
+  });
+
+  test('lookup main Clear button wipes both localStorage keys and empties the input', () => {
+    expect(LOOKUP_MAIN_STR).toMatch(/clearBtn\.addEventListener\('click'/);
+    expect(LOOKUP_MAIN_STR).toMatch(/clearSaved\(\)/);
+    expect(LOOKUP_MAIN_STR).toMatch(/removeItem\(LS_INPUT_KEY\)/);
+    expect(LOOKUP_MAIN_STR).toMatch(/removeItem\(LS_STEAMID_KEY\)/);
+  });
+
+  test('saved-lookup helper caches the edge-fn response so library + wishlist share one round-trip', () => {
+    expect(SAVED_LOOKUP).toContain('getSavedLookupLibraryAppIds');
+    expect(SAVED_LOOKUP).toContain('getSavedLookupWishlistAppIds');
+    expect(SAVED_LOOKUP).toContain('hasSavedLookup');
+    expect(SAVED_LOOKUP).toMatch(/let _cache = null/);
+    // Key comes from the shared module; never duplicates the string literal.
+    expect(SAVED_LOOKUP).toMatch(/import \{ LS_INPUT_KEY \} from ['"]\.\.\/\.\.\/shared\/lookup-storage\.js/);
+    // Reads only -- never writes to localStorage.
+    expect(SAVED_LOOKUP).not.toMatch(/localStorage\.setItem/);
+  });
+
+  test('home.js exposes scope helpers that pick signed-in > saved-lookup > empty', () => {
+    // All three call sites (owner badges, URL-driven filter, filter pill
+    // onChange) MUST use the shared helpers so the fallback stays
+    // consistent. Regressions that call getMyLibraryAppIds directly
+    // silently break the saved-lookup path.
+    expect(HOME_JS).toMatch(/async function _libraryAppIdsForScope\(\)/);
+    expect(HOME_JS).toMatch(/async function _wishlistAppIdsForScope\(\)/);
+    // Each helper checks the session first, then falls back to the saved
+    // lookup if hasSavedLookup, then returns empty.
+    expect(HOME_JS).toMatch(/if \(session\?\.user\) return await getMyLibraryAppIds/);
+    expect(HOME_JS).toMatch(/if \(hasSavedLookup\(\)\) return await getSavedLookupLibraryAppIds/);
+    expect(HOME_JS).toMatch(/if \(session\?\.user\) return await getMyWishlistAppIds/);
+    expect(HOME_JS).toMatch(/if \(hasSavedLookup\(\)\) return await getSavedLookupWishlistAppIds/);
+  });
+
+  test('home.js call sites route through the scope helpers (no direct getMy* calls in filter / badge / URL paths)', () => {
+    // The URL-driven ?filter=mine branch, the filter pill onChange, and
+    // the _buildOwnerBadgeContext all call the shared helpers now. The
+    // ONLY remaining direct getMyLibraryAppIds / getMyWishlistAppIds
+    // calls live INSIDE the scope helpers themselves. Locking this in
+    // ensures a new call site cannot silently regress the fallback.
+    const directLibraryCalls = (HOME_JS.match(/getMyLibraryAppIds\(\)/g) || []).length;
+    const directWishlistCalls = (HOME_JS.match(/getMyWishlistAppIds\(\)/g) || []).length;
+    // One direct call each remains inside the helper itself.
+    expect(directLibraryCalls).toBe(1);
+    expect(directWishlistCalls).toBe(1);
+  });
+
+  test('home.js hides the sign-in callout when a saved lookup exists (no nag)', () => {
+    // The "Sign in to get started" callout is a nag if the user already has
+    // a saved lookup providing the same value. Regressing this makes the
+    // callout appear alongside a fully populated library chart.
+    expect(HOME_JS).toMatch(/_callout\.hidden = hasSavedLookup\(\)/);
+  });
+
+  test('home-library-chart renders for signed-out visitors when a saved lookup exists', () => {
+    // The chart used to bail with `mountEl.innerHTML = ''` for any
+    // signed-out visitor. It must now check hasSavedLookup and swap the
+    // signed-in fetch for the saved-lookup helper instead of returning
+    // blank -- otherwise the "at a glance" chart never appears on the
+    // browse view for anonymous visitors with a saved profile.
+    const CHART = fs.readFileSync(
+      path.join(__dirname, '..', 'js', 'app', 'components', 'home-library-chart.js'),
+      'utf8',
+    );
+    expect(CHART).toContain('hasSavedLookup');
+    expect(CHART).toContain('getSavedLookupLibraryAppIds');
+    expect(CHART).toContain('getSavedLookupWishlistAppIds');
+    expect(CHART).toMatch(/useSavedLookup\s*=\s*true/);
+    // The old "signed-out -> blank" early return is gated on
+    // !hasSavedLookup so it only fires when there is truly nothing to show.
+    expect(CHART).toMatch(/if \(!savedMod\.hasSavedLookup\(\)\)[\s\S]{0,80}mountEl\.innerHTML = ''/);
+  });
+});
+
+describe('#323 followup: inline Library panel under Login button', () => {
+  const PROFILE_HTML = read('profile.html');
+  const PROFILE_MAIN = read('js/profile/main.js');
+  const INLINE = read('js/shared/profile-lookup-inline.js');
+  const STORAGE = read('js/shared/lookup-storage.js');
+  const INLINE_CSS = read('css/shared/lookup-inline.css');
+
+  test('profile.html mount is a peer of the login card, not nested inside it', () => {
+    // The mount container must sit as a SIBLING of .profile-unsigned, not
+    // as a child. Two cards on the page read as two distinct alternatives;
+    // nesting the panel inside the login card makes it look like "part of
+    // the login flow".
+    const unsignedBlock = PROFILE_HTML.match(/<div class="profile-unsigned">[\s\S]*?<\/div>/);
+    expect(unsignedBlock).toBeTruthy();
+    expect(unsignedBlock[0]).not.toContain('profile-lookup-inline-mount');
+    // But the mount container IS still inside the outer signed-out wrapper.
+    const signedOut = PROFILE_HTML.match(/id="profile-signed-out"[\s\S]*?<\/div>\s*<\/div>\s*<\/div>/);
+    expect(signedOut[0]).toContain('id="profile-lookup-inline-mount"');
+    // Order: login card first, then the mount below it.
+    const btnPos = signedOut[0].indexOf('class="profile-unsigned"');
+    const mountPos = signedOut[0].indexOf('id="profile-lookup-inline-mount"');
+    expect(mountPos).toBeGreaterThan(btnPos);
+  });
+
+  test('profile.html includes the shared inline-lookup stylesheet', () => {
+    expect(PROFILE_HTML).toMatch(/href="css\/shared\/lookup-inline\.css/);
+  });
+
+  test('profile main mounts the inline lookup on showSignedOut', () => {
+    expect(PROFILE_MAIN).toContain('mountInlineProfileLookup');
+    expect(PROFILE_MAIN).toContain("'profile-lookup-inline-mount'");
+    expect(PROFILE_MAIN).toMatch(/import\(.*profile-lookup-inline\.js/);
+  });
+
+  test('inline mount uses the shared localStorage keys (never inlines the key string)', () => {
+    expect(INLINE).toMatch(/import \{[^}]*readSavedLookup[^}]*writeSavedLookup[^}]*clearSavedLookup[^}]*\} from ['"]\.\/lookup-storage\.js/);
+    expect(INLINE).not.toContain("'pp:lookup-profile-input'");
+    expect(INLINE).not.toContain("'pp:lookup-profile-steamid'");
+  });
+
+  test('inline mount hits the public-steam-profile edge fn and persists the resolved SteamID', () => {
+    expect(INLINE).toContain('/functions/v1/public-steam-profile');
+    expect(INLINE).toMatch(/writeSavedLookup\(input, body\.steamId/);
+  });
+
+  test('inline mount keeps the Steam help doc + privacy settings links prominent', () => {
+    expect(INLINE).toContain('help.steampowered.com/en/faqs/view/2816-BE67-5B69-0FEC');
+    expect(INLINE).toContain('steamcommunity.com/my/edit/settings');
+  });
+
+  test('inline mount offers a "View full library breakdown" link back to /lookup', () => {
+    expect(INLINE).toMatch(/href="lookup\.html"/);
+  });
+
+  test('inline mount Clear button wipes the saved lookup', () => {
+    expect(INLINE).toMatch(/clearSavedLookup\(\)/);
+  });
+
+  test('shared lookup-storage module exports the three helpers other modules use', () => {
+    expect(STORAGE).toMatch(/export function readSavedLookup/);
+    expect(STORAGE).toMatch(/export function writeSavedLookup/);
+    expect(STORAGE).toMatch(/export function clearSavedLookup/);
+    expect(STORAGE).toMatch(/export const LS_INPUT_KEY = 'pp:lookup-profile-input'/);
+    expect(STORAGE).toMatch(/export const LS_STEAMID_KEY = 'pp:lookup-profile-steamid'/);
+  });
+
+  test('inline CSS ships all element classes the mount renders', () => {
+    for (const cls of ['.profile-lookup-inline', '.pli-title', '.pli-copy', '.pli-input', '.pli-save', '.pli-examples', '.pli-hint', '.pli-status', '.pli-actions', '.pli-clear']) {
+      expect(INLINE_CSS).toContain(cls);
+    }
+  });
+
+  test('auth.html mounts the inline panel as a peer of the auth-card', () => {
+    const AUTH = read('auth.html');
+    // Mount container sits OUTSIDE the <main class="auth-card">, not inside.
+    expect(AUTH).toMatch(/<\/main>\s*[\s\S]{0,200}<div id="profile-lookup-inline-mount"/);
+    // Stylesheet is included so the panel actually renders.
+    expect(AUTH).toMatch(/href="css\/shared\/lookup-inline\.css/);
+    // Bootstrap script imports the mount fn.
+    expect(AUTH).toMatch(/import \{ mountInlineProfileLookup \} from ['"]\.\/js\/shared\/profile-lookup-inline\.js/);
+  });
+
+  test('auth.css sizes the mount to match the auth-card width so they stack cleanly', () => {
+    const AUTH_CSS = read('css/auth/auth.css');
+    expect(AUTH_CSS).toContain('.auth-lookup-mount');
+    expect(AUTH_CSS).toMatch(/width:\s*min\(100%,\s*760px\)/);
+  });
+
+  test('submit.html auth-gate mounts the inline panel as a peer of the login card', () => {
+    const SUBMIT = read('submit.html');
+    // auth-gate wraps two peer divs: the login card + the mount container.
+    const gate = SUBMIT.match(/id="auth-gate"[\s\S]*?<\/div>\s*<\/div>/);
+    expect(gate).toBeTruthy();
+    expect(gate[0]).toContain('id="profile-lookup-inline-mount"');
+    // Stylesheet is included.
+    expect(SUBMIT).toMatch(/href="css\/shared\/lookup-inline\.css/);
+  });
+
+  test('submit main mounts the inline panel when the auth-gate becomes visible', () => {
+    const SUBMIT_MAIN = read('js/submit/main.js');
+    expect(SUBMIT_MAIN).toContain("mountInlineProfileLookup('profile-lookup-inline-mount')");
+    expect(SUBMIT_MAIN).toMatch(/import\(.*profile-lookup-inline\.js/);
   });
 });

--- a/tests/publicSteamProfile.test.js
+++ b/tests/publicSteamProfile.test.js
@@ -155,12 +155,14 @@ describe('deploy plumbing', () => {
 });
 
 describe('sign-in hint spread across the site', () => {
-  test('auth.html offers the no-signin path via the inline mount (replaces the old hint link)', () => {
-    // Post-#323 followup: the auth-no-signin-hint <p> link is gone;
-    // the inline Library panel mounts as a peer of the auth-card and
-    // renders its own "View full library breakdown" link back to /lookup.
+  test('auth.html does NOT offer the no-signin path -- the user came here to sign in', () => {
+    // The inline lookup was later removed from auth.html because the user
+    // clicked "Login with Steam" to reach this page, so offering the
+    // anonymous alt-path here competes with that intent. The alt-path
+    // still lives on profile.html + submit.html and on the dedicated
+    // lookup.html page.
     const AUTH = read('auth.html');
-    expect(AUTH).toContain('id="profile-lookup-inline-mount"');
+    expect(AUTH).not.toContain('profile-lookup-inline-mount');
   });
   test('profile.html signed-out state offers the lookup path', () => {
     // Post-#323 followup: the inline "Library" panel mounts under the
@@ -367,20 +369,12 @@ describe('#323 followup: inline Library panel under Login button', () => {
     }
   });
 
-  test('auth.html mounts the inline panel as a peer of the auth-card', () => {
+  test('auth.html does NOT mount the inline panel: the sign-in page is committed to sign-in', () => {
+    // The user landed here to sign in with Steam. Offering the anonymous
+    // alt-path on the same page competes with that intent and is confusing.
     const AUTH = read('auth.html');
-    // Mount container sits OUTSIDE the <main class="auth-card">, not inside.
-    expect(AUTH).toMatch(/<\/main>\s*[\s\S]{0,200}<div id="profile-lookup-inline-mount"/);
-    // Stylesheet is included so the panel actually renders.
-    expect(AUTH).toMatch(/href="css\/shared\/lookup-inline\.css/);
-    // Bootstrap script imports the mount fn.
-    expect(AUTH).toMatch(/import \{ mountInlineProfileLookup \} from ['"]\.\/js\/shared\/profile-lookup-inline\.js/);
-  });
-
-  test('auth.css sizes the mount to match the auth-card width so they stack cleanly', () => {
-    const AUTH_CSS = read('css/auth/auth.css');
-    expect(AUTH_CSS).toContain('.auth-lookup-mount');
-    expect(AUTH_CSS).toMatch(/width:\s*min\(100%,\s*760px\)/);
+    expect(AUTH).not.toContain('profile-lookup-inline-mount');
+    expect(AUTH).not.toContain('mountInlineProfileLookup');
   });
 
   test('submit.html auth-gate mounts the inline panel as a peer of the login card', () => {

--- a/tests/securityMd.test.js
+++ b/tests/securityMd.test.js
@@ -1,0 +1,73 @@
+/**
+ * #313: SECURITY.md disclosure policy at repo root.
+ *
+ * Pins the minimum content the policy must carry. Regressions here typically
+ * happen when someone edits SECURITY.md and accidentally drops a section --
+ * scope, SLA, or safe-harbor language are the ones researchers actually
+ * check before submitting, so losing them silently is a real cost.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const read = (p) => fs.readFileSync(path.join(ROOT, p), 'utf8');
+
+const SECURITY = read('SECURITY.md');
+const ABOUT = read('about.html');
+
+describe('SECURITY.md disclosure policy', () => {
+  test('file exists at repo root', () => {
+    expect(fs.existsSync(path.join(ROOT, 'SECURITY.md'))).toBe(true);
+  });
+
+  test('advertises private GitHub security advisories as the preferred channel', () => {
+    expect(SECURITY).toMatch(/github\.com\/mdeguzis\/proton-pulse-web\/security\/advisories/);
+    expect(SECURITY.toLowerCase()).toContain('preferred');
+  });
+
+  test('provides an email fallback', () => {
+    expect(SECURITY).toContain('mdeguzis@gmail.com');
+  });
+
+  test('states the response SLA (72 hours + one week)', () => {
+    expect(SECURITY).toMatch(/72 hours/);
+    expect(SECURITY).toMatch(/one week/i);
+  });
+
+  test('spells out in-scope and out-of-scope sections', () => {
+    expect(SECURITY.toLowerCase()).toContain('in scope');
+    expect(SECURITY.toLowerCase()).toContain('out of scope');
+    // must cover the surfaces users can attack that we own
+    expect(SECURITY).toContain('proton-pulse.com');
+    expect(SECURITY).toContain('supabase/functions/');
+    expect(SECURITY).toContain('public-steam-profile');
+  });
+
+  test('carries safe-harbor language for good-faith research', () => {
+    expect(SECURITY.toLowerCase()).toContain('safe harbor');
+    // negation clauses researchers look for
+    expect(SECURITY).toMatch(/will not initiate legal action/i);
+  });
+
+  test('sets a coordinated-disclosure default window', () => {
+    expect(SECURITY).toMatch(/90 days/);
+  });
+
+  test('cross-links to the plugin repo SECURITY.md so researchers land in one place', () => {
+    expect(SECURITY).toMatch(/decky-proton-pulse/);
+  });
+});
+
+describe('about.html Safety and Security section links to SECURITY.md', () => {
+  test('a card links to the full policy at the repo root', () => {
+    // The Safety section already has a Pen testing card that links to
+    // GitHub Security Advisories; the SECURITY.md link is the "read the
+    // whole policy" landing spot for researchers.
+    expect(ABOUT).toMatch(/blob\/main\/SECURITY\.md/);
+  });
+
+  test('the same card mentions the mirrored plugin repo policy', () => {
+    // Kept together so researchers see one policy in two repos.
+    expect(ABOUT).toMatch(/decky-proton-pulse\/blob\/main\/SECURITY\.md/);
+  });
+});

--- a/tests/securityScanners.test.js
+++ b/tests/securityScanners.test.js
@@ -32,6 +32,11 @@ describe('Semgrep SAST workflow (#316)', () => {
   test('runs the semgrep container so the toolchain does not have to be installed per job', () => {
     expect(YAML).toMatch(/image:\s*semgrep\/semgrep/);
   });
+
+  test('excludes the github-actions-mutable-action-tag rule (Dependabot needs version tags)', () => {
+    expect(YAML).toContain('github-actions-mutable-action-tag');
+    expect(YAML).toContain('--exclude-rule');
+  });
 });
 
 describe('SBOM + Grype scan workflow (#317)', () => {
@@ -46,7 +51,7 @@ describe('SBOM + Grype scan workflow (#317)', () => {
   });
 
   test('installs deps before generating the SBOM (otherwise transitive packages are missing)', () => {
-    expect(YAML).toContain('pnpm install --frozen-lockfile');
+    expect(YAML).toContain('npm ci');
   });
 
   test('emits a CycloneDX SBOM (native GitHub dependency graph format)', () => {

--- a/tests/securityScanners.test.js
+++ b/tests/securityScanners.test.js
@@ -59,7 +59,7 @@ describe('SBOM + Grype scan workflow (#317)', () => {
   });
 
   test('Grype fails the build on high or critical (matches npm audit gating)', () => {
-    expect(YAML).toContain('anchore/scan-action@v3');
+    expect(YAML).toMatch(/anchore\/scan-action@v[4-9]/);
     expect(YAML).toMatch(/fail-build:\s*true/);
     expect(YAML).toMatch(/severity-cutoff:\s*high/);
   });

--- a/tests/securityScanners.test.js
+++ b/tests/securityScanners.test.js
@@ -1,0 +1,103 @@
+/**
+ * Pins the three new security scanner workflows (#316, #317, #322) so
+ * regressions that would silently disable a scanner fail CI.
+ *
+ * Each workflow lives at .github/workflows/<name>.yml. The tests here
+ * only check the contract, not the runtime behavior -- the runtime is
+ * verified by the workflows themselves on every push.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const read = (p) => fs.readFileSync(path.join(ROOT, p), 'utf8');
+
+describe('Semgrep SAST workflow (#316)', () => {
+  const YAML = read('.github/workflows/semgrep.yml');
+
+  test('runs on push + PR against main and staging', () => {
+    expect(YAML).toMatch(/branches:\s*\[main,\s*staging\]/);
+  });
+
+  test('runs on a weekly schedule so new upstream rules land without a push', () => {
+    expect(YAML).toMatch(/cron:\s*"0 6 \* \* 1"/);
+  });
+
+  test('applies the TypeScript + OWASP + security-audit rulepacks', () => {
+    expect(YAML).toContain('p/typescript');
+    expect(YAML).toContain('p/owasp-top-ten');
+    expect(YAML).toContain('p/security-audit');
+  });
+
+  test('runs the semgrep container so the toolchain does not have to be installed per job', () => {
+    expect(YAML).toMatch(/image:\s*semgrep\/semgrep/);
+  });
+});
+
+describe('SBOM + Grype scan workflow (#317)', () => {
+  const YAML = read('.github/workflows/sbom.yml');
+
+  test('runs on push + PR against main and staging', () => {
+    expect(YAML).toMatch(/branches:\s*\[main,\s*staging\]/);
+  });
+
+  test('runs on a weekly schedule so new CVEs land without a push', () => {
+    expect(YAML).toMatch(/cron:\s*"0 5 \* \* 1"/);
+  });
+
+  test('installs deps before generating the SBOM (otherwise transitive packages are missing)', () => {
+    expect(YAML).toContain('pnpm install --frozen-lockfile');
+  });
+
+  test('emits a CycloneDX SBOM (native GitHub dependency graph format)', () => {
+    expect(YAML).toMatch(/format:\s*cyclonedx-json/);
+  });
+
+  test('Grype fails the build on high or critical (matches npm audit gating)', () => {
+    expect(YAML).toContain('anchore/scan-action@v3');
+    expect(YAML).toMatch(/fail-build:\s*true/);
+    expect(YAML).toMatch(/severity-cutoff:\s*high/);
+  });
+
+  test('uploads the SBOM as an artifact so tagged releases can attach it', () => {
+    expect(YAML).toContain('actions/upload-artifact');
+    expect(YAML).toContain('sbom.cyclonedx.json');
+  });
+});
+
+describe('Quarterly restore drill reminder workflow (#322)', () => {
+  const YAML = read('.github/workflows/restore-drill-reminder.yml');
+
+  test('scheduled every 90 days (1st of Jan / Apr / Jul / Oct)', () => {
+    expect(YAML).toMatch(/cron:\s*"0 15 1 1,4,7,10 \*"/);
+  });
+
+  test('grants issues:write so the workflow can open the drill issue', () => {
+    expect(YAML).toMatch(/issues:\s*write/);
+  });
+
+  test('idempotent -- skips if an open drill issue for this quarter already exists', () => {
+    // A manual workflow_dispatch run right after a scheduled one must
+    // not spam a second identical issue.
+    expect(YAML).toContain('is:issue is:open label:restore-drill');
+    expect(YAML).toContain('Drill issue already open');
+  });
+
+  test('opens the issue with the restore-drill + security labels', () => {
+    expect(YAML).toContain("labels: ['restore-drill', 'security']");
+  });
+
+  test('body links to the Restore-Runbook wiki + covers every checklist step', () => {
+    expect(YAML).toContain('wiki/Restore-Runbook');
+    for (const step of [
+      'Pull the latest backup tarball',
+      'Verify HMAC signature',
+      'Spin a scratch Supabase project',
+      'Restore schema + data',
+      'Deploy every edge function',
+      'Tear down the scratch project',
+    ]) {
+      expect(YAML).toContain(step);
+    }
+  });
+});

--- a/tests/statusSecuritySection.test.js
+++ b/tests/statusSecuritySection.test.js
@@ -1,0 +1,42 @@
+/**
+ * Pin the status-page Security section to "scanner tiles only".
+ *
+ * The previous implementation also listed every open security issue and
+ * posted an "N open" counter, which duplicated information already
+ * canonical on GitHub. Regressions that re-add the issue list would push
+ * this file back over that line, so lock it here.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const STATUS_MAIN = fs.readFileSync(
+  path.join(__dirname, '..', 'js', 'status', 'main.js'),
+  'utf8',
+);
+
+describe('status page Security section', () => {
+  test('renders the six scanner-status tiles', () => {
+    for (const label of ['CodeQL', 'Dependabot', 'npm audit', 'Rate limiting', 'CSP', 'RLS']) {
+      expect(STATUS_MAIN).toContain(label);
+    }
+  });
+
+  test('does NOT fetch or render the security-labeled issue list', () => {
+    // The whole point of the cleanup: this section stops mirroring the
+    // GitHub issue tracker. If someone re-adds either of these, the
+    // section drifts back into a running bug list.
+    expect(STATUS_MAIN).not.toMatch(/labels=security/);
+    expect(STATUS_MAIN).not.toMatch(/renderSecurityIssue/);
+  });
+
+  test('does NOT post an "N open security issues" counter', () => {
+    expect(STATUS_MAIN).not.toMatch(/open security issue/);
+    expect(STATUS_MAIN).not.toMatch(/openCount/);
+  });
+
+  test('does not schedule a 5-minute security refresh (the section is now static)', () => {
+    // Announcements still have a setInterval; security should not.
+    const securityBlock = STATUS_MAIN.slice(STATUS_MAIN.indexOf('Security scanner posture'));
+    expect(securityBlock).not.toMatch(/setInterval\([\s\S]{0,60}Security/);
+  });
+});

--- a/tests/wishlistFilter.test.js
+++ b/tests/wishlistFilter.test.js
@@ -186,7 +186,10 @@ describe('home.js wires the wishlist filter (#266)', () => {
   test('wishlist selection lazy-loads the appid Set on first activation', () => {
     // Merged handler mirrors the group selection into both librarySel and
     // wishlistSel; wishlistAppIds fetches lazily when the size becomes > 0.
-    expect(HOME_SRC).toMatch(/wishlistSel[\s\S]{0,200}sel\.has\('wishlist'\)[\s\S]{0,400}getMyWishlistAppIds/);
+    // The direct getMyWishlistAppIds call now goes through the shared
+    // _wishlistAppIdsForScope helper (#323 followup) so signed-out
+    // visitors with a saved lookup can still filter by wishlist.
+    expect(HOME_SRC).toMatch(/wishlistSel\s*=\s*sel\.has\('wishlist'\)[\s\S]{0,500}_wishlistAppIdsForScope\(\)/);
   });
 
   test('wishlistSel is included in save + restore + clear + badge count', () => {

--- a/uv.lock
+++ b/uv.lock
@@ -182,11 +182,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]
@@ -342,7 +342,7 @@ requires-dist = [
 dev = [
     { name = "pylint", specifier = ">=3.3.8" },
     { name = "pyright", specifier = ">=1.1.403" },
-    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
 ]
 
@@ -388,7 +388,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -397,9 +397,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -451,9 +451,9 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]


### PR DESCRIPTION
Squash-consolidated release from staging into four logical commits.

## What's in this PR

### Security hardening (#313, #316, #317, #322)
- SECURITY.md vulnerability disclosure policy
- Semgrep SAST workflow (push + PR + weekly cron) with typescript/owasp/security-audit rulepacks
- SBOM generation via Syft + vulnerability scan via Grype (fails high/critical)
- Quarterly restore-drill reminder cron (idempotent, opens tracking issue)
- Status page Security section: scanner tiles only, dropped the open-issue list

### Public Steam profile lookup (#299, #323)
- `supabase/functions/public-steam-profile` returns library + wishlist for a vanity URL or SteamID64
- Browser-storage persistence via `js/shared/lookup-storage.js`
- Inline lookup panel mounted as a peer of the login card on auth/submit/profile
- Signed-out visitors with a saved lookup get chart + filters + owner badges + nav (everything except report submission)
- Shared `_libraryAppIdsForScope` / `_wishlistAppIdsForScope` helpers route session > saved-lookup > empty

### About page reframe (#324)
- Opens with "Proton Pulse is a compatibility platform..." instead of a ProtonDB pitch
- New "Where the data comes from" section listing all six ingest sources
- ProtonDB card explicitly notes "one of several inputs, not the whole site"
- Regression test pins the framing

### Admin + signal-strip spacing polish
- Spacer row above Duration in admin report-detail tables (allReports + pending)
- Signal strip gets more room above the answer-icon row

## Test plan
- 1970 tests pass (`make pre-push`)
- Coverage 93.67% overall
- Verified on staging at https://mdeguzis.github.io/proton-pulse-web-staging/