### PR TITLE
fix(status): allow vendor status origins in CSP (#341)

### DIFF
--- a/status.html
+++ b/status.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' https://*.steamstatic.com https://avatars.steamstatic.com https://cdn.cloudflare.steamstatic.com https://media.steampowered.com data:; connect-src 'self' https://ilsgdshkaocrmibwdezk.supabase.co https://pp-edge-status.mdeguzis.workers.dev https://api.github.com; font-src 'self'; frame-src 'none'; object-src 'none';">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' https://*.steamstatic.com https://avatars.steamstatic.com https://cdn.cloudflare.steamstatic.com https://media.steampowered.com data:; connect-src 'self' https://ilsgdshkaocrmibwdezk.supabase.co https://pp-edge-status.mdeguzis.workers.dev https://api.github.com https://www.githubstatus.com https://www.cloudflarestatus.com; font-src 'self'; frame-src 'none'; object-src 'none';">
 <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
 <meta http-equiv="Pragma" content="no-cache">
 <meta http-equiv="Expires" content="0">

--- a/tests/statusCsp.test.js
+++ b/tests/statusCsp.test.js
@@ -1,0 +1,35 @@
+/**
+ * status.html CSP regression: pin the vendor status origins that the
+ * vendor-status card fetches at runtime. Dropping one silently would
+ * make the tile read "unreachable" in production without any local
+ * signal. #329-followup.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const STATUS_HTML = fs.readFileSync(
+  path.join(__dirname, '..', 'status.html'),
+  'utf8',
+);
+
+describe('status.html Content-Security-Policy', () => {
+  const cspMatch = STATUS_HTML.match(/http-equiv="Content-Security-Policy"\s+content="([^"]+)"/);
+  const csp = cspMatch ? cspMatch[1] : '';
+
+  test('CSP tag is present', () => {
+    expect(csp).not.toBe('');
+  });
+
+  test('connect-src allows www.githubstatus.com (GitHub Pages + Actions health)', () => {
+    expect(csp).toMatch(/connect-src[^;]*https:\/\/www\.githubstatus\.com/);
+  });
+
+  test('connect-src allows www.cloudflarestatus.com (Workers, DNS, CDN health)', () => {
+    expect(csp).toMatch(/connect-src[^;]*https:\/\/www\.cloudflarestatus\.com/);
+  });
+
+  test('connect-src allows the Supabase project + edge-status worker (already relied on)', () => {
+    expect(csp).toMatch(/connect-src[^;]*https:\/\/ilsgdshkaocrmibwdezk\.supabase\.co/);
+    expect(csp).toMatch(/connect-src[^;]*https:\/\/pp-edge-status\.mdeguzis\.workers\.dev/);
+  });
+});


### PR DESCRIPTION
The vendor status card fetches githubstatus.com and cloudflarestatus.com at runtime for the GitHub + Cloudflare health tiles, but status.html's connect-src only whitelisted api.github.com. Browser blocked the fetch and the tiles read \"unreachable\" regardless of actual vendor health.

## What changed
- status.html: adds \`https://www.githubstatus.com\` + \`https://www.cloudflarestatus.com\` to \`connect-src\`
- tests/statusCsp.test.js: pins the vendor origins so a future CSP edit that drops one fails locally
- wiki Security-Guardrails.md: documents the new connect-src whitelist per the security-first rule

Closes #341.