### PR TITLE
feat(monitor): per-IP rate-limit abuse alerts (#320)

### DIFF
--- a/.github/scripts/security-monitor.mjs
+++ b/.github/scripts/security-monitor.mjs
@@ -121,7 +121,7 @@ async function checkRlsViolations() {
   }
 }
 
-// Check 4: Rate limit hits (429s)
+// Check 4: Rate limit hits (429s) -- aggregate across the site.
 async function checkRateLimitHits() {
   const logs = await sbFetch(`/analytics/endpoints/logs?iso_timestamp_start=${ONE_HOUR_AGO}`);
   if (!logs || !Array.isArray(logs)) {
@@ -138,6 +138,40 @@ async function checkRateLimitHits() {
   }
 }
 
+// Check 5 (#320): Per-IP rate-limit abuse. The aggregate check catches
+// site-wide storms but misses one persistent attacker who trips the
+// limit repeatedly. Group last-hour 429s by client IP and alert when
+// any single IP crosses the abuse threshold. Repeated trips from one
+// origin are what warrants a targeted response (add to WAF block list,
+// contact hosting provider, etc.).
+const RATE_LIMIT_ABUSE_THRESHOLD = 50;
+
+async function checkRateLimitAbusePerIp() {
+  const logs = await sbFetch(`/analytics/endpoints/logs?iso_timestamp_start=${ONE_HOUR_AGO}`);
+  if (!logs || !Array.isArray(logs)) {
+    console.log('Per-IP rate limit logs: no data, skipping');
+    return;
+  }
+  const trips = logs.filter(l => l.status_code === 429);
+  const byIp = new Map();
+  for (const t of trips) {
+    const ip = t.remote_addr || t.client_ip || t.x_forwarded_for || 'unknown';
+    byIp.set(ip, (byIp.get(ip) || 0) + 1);
+  }
+  const offenders = [...byIp.entries()]
+    .filter(([, count]) => count >= RATE_LIMIT_ABUSE_THRESHOLD)
+    .sort((a, b) => b[1] - a[1]);
+  console.log(`Per-IP 429s: ${trips.length} total across ${byIp.size} IPs, ${offenders.length} over threshold ${RATE_LIMIT_ABUSE_THRESHOLD}`);
+  if (offenders.length === 0) return;
+  const detail = offenders.slice(0, 10)
+    .map(([ip, count]) => `- ${ip}: ${count} trips`)
+    .join('\n');
+  await createAlert(
+    '[Alert] Rate-limit abuse from single IP',
+    `${offenders.length} IP${offenders.length === 1 ? '' : 's'} tripped the rate limit ≥ ${RATE_LIMIT_ABUSE_THRESHOLD} times in the last hour.\n\nTop offenders:\n${detail}\n\nThis indicates a targeted attacker rather than incidental traffic. Consider blocking at Cloudflare or your DNS provider. The rate limiter itself is doing its job (all requests returned 429).\n\nTriggered at: ${new Date().toISOString()}`
+  );
+}
+
 async function main() {
   console.log(`Security monitor running at ${new Date().toISOString()}`);
   console.log(`Project: ${PROJECT_REF}, Lookback: ${ONE_HOUR_AGO}`);
@@ -145,6 +179,7 @@ async function main() {
   await checkEdgeFunctionErrors();
   await checkRlsViolations();
   await checkRateLimitHits();
+  await checkRateLimitAbusePerIp();
   console.log('Security monitor complete.');
 }
 

--- a/tests/rateLimitAbuseCheck.test.js
+++ b/tests/rateLimitAbuseCheck.test.js
@@ -1,0 +1,36 @@
+/**
+ * Pins the per-IP rate-limit abuse check (#320) inside security-monitor.mjs
+ * so the aggregate check cannot silently drift away from the per-IP
+ * variant. Regressions here mean a persistent attacker slips past.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const SCRIPT = fs.readFileSync(
+  path.join(__dirname, '..', '.github/scripts/security-monitor.mjs'),
+  'utf8',
+);
+
+describe('per-IP rate-limit abuse check (#320)', () => {
+  test('the check function exists', () => {
+    expect(SCRIPT).toContain('checkRateLimitAbusePerIp');
+  });
+
+  test('groups 429 hits by source IP', () => {
+    expect(SCRIPT).toMatch(/byIp\.set\(ip,/);
+    expect(SCRIPT).toMatch(/remote_addr|client_ip|x_forwarded_for/);
+  });
+
+  test('has a documented abuse threshold constant', () => {
+    expect(SCRIPT).toMatch(/RATE_LIMIT_ABUSE_THRESHOLD\s*=\s*\d+/);
+  });
+
+  test('fires an alert with the offender list when the threshold is crossed', () => {
+    expect(SCRIPT).toContain('Rate-limit abuse from single IP');
+    expect(SCRIPT).toContain('Top offenders');
+  });
+
+  test('is wired into main() so the hourly run actually calls it', () => {
+    expect(SCRIPT).toMatch(/await\s+checkRateLimitAbusePerIp\(\)/);
+  });
+});


### PR DESCRIPTION
Adds a per-IP abuse variant to the hourly security-monitor.

The aggregate 429 check catches site-wide storms but misses a persistent attacker tripping the limit repeatedly from the same IP. New check groups last-hour 429s by client IP and files a security-labeled issue when any IP crosses 50 trips/hour.

The existing discord-issues.yml workflow picks up new issues automatically, so no separate Discord webhook is needed. Alert body lists the top 10 offenders with trip counts so the response is a WAF or DNS-provider block, not a code change.

Wired into main() so it runs in the same hourly pass. Source-scan test pins the function shape, threshold, and wiring.

Closes #320.