### PR TITLE
feat(anti-cheat): pipeline enricher + metadata modal badge + broader coverage (#242)

### DIFF
--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=8051e115';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=003f23c0';
-import { renderGamePage } from './game-page.js?v=6f528fd0';
+import { renderGamePage } from './game-page.js?v=af91d6f9';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId, fetchDataWithProdFallback } from '../config.js?v=f9591262';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=9a39c726';
 import { renderGameCard } from '../lib/card.js?v=93448301';

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,6 +1,6 @@
 // router (entry) for the app page. Relocated from app.js.
 
-import { renderGamePage } from './components/game-page.js?v=6f528fd0';
+import { renderGamePage } from './components/game-page.js?v=af91d6f9';
 import { renderHomePage } from './components/home.js?v=baf5a088';
 import { renderSearchPage } from './components/search.js?v=598aaad1';
 

--- a/scripts/pipeline/anti_cheat.py
+++ b/scripts/pipeline/anti_cheat.py
@@ -57,11 +57,10 @@ _APPDETAILS_VENDOR_PATTERNS: dict[str, tuple[str, ...]] = {
 # finalize. The scan queues at most PROBE_CAP fresh appids per run, then
 # stops -- the cache persists so subsequent runs pick up the tail.
 #
-# Set to 0 by default so a first roll-out ships with just the AreWeAntiCheatYet
-# base + title-match backfill, both zero-network passes. Raise once we've
-# confirmed finalize wall-clock is healthy on staging. Also settable via
-# ANTI_CHEAT_APPDETAILS_PROBE_CAP env var so a manual dispatch can turn it
-# on without touching code.
+# Default 0 for the initial rollout so first prod run ships with just the
+# zero-network passes (AreWeAntiCheatYet + title-match backfill). Raise
+# once staging finalize wall-clock is healthy. Overridable via env var
+# so a manual dispatch can flip it on without a code change.
 import os as _os
 APPDETAILS_PROBE_CAP = int(_os.environ.get("ANTI_CHEAT_APPDETAILS_PROBE_CAP", "0"))
 APPDETAILS_WALL_CLOCK_BUDGET_SEC = 240


### PR DESCRIPTION
Closes #242.

## Pipeline
- \`scripts/pipeline/anti_cheat.py\` fetches AreWeAntiCheatYet/games.json (CC-BY), indexes by Steam appid, and publishes \`data/anti-cheat.json\` + writes columns 10+11 (status, vendors) into search-index rows.
- 12h TTL upstream cache. Falls back to on-disk cache when the upstream is unreachable so a bad network run never wipes the enrichment.
- Two extra passes fold in to broaden coverage past AreWeAntiCheatYet's ~698 Steam-tagged rows:
  1. **Title-match backfill** for AreWeAntiCheatYet rows without \`storeIds.steam\`. Matches upstream names against normalized search-index titles.
  2. **Steam appdetails vendor scan** for games AreWeAntiCheatYet does not cover at all. Scans \`drm_notice\` + \`about_the_game\` for known vendor keywords. Detected vendors land with \`status: null\` so the frontend can say "Uses <vendor>" without falsely claiming a Linux verdict.
- Default \`APPDETAILS_PROBE_CAP=0\` for the initial rollout -- zero-network passes only. Raise via env var once staging finalize is healthy.

## Frontend
- \`js/app/lib/anti-cheat.js\` -- memoized \`data/anti-cheat.json\` fetch + status bucket helper.
- Metadata modal on the game page (opened from the report details page) renders an **Anti-cheat** section right below Name -- deal-breaker signal above the fold. Handles both the AreWeAntiCheatYet verdict path and the vendor-only "no Linux verdict yet" path.

## Tests
- 19 Python tests (indexer + refresh + enricher + title-match + vendor-detect + no-op).
- 9 JS source-scan tests (lib memoization + modal wiring + manifest).
- Full suite: 2035 pass.

## Wiki
Data-Pipeline.md updated with the new column shape + cache files.

## Staging preview blocked
Attempted three \`make gh-staging-finalize\` runs today. All three stalled on \"Finalize (Indexes + Coverage)\" for 45-65 min each. Traced to #258 (not this PR): the third run had my enricher's only network path off (\`APPDETAILS_PROBE_CAP=0\`) and stalled the same way. Note added to #258 with the run IDs.

Recommendation: merge based on local pytest coverage; the scheduled cron on \`main\` will surface the enricher output on the next prod pipeline run.