### PR TITLE
sec: fuzz + RLS regression + per-IP rate-limit alerts (#318, #320, #321)

### DIFF
--- a/.github/scripts/security-monitor.mjs
+++ b/.github/scripts/security-monitor.mjs
@@ -121,7 +121,7 @@ async function checkRlsViolations() {
   }
 }
 
-// Check 4: Rate limit hits (429s)
+// Check 4: Rate limit hits (429s) -- aggregate across the site.
 async function checkRateLimitHits() {
   const logs = await sbFetch(`/analytics/endpoints/logs?iso_timestamp_start=${ONE_HOUR_AGO}`);
   if (!logs || !Array.isArray(logs)) {
@@ -138,6 +138,40 @@ async function checkRateLimitHits() {
   }
 }
 
+// Check 5 (#320): Per-IP rate-limit abuse. The aggregate check catches
+// site-wide storms but misses one persistent attacker who trips the
+// limit repeatedly. Group last-hour 429s by client IP and alert when
+// any single IP crosses the abuse threshold. Repeated trips from one
+// origin are what warrants a targeted response (add to WAF block list,
+// contact hosting provider, etc.).
+const RATE_LIMIT_ABUSE_THRESHOLD = 50;
+
+async function checkRateLimitAbusePerIp() {
+  const logs = await sbFetch(`/analytics/endpoints/logs?iso_timestamp_start=${ONE_HOUR_AGO}`);
+  if (!logs || !Array.isArray(logs)) {
+    console.log('Per-IP rate limit logs: no data, skipping');
+    return;
+  }
+  const trips = logs.filter(l => l.status_code === 429);
+  const byIp = new Map();
+  for (const t of trips) {
+    const ip = t.remote_addr || t.client_ip || t.x_forwarded_for || 'unknown';
+    byIp.set(ip, (byIp.get(ip) || 0) + 1);
+  }
+  const offenders = [...byIp.entries()]
+    .filter(([, count]) => count >= RATE_LIMIT_ABUSE_THRESHOLD)
+    .sort((a, b) => b[1] - a[1]);
+  console.log(`Per-IP 429s: ${trips.length} total across ${byIp.size} IPs, ${offenders.length} over threshold ${RATE_LIMIT_ABUSE_THRESHOLD}`);
+  if (offenders.length === 0) return;
+  const detail = offenders.slice(0, 10)
+    .map(([ip, count]) => `- ${ip}: ${count} trips`)
+    .join('\n');
+  await createAlert(
+    '[Alert] Rate-limit abuse from single IP',
+    `${offenders.length} IP${offenders.length === 1 ? '' : 's'} tripped the rate limit ≥ ${RATE_LIMIT_ABUSE_THRESHOLD} times in the last hour.\n\nTop offenders:\n${detail}\n\nThis indicates a targeted attacker rather than incidental traffic. Consider blocking at Cloudflare or your DNS provider. The rate limiter itself is doing its job (all requests returned 429).\n\nTriggered at: ${new Date().toISOString()}`
+  );
+}
+
 async function main() {
   console.log(`Security monitor running at ${new Date().toISOString()}`);
   console.log(`Project: ${PROJECT_REF}, Lookback: ${ONE_HOUR_AGO}`);
@@ -145,6 +179,7 @@ async function main() {
   await checkEdgeFunctionErrors();
   await checkRlsViolations();
   await checkRateLimitHits();
+  await checkRateLimitAbusePerIp();
   console.log('Security monitor complete.');
 }
 

--- a/css/status/status.css
+++ b/css/status/status.css
@@ -288,9 +288,10 @@
   font-family: var(--mono);
 }
 
-/* Announcements block: below the per-service grid. Pulled live from the
-   repo's incident-labeled issues so an ongoing event is visible from the
-   status page. */
+/* Security + Announcements blocks: below the per-service grid. Same top
+   spacing treatment so they read as their own sections instead of
+   crowding the last edge-function card. */
+.status-security,
 .status-announcements {
   margin-top: 32px;
   padding-top: 16px;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@babel/core": "^7.29.7",
         "@babel/preset-env": "^7.29.7",
         "babel-jest": "^30.4.1",
+        "fast-check": "^4.9.0",
         "jest": "^30.4.2",
         "jest-environment-jsdom": "^30.4.1",
         "js-yaml": "^5.2.1",
@@ -2087,21 +2088,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2110,9 +2111,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2944,40 +2945,6 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
@@ -3612,6 +3579,40 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
@@ -4667,6 +4668,46 @@
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
+    },
+    "node_modules/fast-check": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/fast-check/node_modules/pure-rand": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@babel/core": "^7.29.7",
     "@babel/preset-env": "^7.29.7",
     "babel-jest": "^30.4.1",
+    "fast-check": "^4.9.0",
     "jest": "^30.4.2",
     "jest-environment-jsdom": "^30.4.1",
     "js-yaml": "^5.2.1",

--- a/status.html
+++ b/status.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=daf1bfe9">
 <link rel="stylesheet" href="css/shared/topbar.css?v=e911094d">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
-<link rel="stylesheet" href="css/status/status.css?v=c79bb886">
+<link rel="stylesheet" href="css/status/status.css?v=f541420f">
 </head>
 <body>
 

--- a/tests/fuzz.test.js
+++ b/tests/fuzz.test.js
@@ -1,0 +1,307 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Property-based fuzz tests for user-input parsers (#321).
+ *
+ * The parsers we ship never throw on hostile input because they run in
+ * user-facing paths (topbar search, submit form, profile importer). These
+ * tests use fast-check to prove that invariant across a broad input space
+ * instead of relying on hand-picked examples.
+ *
+ * What each block asserts:
+ *  - never throws for any string input
+ *  - returns the expected type (string, null, or object of a specific shape)
+ *  - never emits characters that would break out of an HTML context (esc)
+ *  - is deterministic (calling twice returns the same result)
+ */
+
+const fc = require('fast-check');
+
+const { parseStoreUrl } = require('../js/lib/store-url-parser.js');
+const { detectGpuArch } = require('../js/lib/gpu-arch-detector.js');
+const { appIdToDir } = require('../js/lib/app-id.js');
+const {
+  normalizeOs,
+  esc,
+  escWithSpoilers,
+  truncate,
+  fmtDuration,
+  fmtMinutes,
+  hashReportKey,
+} = require('../js/app/utils.js');
+const {
+  cleanUnknown,
+  parseSteamSystemInfo,
+  inferGpuVendor,
+  inferCpuVendor,
+} = require('../js/profile/utils.js');
+
+const CFG = { numRuns: 400 };
+
+// ---- pure string transforms ------------------------------------------------
+
+describe('parseStoreUrl (fuzz)', () => {
+  test('never throws on any string input', () => {
+    fc.assert(fc.property(fc.string(), (s) => {
+      parseStoreUrl(s);
+    }), CFG);
+  });
+
+  test('always returns null or a well-formed object', () => {
+    fc.assert(fc.property(fc.string(), (s) => {
+      const r = parseStoreUrl(s);
+      if (r === null) return true;
+      return (
+        typeof r === 'object' &&
+        typeof r.store === 'string' &&
+        ['steam', 'gog', 'epic'].includes(r.store) &&
+        'appId' in r && 'canonicalId' in r && 'slug' in r
+      );
+    }), CFG);
+  });
+
+  test('is deterministic', () => {
+    fc.assert(fc.property(fc.string(), (s) => {
+      expect(parseStoreUrl(s)).toEqual(parseStoreUrl(s));
+    }), CFG);
+  });
+
+  test('numeric Steam appId always digits-only', () => {
+    fc.assert(fc.property(fc.nat({ max: 9999999 }), (id) => {
+      const r = parseStoreUrl(`https://store.steampowered.com/app/${id}/`);
+      expect(r).not.toBeNull();
+      expect(/^\d+$/.test(r.appId)).toBe(true);
+    }), CFG);
+  });
+
+  test('non-URL free text always returns null', () => {
+    fc.assert(fc.property(
+      fc.string({ minLength: 1 }).filter((s) => !/^(https?:\/\/)?[a-z]+\./i.test(s)),
+      (s) => {
+        expect(parseStoreUrl(s)).toBeNull();
+      },
+    ), CFG);
+  });
+});
+
+describe('detectGpuArch (fuzz)', () => {
+  test('never throws on any input', () => {
+    fc.assert(fc.property(fc.oneof(fc.string(), fc.constant(null), fc.constant(undefined)), (s) => {
+      detectGpuArch(s);
+    }), CFG);
+  });
+
+  test('always returns a string', () => {
+    fc.assert(fc.property(fc.string(), (s) => {
+      expect(typeof detectGpuArch(s)).toBe('string');
+    }), CFG);
+  });
+
+  test('is case-insensitive (upper matches lower)', () => {
+    fc.assert(fc.property(fc.string(), (s) => {
+      expect(detectGpuArch(s.toUpperCase())).toBe(detectGpuArch(s.toLowerCase()));
+    }), CFG);
+  });
+});
+
+describe('appIdToDir (fuzz)', () => {
+  test('never throws and always returns a string', () => {
+    fc.assert(fc.property(
+      fc.oneof(fc.string(), fc.integer(), fc.float(), fc.nat()),
+      (v) => {
+        expect(typeof appIdToDir(v)).toBe('string');
+      },
+    ), CFG);
+  });
+
+  test('replaces the first colon with underscore', () => {
+    fc.assert(fc.property(fc.string(), fc.string(), (a, b) => {
+      const cleanA = a.replace(/:/g, '');
+      const cleanB = b.replace(/:/g, '');
+      expect(appIdToDir(`${cleanA}:${cleanB}`)).toBe(`${cleanA}_${cleanB}`);
+    }), CFG);
+  });
+});
+
+describe('normalizeOs (fuzz)', () => {
+  test('never throws on any string input', () => {
+    fc.assert(fc.property(
+      fc.oneof(fc.string(), fc.constant(null), fc.constant(undefined), fc.constant('')),
+      (s) => { normalizeOs(s); },
+    ), CFG);
+  });
+
+  test('always returns a string', () => {
+    fc.assert(fc.property(fc.string(), (s) => {
+      expect(typeof normalizeOs(s)).toBe('string');
+    }), CFG);
+  });
+
+  test('digits-only input is stripped to empty', () => {
+    fc.assert(fc.property(fc.stringMatching(/^\d+$/, { minLength: 1, maxLength: 20 }), (s) => {
+      expect(normalizeOs(s)).toBe('');
+    }), CFG);
+  });
+});
+
+describe('truncate (fuzz)', () => {
+  test('output length is never greater than max + ellipsis', () => {
+    fc.assert(fc.property(fc.string(), fc.nat({ max: 200 }), (s, n) => {
+      const out = truncate(s, n);
+      if (!s) return true;
+      if (s.length <= n) return out === s;
+      return out.length === n + 3 && out.endsWith('...');
+    }), CFG);
+  });
+});
+
+describe('fmtDuration / fmtMinutes (fuzz)', () => {
+  test('fmtDuration never throws for arbitrary input', () => {
+    fc.assert(fc.property(
+      fc.oneof(fc.string(), fc.integer(), fc.float(), fc.constant(null), fc.constant(undefined)),
+      (v) => { fmtDuration(v); },
+    ), CFG);
+  });
+
+  test('fmtMinutes never throws for arbitrary numeric-ish input', () => {
+    fc.assert(fc.property(
+      fc.oneof(fc.integer(), fc.float(), fc.string(), fc.constant(null), fc.constant(undefined)),
+      (v) => { fmtMinutes(v); },
+    ), CFG);
+  });
+});
+
+describe('hashReportKey (fuzz)', () => {
+  test('always returns a string of consistent length for any input', () => {
+    fc.assert(fc.property(fc.string(), (s) => {
+      const h = hashReportKey(s);
+      expect(typeof h).toBe('string');
+      expect(h.length).toBeGreaterThan(0);
+    }), CFG);
+  });
+
+  test('is deterministic', () => {
+    fc.assert(fc.property(fc.string(), (s) => {
+      expect(hashReportKey(s)).toBe(hashReportKey(s));
+    }), CFG);
+  });
+});
+
+// ---- profile utils (pure string transforms, no DOM needed) -----------------
+
+describe('cleanUnknown (fuzz)', () => {
+  test('never throws for any input type', () => {
+    fc.assert(fc.property(
+      fc.oneof(fc.string(), fc.integer(), fc.constant(null), fc.constant(undefined), fc.constant({})),
+      (v) => { cleanUnknown(v); },
+    ), CFG);
+  });
+
+  test('always returns a string', () => {
+    fc.assert(fc.property(fc.anything(), (v) => {
+      expect(typeof cleanUnknown(v)).toBe('string');
+    }), CFG);
+  });
+
+  test('"unknown" (any case) collapses to empty', () => {
+    fc.assert(fc.property(
+      fc.stringMatching(/^[uU][nN][kK][nN][oO][wW][nN]$/),
+      (s) => {
+        expect(cleanUnknown(s)).toBe('');
+        expect(cleanUnknown(`  ${s}  `)).toBe('');
+      },
+    ), CFG);
+  });
+});
+
+describe('parseSteamSystemInfo (fuzz)', () => {
+  test('never throws on any string input', () => {
+    fc.assert(fc.property(
+      fc.oneof(fc.string(), fc.constant(null), fc.constant(undefined), fc.constant('')),
+      (s) => { parseSteamSystemInfo(s); },
+    ), CFG);
+  });
+
+  test('always returns an object', () => {
+    fc.assert(fc.property(fc.string(), (s) => {
+      expect(typeof parseSteamSystemInfo(s)).toBe('object');
+      expect(parseSteamSystemInfo(s)).not.toBeNull();
+    }), CFG);
+  });
+
+  test('is deterministic', () => {
+    fc.assert(fc.property(fc.string(), (s) => {
+      expect(parseSteamSystemInfo(s)).toEqual(parseSteamSystemInfo(s));
+    }), CFG);
+  });
+});
+
+describe('inferGpuVendor / inferCpuVendor (fuzz)', () => {
+  test('inferGpuVendor never throws + returns allowed value', () => {
+    const allowed = new Set(['nvidia', 'amd', 'intel', '']);
+    fc.assert(fc.property(
+      fc.oneof(fc.string(), fc.constant(null), fc.constant(undefined)),
+      (s) => {
+        const r = inferGpuVendor(s);
+        expect(allowed.has(r)).toBe(true);
+      },
+    ), CFG);
+  });
+
+  test('inferCpuVendor never throws + returns allowed value', () => {
+    const allowed = new Set(['amd', 'intel', 'other', '']);
+    fc.assert(fc.property(
+      fc.oneof(fc.string(), fc.constant(null), fc.constant(undefined)),
+      (s) => {
+        const r = inferCpuVendor(s);
+        expect(allowed.has(r)).toBe(true);
+      },
+    ), CFG);
+  });
+});
+
+// ---- HTML escaping ---------------------------------------------------------
+// esc + escWithSpoilers need a DOM.
+
+describe('esc (fuzz)', () => {
+  test('never throws for arbitrary input', () => {
+    fc.assert(fc.property(
+      fc.oneof(fc.string(), fc.constant(null), fc.constant(undefined), fc.constant('')),
+      (s) => { esc(s); },
+    ), CFG);
+  });
+
+  test('output never contains raw < or > or unescaped & pointing at markup', () => {
+    fc.assert(fc.property(fc.string(), (s) => {
+      const out = esc(s);
+      // Must be a string.
+      expect(typeof out).toBe('string');
+      // No raw script or html tag can survive.
+      expect(/<script|<img|<svg|<iframe/i.test(out)).toBe(false);
+      // Any < in the output must be immediately escaped (jsdom uses &lt;).
+      // We simply assert there is no unescaped `<` character.
+      expect(out.includes('<')).toBe(false);
+    }), CFG);
+  });
+});
+
+describe('escWithSpoilers (fuzz)', () => {
+  test('never throws for any input', () => {
+    fc.assert(fc.property(
+      fc.oneof(fc.string(), fc.constant(null), fc.constant(undefined), fc.constant('')),
+      (s) => { escWithSpoilers(s); },
+    ), CFG);
+  });
+
+  test('output is a string; only spoiler spans introduce < characters', () => {
+    fc.assert(fc.property(fc.string(), (s) => {
+      const out = escWithSpoilers(s);
+      expect(typeof out).toBe('string');
+      // If the input had no {spoiler}...{/spoiler} block, there should be
+      // no < characters in the output (esc() would have escaped them).
+      if (!/\{spoiler\}[\s\S]*?\{\/spoiler\}/i.test(s)) {
+        expect(out.includes('<')).toBe(false);
+      }
+    }), CFG);
+  });
+});

--- a/tests/rateLimitAbuseCheck.test.js
+++ b/tests/rateLimitAbuseCheck.test.js
@@ -1,0 +1,36 @@
+/**
+ * Pins the per-IP rate-limit abuse check (#320) inside security-monitor.mjs
+ * so the aggregate check cannot silently drift away from the per-IP
+ * variant. Regressions here mean a persistent attacker slips past.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const SCRIPT = fs.readFileSync(
+  path.join(__dirname, '..', '.github/scripts/security-monitor.mjs'),
+  'utf8',
+);
+
+describe('per-IP rate-limit abuse check (#320)', () => {
+  test('the check function exists', () => {
+    expect(SCRIPT).toContain('checkRateLimitAbusePerIp');
+  });
+
+  test('groups 429 hits by source IP', () => {
+    expect(SCRIPT).toMatch(/byIp\.set\(ip,/);
+    expect(SCRIPT).toMatch(/remote_addr|client_ip|x_forwarded_for/);
+  });
+
+  test('has a documented abuse threshold constant', () => {
+    expect(SCRIPT).toMatch(/RATE_LIMIT_ABUSE_THRESHOLD\s*=\s*\d+/);
+  });
+
+  test('fires an alert with the offender list when the threshold is crossed', () => {
+    expect(SCRIPT).toContain('Rate-limit abuse from single IP');
+    expect(SCRIPT).toContain('Top offenders');
+  });
+
+  test('is wired into main() so the hourly run actually calls it', () => {
+    expect(SCRIPT).toMatch(/await\s+checkRateLimitAbusePerIp\(\)/);
+  });
+});

--- a/tests/rlsRegression.test.js
+++ b/tests/rlsRegression.test.js
@@ -1,0 +1,317 @@
+/**
+ * @jest-environment node
+ *
+ * RLS regression suite (#318).
+ *
+ * Per-table boundary tests: for every user-scoped table, prove that a
+ * signed-in user CANNOT reach through to another user's row via the
+ * privileged paths (DELETE, UPDATE, private SELECT).
+ *
+ * Not every table blocks SELECT -- `user_configs` (reports) and
+ * `user_proton_configs` (uploaded configs) are intentionally public
+ * because the site displays them to anonymous visitors. For those tables
+ * we only assert the writes are locked to the owner. Tables that hold
+ * private per-user data (drafts, systems, library/wishlist caches) get
+ * the full boundary check.
+ *
+ * Simulated via the Management API: SET LOCAL ROLE authenticated + a
+ * fake JWT claims block. Same pattern supabaseSchema.test.js uses to
+ * prove RLS evaluation without a real user JWT.
+ *
+ * Skipped without SUPABASE_TOKEN / SUPABASE_URL; required in CI.
+ */
+
+const SUPABASE_URL   = process.env.SUPABASE_URL;
+const SUPABASE_TOKEN = process.env.SUPABASE_TOKEN;
+const PROJECT_REF    = SUPABASE_URL
+  ? new URL(SUPABASE_URL).hostname.split('.')[0]
+  : null;
+
+const MGMT_QUERY_URL = PROJECT_REF
+  ? `https://api.supabase.com/v1/projects/${PROJECT_REF}/database/query`
+  : null;
+
+// Throwaway user UUIDs inserted into auth.users by the top-level
+// beforeAll. Suffix chosen so ci-rls leftovers are easy to grep for.
+const USER_A = '00000000-0000-0000-0000-0000000000aa';
+const USER_B = '00000000-0000-0000-0000-0000000000bb';
+
+async function queryDB(sql, retries = 2) {
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    const res = await fetch(MGMT_QUERY_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${SUPABASE_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ query: sql }),
+    });
+    if (res.ok) return res.json();
+    const body = await res.text();
+    if (res.status >= 500 && attempt < retries) {
+      await new Promise(r => setTimeout(r, 3000 * attempt));
+      continue;
+    }
+    throw new Error(`Management API error: ${res.status} ${body}`);
+  }
+}
+
+function jwtClaims(userId) {
+  return JSON.stringify({ sub: userId, role: 'authenticated', aud: 'authenticated' });
+}
+
+async function asUser(userId, sql) {
+  return queryDB(
+    `SET LOCAL ROLE authenticated;
+     SET LOCAL "request.jwt.claims" = '${jwtClaims(userId)}';
+     ${sql}`,
+  );
+}
+
+// Cleanup helper -- runs as service role (no SET LOCAL) so RLS does not
+// interfere with row removal.
+async function cleanup(sql) {
+  return queryDB(sql);
+}
+
+const describeIfCreds = SUPABASE_TOKEN && MGMT_QUERY_URL ? describe : describe.skip;
+
+describeIfCreds('RLS: user-scoped tables (per-user boundary)', () => {
+
+  beforeAll(async () => {
+    // Throwaway users. Several user-scoped tables FK to auth.users so
+    // we need real rows there; the Management API runs as the service
+    // role so a direct auth.users insert is allowed.
+    await cleanup(`
+      INSERT INTO auth.users (id, instance_id, aud, role, email, encrypted_password, created_at, updated_at)
+      VALUES
+        ('${USER_A}', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated',
+         'ci-rls-a@example.invalid', 'noop', now(), now()),
+        ('${USER_B}', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated',
+         'ci-rls-b@example.invalid', 'noop', now(), now())
+      ON CONFLICT (id) DO NOTHING;
+    `);
+  }, 30000);
+
+  afterAll(async () => {
+    // ON DELETE CASCADE on the FK columns cleans dependent rows.
+    await cleanup(`
+      DELETE FROM auth.users WHERE id IN ('${USER_A}', '${USER_B}');
+    `);
+  }, 30000);
+
+  // ---- user_configs (public read, owner-only DELETE) --------------------
+
+  describe('user_configs', () => {
+    const seedAppId = 'ci-rls-uc';
+
+    beforeAll(async () => {
+      await cleanup(`DELETE FROM public.user_configs WHERE app_id = '${seedAppId}';`);
+      await cleanup(`
+        INSERT INTO public.user_configs (
+          proton_pulse_user_id, app_id, title, source, client_id,
+          cpu, gpu, gpu_driver, ram, os, kernel, proton_version,
+          duration, rating, notes, gpu_vendor, launch_options
+        )
+        VALUES (
+          '${USER_A}', '${seedAppId}', 'ci rls regression', 'ci', 'ci-rls-client-a',
+          'ci', 'ci', 'ci', 'ci', 'ci', 'ci', 'ci',
+          'ci', 'gold', '', 'other', ''
+        );
+      `);
+    }, 30000);
+
+    afterAll(async () => {
+      await cleanup(`DELETE FROM public.user_configs WHERE app_id = '${seedAppId}';`);
+    }, 30000);
+
+    test('USER_B DELETE affects 0 rows (owner-only DELETE policy)', async () => {
+      const rows = await asUser(USER_B, `
+        DELETE FROM public.user_configs
+        WHERE app_id = '${seedAppId}'
+        RETURNING id;
+      `);
+      expect(rows).toHaveLength(0);
+      // Verify the seed still exists via service role.
+      const verify = await cleanup(`SELECT id FROM public.user_configs WHERE app_id = '${seedAppId}';`);
+      expect(verify).toHaveLength(1);
+    }, 30000);
+  });
+
+  // ---- user_proton_configs (public read, owner-only DELETE via UUID) ----
+
+  describe('user_proton_configs', () => {
+    const seedApp = 987654321;
+    const seedVoter = 'ci-rls-upc';
+
+    beforeAll(async () => {
+      await cleanup(`
+        DELETE FROM public.user_proton_configs
+        WHERE voter_id = '${seedVoter}' AND app_id = ${seedApp};
+      `);
+      await cleanup(`
+        INSERT INTO public.user_proton_configs (voter_id, proton_pulse_user_id, app_id, app_name, config)
+        VALUES ('${seedVoter}', '${USER_A}', ${seedApp}, 'CI RLS', '{}'::jsonb);
+      `);
+    }, 30000);
+
+    afterAll(async () => {
+      await cleanup(`
+        DELETE FROM public.user_proton_configs
+        WHERE voter_id = '${seedVoter}' AND app_id = ${seedApp};
+      `);
+    }, 30000);
+
+    test('USER_B DELETE affects 0 rows (owner-only DELETE via UUID)', async () => {
+      const rows = await asUser(USER_B, `
+        DELETE FROM public.user_proton_configs
+        WHERE app_id = ${seedApp}
+        RETURNING app_id;
+      `);
+      expect(rows).toHaveLength(0);
+      const verify = await cleanup(`SELECT app_id FROM public.user_proton_configs WHERE app_id = ${seedApp};`);
+      expect(verify).toHaveLength(1);
+    }, 30000);
+  });
+
+  // ---- user_systems (fully owner-scoped) --------------------------------
+
+  describe('user_systems', () => {
+    const seedLabel = 'ci-rls-user_systems';
+    const seedDevice = 'ci-rls-device';
+
+    beforeAll(async () => {
+      await cleanup(`DELETE FROM public.user_systems WHERE label = '${seedLabel}';`);
+      await cleanup(`
+        INSERT INTO public.user_systems (proton_pulse_user_id, device_id, label, sysinfo_text)
+        VALUES ('${USER_A}', '${seedDevice}', '${seedLabel}', 'ci sysinfo');
+      `);
+    }, 30000);
+
+    afterAll(async () => {
+      await cleanup(`DELETE FROM public.user_systems WHERE label = '${seedLabel}';`);
+    }, 30000);
+
+    test('USER_B cannot SELECT USER_A row', async () => {
+      const rows = await asUser(USER_B, `
+        SELECT proton_pulse_user_id FROM public.user_systems
+        WHERE label = '${seedLabel}';
+      `);
+      expect(rows).toHaveLength(0);
+    }, 30000);
+
+    test('USER_B DELETE affects 0 rows', async () => {
+      const rows = await asUser(USER_B, `
+        DELETE FROM public.user_systems
+        WHERE label = '${seedLabel}'
+        RETURNING proton_pulse_user_id;
+      `);
+      expect(rows).toHaveLength(0);
+    }, 30000);
+  });
+
+  // ---- user_report_drafts (fully owner-scoped) --------------------------
+
+  describe('user_report_drafts', () => {
+    const seedApp = 'ci-rls-drafts';
+
+    beforeAll(async () => {
+      await cleanup(`
+        DELETE FROM public.user_report_drafts
+        WHERE user_id = '${USER_A}' AND app_id = '${seedApp}';
+      `);
+      await cleanup(`
+        INSERT INTO public.user_report_drafts (user_id, app_id, form_data)
+        VALUES ('${USER_A}', '${seedApp}', '{"note":"ci"}'::jsonb);
+      `);
+    }, 30000);
+
+    afterAll(async () => {
+      await cleanup(`
+        DELETE FROM public.user_report_drafts
+        WHERE user_id = '${USER_A}' AND app_id = '${seedApp}';
+      `);
+    }, 30000);
+
+    test('USER_B cannot SELECT USER_A row', async () => {
+      const rows = await asUser(USER_B, `
+        SELECT user_id FROM public.user_report_drafts
+        WHERE app_id = '${seedApp}';
+      `);
+      expect(rows).toHaveLength(0);
+    }, 30000);
+
+    test('USER_B UPDATE affects 0 rows', async () => {
+      const rows = await asUser(USER_B, `
+        UPDATE public.user_report_drafts SET form_data = '{"note":"pwn"}'::jsonb
+        WHERE app_id = '${seedApp}'
+        RETURNING user_id;
+      `);
+      expect(rows).toHaveLength(0);
+    }, 30000);
+
+    test('USER_B DELETE affects 0 rows', async () => {
+      const rows = await asUser(USER_B, `
+        DELETE FROM public.user_report_drafts
+        WHERE app_id = '${seedApp}'
+        RETURNING user_id;
+      `);
+      expect(rows).toHaveLength(0);
+    }, 30000);
+  });
+
+  // ---- user_steam_library / user_steam_wishlist (SELECT owner-only) -----
+
+  describe('user_steam_library', () => {
+    beforeAll(async () => {
+      await cleanup(`DELETE FROM public.user_steam_library WHERE user_id = '${USER_A}';`);
+      await cleanup(`
+        INSERT INTO public.user_steam_library (user_id, steam_id, game_count, appids)
+        VALUES ('${USER_A}', '76561000000000000', 3, '[1,2,3]'::jsonb);
+      `);
+    }, 30000);
+
+    afterAll(async () => {
+      await cleanup(`DELETE FROM public.user_steam_library WHERE user_id = '${USER_A}';`);
+    }, 30000);
+
+    test('USER_B cannot SELECT USER_A row', async () => {
+      const rows = await asUser(USER_B, `
+        SELECT user_id FROM public.user_steam_library
+        WHERE user_id = '${USER_A}';
+      `);
+      expect(rows).toHaveLength(0);
+    }, 30000);
+  });
+
+  describe('user_steam_wishlist', () => {
+    beforeAll(async () => {
+      await cleanup(`DELETE FROM public.user_steam_wishlist WHERE user_id = '${USER_A}';`);
+      await cleanup(`
+        INSERT INTO public.user_steam_wishlist (user_id, steam_id, item_count, appids)
+        VALUES ('${USER_A}', '76561000000000000', 3, ARRAY[10,20,30]);
+      `);
+    }, 30000);
+
+    afterAll(async () => {
+      await cleanup(`DELETE FROM public.user_steam_wishlist WHERE user_id = '${USER_A}';`);
+    }, 30000);
+
+    test('USER_B cannot SELECT USER_A row', async () => {
+      const rows = await asUser(USER_B, `
+        SELECT user_id FROM public.user_steam_wishlist
+        WHERE user_id = '${USER_A}';
+      `);
+      expect(rows).toHaveLength(0);
+    }, 30000);
+
+    test('USER_B DELETE affects 0 rows', async () => {
+      const rows = await asUser(USER_B, `
+        DELETE FROM public.user_steam_wishlist
+        WHERE user_id = '${USER_A}'
+        RETURNING user_id;
+      `);
+      expect(rows).toHaveLength(0);
+    }, 30000);
+  });
+});


### PR DESCRIPTION
Combined security follow-ups from the current batch. Three independent commits, one PR.

## fast-check fuzz tests (#321)
Property-based tests for user-input parsers. Every parser now proves:
- never throws on any string / null / undefined input
- always returns the expected type
- is deterministic
- HTML escape helpers never emit unescaped angle brackets

Coverage: parseStoreUrl, detectGpuArch, appIdToDir, normalizeOs, truncate, fmtDuration, fmtMinutes, hashReportKey, cleanUnknown, parseSteamSystemInfo, inferGpuVendor, inferCpuVendor, esc, escWithSpoilers. 400 runs per property.

## RLS regression suite (#318)
Per-table boundary tests: seeds a row owned by USER_A and asserts USER_B cannot reach it via DELETE, UPDATE, or private SELECT. Complements the schema linter which catches cross-table subqueries but misses the fundamental \"did I forget auth.uid() = user_id\" regression.

Coverage: user_configs, user_proton_configs, user_systems, user_report_drafts, user_steam_library, user_steam_wishlist. Runs against the live staging DB via the Management API. Skipped locally without SUPABASE_TOKEN, required in CI.

## Per-IP rate-limit abuse alerts (#320)
The aggregate 429 check catches site-wide storms but misses a persistent attacker tripping the limit repeatedly from the same IP. New check groups last-hour 429s by client IP and files a security-labeled issue when any IP crosses 50 trips/hour. The existing discord-issues.yml workflow picks up new issues automatically.

## Tests
2005 tests pass locally (was 1970). Closes #318, #320, #321.