### PR TITLE
style(status): separate Security section from edge-function grid (#329)

### DIFF
--- a/css/status/status.css
+++ b/css/status/status.css
@@ -288,9 +288,10 @@
   font-family: var(--mono);
 }
 
-/* Announcements block: below the per-service grid. Pulled live from the
-   repo's incident-labeled issues so an ongoing event is visible from the
-   status page. */
+/* Security + Announcements blocks: below the per-service grid. Same top
+   spacing treatment so they read as their own sections instead of
+   crowding the last edge-function card. */
+.status-security,
 .status-announcements {
   margin-top: 32px;
   padding-top: 16px;

--- a/status.html
+++ b/status.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=daf1bfe9">
 <link rel="stylesheet" href="css/shared/topbar.css?v=e911094d">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
-<link rel="stylesheet" href="css/status/status.css?v=c79bb886">
+<link rel="stylesheet" href="css/status/status.css?v=f541420f">
 </head>
 <body>
 


### PR DESCRIPTION
Security section was flush against the last edge-function card. Extends the announcements-block spacing treatment (margin-top + padding-top + border-top) to Security so both bottom-page sections have breathing room.

Closes #329.