### PR TITLE
release: promote staging to main (AC col collision fix + plugin classifier + status link)

### DIFF
--- a/.github/ISSUE_TEMPLATE/security_report.yml
+++ b/.github/ISSUE_TEMPLATE/security_report.yml
@@ -1,0 +1,55 @@
+name: Security Concern
+description: Report a security issue on proton-pulse.com or a suspicious behavior you noticed
+labels: ["security"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to flag this.
+
+        **Before filing:** if what you found is a real exploit that would let someone read another user's data, take over an account, or bypass moderation, please use the private disclosure path instead: [Report a vulnerability privately](https://github.com/mdeguzis/proton-pulse-web/security/advisories/new). Public issues are visible to everyone, so a working exploit posted here is a gift to attackers until it is fixed.
+
+        Everything else (suspicious warnings, weak-looking behavior, "I'm not sure but this looks wrong") is fine to post here.
+  - type: dropdown
+    id: kind
+    attributes:
+      label: What kind of concern?
+      options:
+        - Suspicious warning or error message
+        - Behavior that looks like it might leak data
+        - Rate limit or abuse-prevention gap
+        - Broken login / session behavior
+        - Content moderation missed something harmful
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: page
+    attributes:
+      label: Page URL (if applicable)
+      placeholder: https://www.proton-pulse.com/...
+  - type: textarea
+    id: description
+    attributes:
+      label: What did you see?
+      description: Describe what happened in plain language. Do NOT paste secrets, tokens, or a working exploit.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce (if you can)
+      placeholder: |
+        1. Open https://www.proton-pulse.com/...
+        2. Click X
+        3. Notice Y
+  - type: input
+    id: browser
+    attributes:
+      label: Browser / device
+      placeholder: Firefox 134 on Steam Deck, Chrome 132 on desktop
+  - type: textarea
+    id: screenshot
+    attributes:
+      label: Screenshot (optional)
+      description: Drag and drop an image. Redact any personal info first.

--- a/gh-pages-manifest.txt
+++ b/gh-pages-manifest.txt
@@ -101,6 +101,7 @@ js/admin/api/admins.js
 js/admin/api/phrases.js
 js/admin/api/userDetail.js
 js/admin/api/analytics.js
+js/admin/lib/reportSource.js
 js/admin/api/boxart.js
 js/admin/components/boxart.js
 js/admin/api/steam-explore.js

--- a/js/admin/api/allReports.js
+++ b/js/admin/api/allReports.js
@@ -3,8 +3,12 @@ import { supabaseHeaders } from '../utils.js?v=2668b2f0';
 
 // #48: flagged_reason on rows so the All Reports table can surface why a
 // row was flagged. flagged_at on detail to show when the flag landed.
-const COLS = 'id,app_id,title,client_id,proton_pulse_user_id,rating,source,app_type,is_flagged,is_hidden,flagged_reason,created_at';
-const DETAIL_COLS = 'id,app_id,title,client_id,proton_pulse_user_id,rating,proton_version,cpu,gpu,gpu_driver,gpu_vendor,gpu_architecture,ram,vram_mb,os,kernel,duration,duration_minutes,notes,form_responses,config_key,game_owned,source,app_type,is_flagged,is_hidden,flagged_reason,flagged_at,created_at,updated_at';
+// installation_id is the Deck-plugin signature -- the web submit path never
+// sets it -- so classifyReportSource can distinguish a real plugin
+// submission from a web (or imported) row whose source string happens to be
+// 'user' / 'protondb' / etc.
+const COLS = 'id,app_id,title,client_id,proton_pulse_user_id,installation_id,rating,source,app_type,is_flagged,is_hidden,flagged_reason,created_at';
+const DETAIL_COLS = 'id,app_id,title,client_id,proton_pulse_user_id,installation_id,rating,proton_version,cpu,gpu,gpu_driver,gpu_vendor,gpu_architecture,ram,vram_mb,os,kernel,duration,duration_minutes,notes,form_responses,config_key,game_owned,source,app_type,is_flagged,is_hidden,flagged_reason,flagged_at,created_at,updated_at';
 
 export async function fetchReportById(session, id) {
   const [res, approvalRes] = await Promise.all([

--- a/js/admin/api/analytics.js
+++ b/js/admin/api/analytics.js
@@ -1,5 +1,6 @@
 import { SUPABASE_URL } from '../config.js?v=ffed3d84';
 import { supabaseHeaders } from '../utils.js?v=2668b2f0';
+import { classifyReportSource } from '../lib/reportSource.js?v=c366fc24';
 
 export async function fetchAnalytics(session, { daysBack = 30 } = {}) {
   const url = `${SUPABASE_URL}/rest/v1/rpc/admin_analytics`;
@@ -59,19 +60,15 @@ async function fetchSwCacheStats(session, daysBack) {
 }
 
 // #76: broken down by source so the chart can show web vs plugin vs other.
-// Source values cluster into 'web-*' (web submissions), 'plugin-*' (Deck plugin),
-// and a long tail of other tags. Anything that does not match those prefixes
-// falls into 'other' so admins can spot weird traffic.
-function classifyReportSource(src) {
-  const s = (src || '').toLowerCase();
-  if (s.startsWith('web')) return 'web';
-  if (s.startsWith('plugin')) return 'plugin';
-  return 'other';
-}
+// classifyReportSource lives in lib/reportSource.js so the admin all-reports
+// table can share the same "user -> plugin" translation the chart uses.
 
 async function fetchReportsByDay(session, daysBack) {
   const since = new Date(Date.now() - daysBack * 86400000).toISOString().slice(0, 10);
-  const url = `${SUPABASE_URL}/rest/v1/user_configs?select=created_at,source&created_at=gte.${since}T00:00:00&order=created_at.asc`;
+  // installation_id is the Deck-plugin signature -- classifyReportSource
+  // requires it to bucket a row into 'plugin' since 'source' is client-
+  // controlled and cannot be trusted on its own.
+  const url = `${SUPABASE_URL}/rest/v1/user_configs?select=created_at,source,installation_id&created_at=gte.${since}T00:00:00&order=created_at.asc`;
   const res = await fetch(url, { headers: supabaseHeaders(session) });
   if (!res.ok) return [];
   const rows = await res.json();
@@ -81,7 +78,7 @@ async function fetchReportsByDay(session, daysBack) {
     const day = r.created_at?.slice(0, 10);
     if (!day) continue;
     if (!buckets[day]) buckets[day] = { web: 0, plugin: 0, other: 0, count: 0 };
-    const bucket = classifyReportSource(r.source);
+    const bucket = classifyReportSource(r);
     buckets[day][bucket] += 1;
     buckets[day].count += 1;
   }

--- a/js/admin/components/allReports.js
+++ b/js/admin/components/allReports.js
@@ -1,5 +1,6 @@
 import { escapeHtml, fmtDateTime } from '../utils.js?v=2668b2f0';
-import { fetchAllReports, fetchStatusCounts } from '../api/allReports.js?v=f6b28b0d';
+import { fetchAllReports, fetchStatusCounts } from '../api/allReports.js?v=0f587828';
+import { formatReportSourceLabel } from '../lib/reportSource.js?v=c366fc24';
 
 // Summary strip of exact per-status counts above the table. Each tile is a
 // button that filters the table to that status. Runs its own count queries so
@@ -103,7 +104,12 @@ export async function renderAllReports(session) {
         : 'Unknown';
       const rid    = escapeHtml(String(r.id));
       const title  = escapeHtml(r.title || '');
-      const source  = escapeHtml(r.source || '');
+      // Structural signature detection: a row is only labelled 'plugin' if
+      // installation_id is set (the Deck-plugin submit path populates it;
+      // the web submit path never does). Rows with source='user' but no
+      // installation_id -- e.g. imported ProtonDB mirror rows -- keep
+      // their raw source string so admins can spot the actual origin.
+      const source  = escapeHtml(formatReportSourceLabel(r));
       const appType = escapeHtml(r.app_type || 'steam');
       const date    = escapeHtml(fmtDateTime(r.created_at));
       const uid    = r.proton_pulse_user_id || null;
@@ -173,7 +179,7 @@ export function renderAllReportsDetail(report, { onAction, onBack } = {}) {
     ['User ID',         val(report.proton_pulse_user_id)],
     ['App ID',          val(report.app_id)],
     ['Title',           val(report.title)],
-    ['Source',          val(report.source)],
+    ['Source',          report.source || report.installation_id ? escapeHtml(formatReportSourceLabel(report)) : val(report.source)],
     ['App Type',        val(report.app_type)],
     ['Rating',          val(report.rating)],
     ['Proton Version',  val(report.proton_version)],

--- a/js/admin/components/analytics.js
+++ b/js/admin/components/analytics.js
@@ -467,7 +467,7 @@ export function renderAnalytics(data, { daysBack, onChangeDays }) {
     <div class="analytics-chart-wrap">
       <canvas id="analytics-reports-chart"></canvas>
     </div>
-    <p class="chart-caption">Pulse Reports landed per day, stacked by source. Web = browser submissions, Plugin = Steam Deck plugin, Other = anything that does not match those prefixes.</p>
+    <p class="chart-caption">Pulse Reports landed per day, stacked by source. Web = browser submissions (source starts with "web-"). Plugin = Steam Deck plugin (row carries an installation_id, which the plugin submit path always sets and the web never does; a bare source="user" without the signature does NOT count as Plugin). Other = anything else.</p>
     <div id="sec-pages" class="analytics-two-col" style="margin-top:20px">
       <div>
         <div class="analytics-section-title">Top pages</div>

--- a/js/admin/lib/reportSource.js
+++ b/js/admin/lib/reportSource.js
@@ -1,0 +1,62 @@
+// Single source of truth for how the admin UI interprets a user_configs
+// row's origin. Two consumers:
+//
+//   - api/analytics.js uses classifyReportSource() to group rows into
+//     the Web / Plugin / Other buckets on the Report Submissions chart.
+//   - components/allReports.js uses formatReportSourceLabel() to render
+//     the SOURCE cell in the All Reports table.
+//
+// Signature detection, not source-string trust
+// --------------------------------------------
+// Earlier passes tried to auto-classify by the raw `source` field, which
+// the client controls. That misclassified rows that carry source='user'
+// (or 'protondb', 'protondb-local') but were NOT actually submitted from
+// the Deck plugin -- for example an old browser submit path or an
+// imported ProtonDB mirror row. Anyone can put any string in `source`.
+//
+// The real discriminator is installation_id: the decky-proton-pulse
+// plugin's submit path (src/lib/userConfigs.ts) always populates it, and
+// the web submit path (js/shared/submit.js) never sets it. So we only
+// call a row 'plugin' when we have a positive signature: installation_id
+// is present, OR the source string starts with the forward-looking
+// 'plugin' prefix. Everything else falls to 'web' or 'other' based on
+// the source string alone -- no more guessing.
+
+// Positive plugin signature. Callers pass the whole row so we can check
+// installation_id, not just the client-controlled source string.
+function _hasPluginSignature(row) {
+  if (!row) return false;
+  if (row.installation_id) return true;
+  const s = String(row.source || '').toLowerCase();
+  return s.startsWith('plugin');
+}
+
+// Bucket a row into 'web' | 'plugin' | 'other'. Web submissions have
+// source starting with 'web'; plugin submissions have a positive
+// signature (installation_id set or explicit 'plugin' prefix); anything
+// else is 'other' so admins can spot weird traffic.
+//
+// Accepts either a full row object or a bare source string for
+// convenience -- when given a string, only the 'plugin'/'web' prefix
+// branches can fire, so a bare 'user' string that ISN'T from a plugin
+// (say an imported ProtonDB mirror row) will fall to 'other', not a
+// false-positive 'plugin'.
+export function classifyReportSource(rowOrSrc) {
+  const row = (rowOrSrc && typeof rowOrSrc === 'object') ? rowOrSrc : { source: rowOrSrc };
+  if (_hasPluginSignature(row)) return 'plugin';
+  const s = String(row.source || '').toLowerCase();
+  if (s.startsWith('web')) return 'web';
+  return 'other';
+}
+
+// Format the row's source for display in an admin table cell. Rows with
+// a positive plugin signature render as bare 'plugin' so the SOURCE
+// column reads consistently. Everything else renders its raw source
+// string unchanged (do NOT lie about origin: an imported row with
+// source='user' but no installation_id is not from the plugin).
+export function formatReportSourceLabel(rowOrSrc) {
+  const row = (rowOrSrc && typeof rowOrSrc === 'object') ? rowOrSrc : { source: rowOrSrc };
+  const raw = String(row.source || '').trim();
+  if (_hasPluginSignature(row)) return 'plugin';
+  return raw;
+}

--- a/js/admin/main.js
+++ b/js/admin/main.js
@@ -14,15 +14,15 @@ import { renderPhrases } from './components/phrases.js?v=5fb05dc2';
 import { loadWordlist, checkAgainstWordlist } from './api/wordlist.js?v=51c55965';
 import { fetchUserReports, fetchUserActivity } from './api/userDetail.js?v=28cb08af';
 import { renderUserDetail } from './components/userDetail.js?v=5ff164c0';
-import { fetchAnalytics } from './api/analytics.js?v=a1c14331';
-import { renderAnalytics } from './components/analytics.js?v=61349dfd';
+import { fetchAnalytics } from './api/analytics.js?v=2f32672f';
+import { renderAnalytics } from './components/analytics.js?v=41cda1fe';
 import { renderCacheStatus } from './components/cache-status.js?v=0c6c0cb7';
 import { renderDepotTracking } from './components/depotTracking.js?v=8ce33fc6';
 import { renderBoxartAdmin, renderBoxartAdminDetail } from './components/boxart.js?v=3847ca76';
 import { renderApiExplorer } from './components/api-explorer.js?v=dafbc22e';
 import { renderGameManager } from './components/gameManager.js?v=b1d1211c';
-import { renderAllReports, updateAllReportsRow, renderAllReportsDetail } from './components/allReports.js?v=377d9321';
-import { patchReportFlags, fetchReportById } from './api/allReports.js?v=f6b28b0d';
+import { renderAllReports, updateAllReportsRow, renderAllReportsDetail } from './components/allReports.js?v=3a48e0ad';
+import { patchReportFlags, fetchReportById } from './api/allReports.js?v=0f587828';
 import { approveReport } from './api/pending.js?v=84292a58';
 
 // ---------------------------------------------------------------------------

--- a/scripts/pipeline/anti_cheat.py
+++ b/scripts/pipeline/anti_cheat.py
@@ -9,11 +9,16 @@ publishes one row per game with:
 We fetch nightly, index by Steam appid, and cache to disk. The enricher
 maps each cache hit into two columns on search-index rows:
 
-    col 10 (index 10): ac_status -- one of the enum values above, lowercased.
-    col 11 (index 11): ac_vendors -- list of anti-cheat vendor strings.
+    col 12 (index 12): ac_status -- one of the enum values above, lowercased.
+    col 13 (index 13): ac_vendors -- list of anti-cheat vendor strings.
 
 Both default to None for apps not in the cache. Older frontend consumers
 that only read columns 0..9 keep working (JS destructuring ignores extras).
+
+History: originally at cols 10 + 11 (#242). That stomped col 10 (replaced_by,
+set by game_images.py) and col 11 (steam_type, set by steam_type.py) since
+anti_cheat runs last in finalize. Moved to cols 12 + 13 in #354 so the
+three enrichers land at non-overlapping indices.
 
 License: AreWeAntiCheatYet ships CC-BY. Attribution lives in
 proton-pulse-web-wiki/Data-Pipeline.md.
@@ -365,12 +370,18 @@ def _scan_appdetails_for_vendors(
 
 
 def enrich_search_index_with_anti_cheat(output_dir: Path) -> None:
-    """Merge anti-cheat status + vendors into search-index columns 10 + 11.
+    """Merge anti-cheat status + vendors into search-index columns 12 + 13.
 
     Pads shorter rows with None so both columns land at the expected index
     regardless of what upstream enrichers wrote. Rows without a cache hit
     get None in both slots so the frontend can distinguish "no anti-cheat
     data" from "no anti-cheat".
+
+    #354: cols 12 + 13, not 10 + 11. Col 10 belongs to game_images.py's
+    replaced_by (game-was-superseded redirect). Col 11 belongs to
+    steam_type.py's Steam appdetails type (game / dlc / mod / ...).
+    Anti-cheat runs last in finalize, so writing at 10/11 was silently
+    overwriting both of those columns for every game with AC data.
     """
     output_dir = Path(output_dir)
     index_path = output_dir / "search-index.json"
@@ -415,22 +426,21 @@ def enrich_search_index_with_anti_cheat(output_dir: Path) -> None:
     for row in entries:
         if not isinstance(row, list) or not row:
             continue
-        # Pad to at least 12 columns so col 10 + 11 land at the right index.
-        while len(row) < 12:
+        # Pad to at least 14 columns so col 12 + 13 land at the right index
+        # without disturbing col 10 (replaced_by, set by game_images.py) or
+        # col 11 (steam_type, set by steam_type.py). Pad with None so the
+        # frontend can distinguish "not enriched yet" from a real value.
+        while len(row) < 14:
             row.append(None)
         app_id = str(row[0])
         info = by_appid.get(app_id)
         if info:
-            row[10] = info["status"]
-            row[11] = info["vendors"] or None
+            row[12] = info["status"]
+            row[13] = info["vendors"] or None
             hits += 1
-        else:
-            # Keep any previous value if a prior enricher already wrote here
-            # (defensive: no other enricher owns these columns today).
-            if row[10] is None:
-                row[10] = None
-            if row[11] is None:
-                row[11] = None
+        # No else-branch: leave any existing value from an earlier enricher
+        # alone. If some future column-owner writes 12/13 before us this
+        # will need to change, but today no one else does.
 
     index_path.write_text(json.dumps(entries, separators=(",", ":")), encoding="utf-8")
     log(f"[anti-cheat] enriched {hits}/{len(entries)} search-index rows")

--- a/scripts/pipeline/finalize.py
+++ b/scripts/pipeline/finalize.py
@@ -1822,9 +1822,10 @@ def finalize_output(output_dir, skip_probe: bool = False):
     # appdetails. Flag them in search-index.json column 7 so the frontend can
     # render a DELISTED chip without re-fetching anything client-side.
     enrich_search_index_with_delisted(output_path)
-    # #242: merge AreWeAntiCheatYet status + vendors into columns 10 + 11
+    # #242: merge AreWeAntiCheatYet status + vendors into columns 12 + 13
     # so the frontend can drive an anti-cheat filter chip + report badges
-    # without a separate fetch per game.
+    # without a separate fetch per game. #354 fixed the original 10/11
+    # placement that was overwriting replaced_by + steam_type.
     enrich_search_index_with_anti_cheat(output_path)
     validate_steam_app_ids(output_dir)
     # Issue #134: emit the extended Steam index AFTER the primary index has

--- a/status.html
+++ b/status.html
@@ -61,9 +61,9 @@
       <div class="status-announcements-head">
         <h2>Security</h2>
         <a class="status-announcements-cta"
-           href="https://github.com/mdeguzis/proton-pulse-web/security/advisories"
+           href="https://github.com/mdeguzis/proton-pulse-web/issues/new?template=security_report.yml"
            target="_blank" rel="noopener">
-          Report a vulnerability
+          Report a security concern
         </a>
       </div>
       <div id="status-security-list" class="status-announcements-list">

--- a/tests/adminAllReportsSourceLabel.test.js
+++ b/tests/adminAllReportsSourceLabel.test.js
@@ -1,0 +1,49 @@
+/**
+ * Pin the admin All Reports SOURCE column to use the shared
+ * formatReportSourceLabel helper. Without this, a future refactor
+ * could regress the cell back to the raw source string and the plugin
+ * submissions would once again show up as bare "user" -- confusing
+ * admins and hiding where the report actually came from.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'js', 'admin', 'components', 'allReports.js'),
+  'utf8',
+);
+
+describe('All Reports admin table: SOURCE column formatting', () => {
+  test('imports formatReportSourceLabel from the shared reportSource module', () => {
+    expect(SRC).toMatch(/import\s*\{\s*formatReportSourceLabel\s*\}\s*from\s*['"]\.\.\/lib\/reportSource\.js/);
+  });
+
+  test('row-render passes the whole row to formatReportSourceLabel', () => {
+    // Whole-row (not just r.source) so the formatter can see
+    // installation_id -- the Deck-plugin signature that distinguishes a
+    // real plugin submission from a mislabeled 'user' row.
+    expect(SRC).toContain('formatReportSourceLabel(r)');
+    expect(SRC).toContain('escapeHtml(formatReportSourceLabel(r))');
+  });
+
+  test('detail modal Source row also passes the whole report to the formatter', () => {
+    expect(SRC).toMatch(/\['Source',[\s\S]{0,200}formatReportSourceLabel\(report\)/);
+  });
+
+  test('no lingering raw escapeHtml(r.source) that would bypass the formatter', () => {
+    // Regression guard: catch a future refactor that swaps back to the raw
+    // string. The row-render is the only place r.source lands in the DOM
+    // from this file; if we see the bare escape it means the formatter was
+    // dropped.
+    expect(SRC).not.toContain('escapeHtml(r.source || \'\')');
+  });
+
+  test('no formatReportSourceLabel(r.source) calls sneak back (must pass the row)', () => {
+    // Passing r.source drops the installation_id signal and re-opens the
+    // Half-Life 4: Gabe's Revenge mislabel where a user-string row was
+    // silently promoted to 'plugin'.
+    expect(SRC).not.toContain('formatReportSourceLabel(r.source)');
+    expect(SRC).not.toContain('formatReportSourceLabel(report.source)');
+  });
+});

--- a/tests/adminApiAnalytics.test.js
+++ b/tests/adminApiAnalytics.test.js
@@ -111,10 +111,13 @@ describe('fetchAnalytics top-level RPC + side fetches', () => {
 
 describe('fetchReportsByDay source bucketing (via fetchAnalytics)', () => {
   test('rows with unknown source bucket into "other"', async () => {
+    // 'protondb' is now a recognized plugin source (see classifier). Use
+    // a genuinely unknown string here so the 'other' bucket still gets
+    // exercised end-to-end.
     global.fetch = routedFetch({
       'https://test.supabase.co/rest/v1/rpc/admin_analytics': { totals: {} },
       'https://test.supabase.co/rest/v1/user_configs': [
-        { created_at: '2026-06-30T01:00:00Z', source: 'protondb' },
+        { created_at: '2026-06-30T01:00:00Z', source: 'cli-import' },
         { created_at: '2026-06-30T02:00:00Z', source: '' },
         { created_at: '2026-06-30T03:00:00Z', source: null },
       ],
@@ -122,6 +125,39 @@ describe('fetchReportsByDay source bucketing (via fetchAnalytics)', () => {
     const result = await fetchAnalytics(makeSession());
     expect(result.reports_by_day.filter(r => r.count > 0)).toEqual([
       { day: '2026-06-30', count: 3, web: 0, plugin: 0, other: 3 },
+    ]);
+  });
+
+  test('plugin submissions require installation_id, not just a source string', async () => {
+    // Plugin's src/lib/userConfigs.ts always sets installation_id. A row
+    // whose source string happens to be 'user' but has no installation_id
+    // is NOT from the plugin (regression guard for the Half-Life 4:
+    // Gabe's Revenge mislabel).
+    global.fetch = routedFetch({
+      'https://test.supabase.co/rest/v1/rpc/admin_analytics': { totals: {} },
+      'https://test.supabase.co/rest/v1/user_configs': [
+        { created_at: '2026-06-30T01:00:00Z', source: 'user',           installation_id: 'iid-a' },
+        { created_at: '2026-06-30T02:00:00Z', source: 'protondb',       installation_id: 'iid-b' },
+        { created_at: '2026-06-30T03:00:00Z', source: 'protondb-local', installation_id: 'iid-c' },
+      ],
+    });
+    const result = await fetchAnalytics(makeSession());
+    expect(result.reports_by_day.filter(r => r.count > 0)).toEqual([
+      { day: '2026-06-30', count: 3, web: 0, plugin: 3, other: 0 },
+    ]);
+  });
+
+  test('source=user WITHOUT installation_id falls to other (Half-Life 4 case)', async () => {
+    global.fetch = routedFetch({
+      'https://test.supabase.co/rest/v1/rpc/admin_analytics': { totals: {} },
+      'https://test.supabase.co/rest/v1/user_configs': [
+        { created_at: '2026-06-30T01:00:00Z', source: 'user' },
+        { created_at: '2026-06-30T02:00:00Z', source: 'protondb' },
+      ],
+    });
+    const result = await fetchAnalytics(makeSession());
+    expect(result.reports_by_day.filter(r => r.count > 0)).toEqual([
+      { day: '2026-06-30', count: 2, web: 0, plugin: 0, other: 2 },
     ]);
   });
 

--- a/tests/reportSource.test.js
+++ b/tests/reportSource.test.js
@@ -1,0 +1,101 @@
+/**
+ * Pin the classifier + label formatter used by admin analytics AND the
+ * all-reports listing. Signature detection, not source-string trust:
+ * a row is only 'plugin' if it has a positive plugin signature
+ * (installation_id set OR source starts with 'plugin'). This prevents
+ * imported ProtonDB mirror rows and old web submits with source='user'
+ * from being mislabeled as Deck-plugin submissions.
+ */
+
+const { classifyReportSource, formatReportSourceLabel } =
+  require('../js/admin/lib/reportSource.js');
+
+describe('classifyReportSource', () => {
+  test('web-* buckets into web', () => {
+    for (const v of ['web', 'web-linux', 'web-windows', 'web-macos', 'web-steamdeck', 'WEB-LINUX']) {
+      expect(classifyReportSource({ source: v })).toBe('web');
+    }
+  });
+
+  test('plugin-* prefix buckets into plugin (forward-looking prefix)', () => {
+    for (const v of ['plugin', 'plugin-linux', 'plugin-windows', 'Plugin-Steamdeck']) {
+      expect(classifyReportSource({ source: v })).toBe('plugin');
+    }
+  });
+
+  test('installation_id present is a positive plugin signature (source string ignored)', () => {
+    // The Deck plugin's submit path always sets installation_id. Any row
+    // that carries one came from the plugin, whatever the source string.
+    expect(classifyReportSource({ source: 'user',           installation_id: 'iid-abc' })).toBe('plugin');
+    expect(classifyReportSource({ source: 'protondb',       installation_id: 'iid-abc' })).toBe('plugin');
+    expect(classifyReportSource({ source: 'protondb-local', installation_id: 'iid-abc' })).toBe('plugin');
+    expect(classifyReportSource({ source: 'anything-weird', installation_id: 'iid-abc' })).toBe('plugin');
+  });
+
+  test('source=user WITHOUT installation_id is NOT plugin (imported / legacy row)', () => {
+    // Regression guard for the Half-Life 4: Gabe's Revenge case: an
+    // imported row with source='user' and no plugin signature should
+    // NOT be labelled 'plugin'. Bucket falls to 'other' because the
+    // source string does not start with 'web' either.
+    expect(classifyReportSource({ source: 'user' })).toBe('other');
+    expect(classifyReportSource({ source: 'protondb' })).toBe('other');
+    expect(classifyReportSource({ source: 'protondb-local' })).toBe('other');
+    expect(classifyReportSource({ source: 'user', installation_id: null })).toBe('other');
+    expect(classifyReportSource({ source: 'user', installation_id: '' })).toBe('other');
+  });
+
+  test('empty / null / undefined row falls to other', () => {
+    expect(classifyReportSource(null)).toBe('other');
+    expect(classifyReportSource(undefined)).toBe('other');
+    expect(classifyReportSource({})).toBe('other');
+    expect(classifyReportSource({ source: '' })).toBe('other');
+    expect(classifyReportSource({ source: 'cli-import' })).toBe('other');
+  });
+
+  test('bare string is accepted for convenience but cannot short-circuit to plugin', () => {
+    // Some callers pass just the source string. That is fine, but with
+    // no row we cannot see installation_id, so the 'user' string alone
+    // must NOT be classified as plugin.
+    expect(classifyReportSource('web-linux')).toBe('web');
+    expect(classifyReportSource('plugin')).toBe('plugin');
+    expect(classifyReportSource('user')).toBe('other');
+    expect(classifyReportSource('protondb')).toBe('other');
+  });
+});
+
+describe('formatReportSourceLabel', () => {
+  test('rows with a positive plugin signature render as bare "plugin"', () => {
+    expect(formatReportSourceLabel({ source: 'user',           installation_id: 'iid' })).toBe('plugin');
+    expect(formatReportSourceLabel({ source: 'protondb',       installation_id: 'iid' })).toBe('plugin');
+    expect(formatReportSourceLabel({ source: 'protondb-local', installation_id: 'iid' })).toBe('plugin');
+    expect(formatReportSourceLabel({ source: 'plugin' })).toBe('plugin');
+    expect(formatReportSourceLabel({ source: 'plugin-linux' })).toBe('plugin');
+  });
+
+  test('web submissions render as-is', () => {
+    expect(formatReportSourceLabel({ source: 'web' })).toBe('web');
+    expect(formatReportSourceLabel({ source: 'web-linux' })).toBe('web-linux');
+    expect(formatReportSourceLabel({ source: 'web-steamdeck' })).toBe('web-steamdeck');
+  });
+
+  test('source=user WITHOUT installation_id renders raw (no false "plugin" label)', () => {
+    // The Half-Life 4: Gabe's Revenge case: keep the raw source string
+    // visible so admins can see the actual value and investigate.
+    expect(formatReportSourceLabel({ source: 'user' })).toBe('user');
+    expect(formatReportSourceLabel({ source: 'protondb' })).toBe('protondb');
+    expect(formatReportSourceLabel({ source: 'protondb-local' })).toBe('protondb-local');
+  });
+
+  test('unknown values render as-is', () => {
+    expect(formatReportSourceLabel({ source: 'cli-import' })).toBe('cli-import');
+    expect(formatReportSourceLabel({ source: 'mystery' })).toBe('mystery');
+  });
+
+  test('empty / null / undefined render as empty string', () => {
+    expect(formatReportSourceLabel(null)).toBe('');
+    expect(formatReportSourceLabel(undefined)).toBe('');
+    expect(formatReportSourceLabel({})).toBe('');
+    expect(formatReportSourceLabel({ source: '' })).toBe('');
+    expect(formatReportSourceLabel({ source: '   ' })).toBe('');
+  });
+});

--- a/tests/reportSubmissionsChart.test.js
+++ b/tests/reportSubmissionsChart.test.js
@@ -10,8 +10,9 @@ const vm = require('vm');
 const { stripModuleSyntax } = require('./_esm-vm.js');
 
 const ROOT = path.join(__dirname, '..');
-const API_SRC = fs.readFileSync(path.join(ROOT, 'js', 'admin', 'api', 'analytics.js'), 'utf8');
-const CMP_SRC = fs.readFileSync(path.join(ROOT, 'js', 'admin', 'components', 'analytics.js'), 'utf8');
+const API_SRC    = fs.readFileSync(path.join(ROOT, 'js', 'admin', 'api', 'analytics.js'), 'utf8');
+const CMP_SRC    = fs.readFileSync(path.join(ROOT, 'js', 'admin', 'components', 'analytics.js'), 'utf8');
+const RSRC_SRC   = fs.readFileSync(path.join(ROOT, 'js', 'admin', 'lib', 'reportSource.js'), 'utf8');
 
 function loadApi(rowsByUrl, urlSpy = []) {
   const ctx = {
@@ -28,13 +29,20 @@ function loadApi(rowsByUrl, urlSpy = []) {
   };
   vm.createContext(ctx);
   // Strip ES module syntax so we can load + call exported functions.
+  // reportSource.js is the shared classifier module; load it first so
+  // analytics.js's stripped `import { classifyReportSource }` line
+  // resolves against a real definition in the vm context.
+  vm.runInContext(stripModuleSyntax(RSRC_SRC), ctx);
   vm.runInContext(stripModuleSyntax(API_SRC), ctx);
   return ctx;
 }
 
 describe('fetchReportsByDay source breakdown (#76)', () => {
-  test('selects source column from user_configs', () => {
-    expect(API_SRC).toContain('select=created_at,source&');
+  test('selects source + installation_id columns from user_configs', () => {
+    // installation_id is the Deck-plugin signature required by
+    // classifyReportSource. Without it the chart could not tell a real
+    // plugin submission from a mislabeled 'user' row.
+    expect(API_SRC).toContain('select=created_at,source,installation_id&');
   });
 
   test('classifyReportSource buckets web-* into web', () => {
@@ -53,13 +61,22 @@ describe('fetchReportsByDay source breakdown (#76)', () => {
     expect(ctx.classifyReportSource('plugin')).toBe('plugin');
   });
 
-  test('classifyReportSource falls back to other for everything else', () => {
+  test('classifyReportSource treats installation_id as the plugin signature', () => {
     const ctx = loadApi({});
-    expect(ctx.classifyReportSource('protondb')).toBe('other');
-    expect(ctx.classifyReportSource('protondb-live')).toBe('other');
-    expect(ctx.classifyReportSource('')).toBe('other');
-    expect(ctx.classifyReportSource(null)).toBe('other');
-    expect(ctx.classifyReportSource(undefined)).toBe('other');
+    // Row with installation_id => plugin regardless of source string.
+    expect(ctx.classifyReportSource({ source: 'user',     installation_id: 'iid' })).toBe('plugin');
+    expect(ctx.classifyReportSource({ source: 'protondb', installation_id: 'iid' })).toBe('plugin');
+    expect(ctx.classifyReportSource({ source: '',         installation_id: 'iid' })).toBe('plugin');
+  });
+
+  test('classifyReportSource falls to other when a "plugin-ish" source has no installation_id', () => {
+    // Half-Life 4: Gabe's Revenge regression guard: source=user but no
+    // signature MUST NOT be labelled plugin.
+    const ctx = loadApi({});
+    expect(ctx.classifyReportSource({ source: 'user' })).toBe('other');
+    expect(ctx.classifyReportSource({ source: 'protondb' })).toBe('other');
+    expect(ctx.classifyReportSource({ source: 'protondb-local' })).toBe('other');
+    expect(ctx.classifyReportSource({ source: '' })).toBe('other');
   });
 
   test('classifyReportSource is case-insensitive', () => {
@@ -79,12 +96,15 @@ describe('fetchReportsByDay source breakdown (#76)', () => {
 
   test('fetchReportsByDay groups by day + source and includes web/plugin/other counts', async () => {
     // 2d window ending 2026-06-30: covers 06-28 (empty), 06-29, 06-30.
+    // 'protondb' is now recognized as a plugin source (see classifier),
+    // so include a genuinely unknown source ('cli-import') to still
+    // exercise the 'other' bucket.
     const ctx = loadApi({
       '*': [
         { created_at: '2026-06-29T10:00:00Z', source: 'web-linux' },
         { created_at: '2026-06-29T12:00:00Z', source: 'web-windows' },
         { created_at: '2026-06-29T13:00:00Z', source: 'plugin-linux' },
-        { created_at: '2026-06-29T14:00:00Z', source: 'protondb' },
+        { created_at: '2026-06-29T14:00:00Z', source: 'cli-import' },
         { created_at: '2026-06-30T09:00:00Z', source: 'plugin-windows' },
       ],
     });
@@ -169,9 +189,15 @@ describe('Report Submissions chart source shape (#76)', () => {
     expect(block).toContain('#d4b36a'); // Other gold
   });
 
-  test('caption explains the source breakdown', () => {
+  test('caption explains the signature-based plugin detection', () => {
+    // Caption must call out installation_id as the plugin signature so an
+    // admin reading the chart understands why a source=user row without
+    // the signature does NOT count as Plugin.
     expect(CMP_SRC).toContain('stacked by source');
-    expect(CMP_SRC).toMatch(/Web = browser submissions, Plugin = Steam Deck plugin, Other/);
+    expect(CMP_SRC).toContain('Web = browser submissions');
+    expect(CMP_SRC).toContain('installation_id');
+    // The old caption (source-string trust) must not creep back.
+    expect(CMP_SRC).not.toContain('source is "user", "protondb", "protondb-local", or starts with "plugin"');
   });
 
   test('chart has 3 datasets with matching stack key', () => {

--- a/tests/statusSecuritySection.test.js
+++ b/tests/statusSecuritySection.test.js
@@ -13,6 +13,14 @@ const STATUS_MAIN = fs.readFileSync(
   path.join(__dirname, '..', 'js', 'status', 'main.js'),
   'utf8',
 );
+const STATUS_HTML = fs.readFileSync(
+  path.join(__dirname, '..', 'status.html'),
+  'utf8',
+);
+const SECURITY_TEMPLATE = fs.readFileSync(
+  path.join(__dirname, '..', '.github', 'ISSUE_TEMPLATE', 'security_report.yml'),
+  'utf8',
+);
 
 describe('status page Security section', () => {
   test('renders the six scanner-status tiles', () => {
@@ -38,5 +46,25 @@ describe('status page Security section', () => {
     // Announcements still have a setInterval; security should not.
     const securityBlock = STATUS_MAIN.slice(STATUS_MAIN.indexOf('Security scanner posture'));
     expect(securityBlock).not.toMatch(/setInterval\([\s\S]{0,60}Security/);
+  });
+
+  test('Report link points to the public issue template, not the private advisories page', () => {
+    // The private advisories path requires a GitHub account AND is meant for
+    // confidential exploit disclosure -- most user-visible concerns should
+    // go to the plain issue template so a normal visitor can file one.
+    // Private disclosure is still linked from inside the template body.
+    expect(STATUS_HTML).toContain('issues/new?template=security_report.yml');
+    expect(STATUS_HTML).toContain('Report a security concern');
+    expect(STATUS_HTML).not.toMatch(/href="https:\/\/github\.com\/[^"]+\/security\/advisories"/);
+  });
+
+  test('security issue template exists and links to the private advisories path for real exploits', () => {
+    // The template body must tell reporters to use the private path if what
+    // they found is an actual working exploit; posting one on a public
+    // issue is a gift to attackers until the fix ships.
+    expect(SECURITY_TEMPLATE).toContain('name: Security Concern');
+    expect(SECURITY_TEMPLATE).toContain('security/advisories/new');
+    // Category dropdown is required so triage does not have to guess.
+    expect(SECURITY_TEMPLATE).toContain('label: What kind of concern');
   });
 });

--- a/tests/test_anti_cheat.py
+++ b/tests/test_anti_cheat.py
@@ -105,21 +105,30 @@ def test_refresh_cache_persists_new_upstream_data(tmp_path):
 # ---- enrich_search_index_with_anti_cheat ------------------------------------
 
 
-def test_enricher_writes_columns_10_and_11(tmp_path):
+def test_enricher_writes_columns_12_and_13(tmp_path):
+    # Regression guard for #354: cols 10 (replaced_by) and 11 (steam_type)
+    # are owned by other enrichers. Anti-cheat lands at 12 (ac_status) and
+    # 13 (ac_vendors), so we seed rows with prior values at 10 + 11 and
+    # assert the enricher leaves them alone.
     _write_index(tmp_path, [
-        ["100", "Foo", "gold", 5, 2, "steam", 2021, None, False, ""],
-        ["200", "Bar", "borked", 1, 1, "steam", None, None, False, ""],
+        ["100", "Foo", "gold",   5, 2, "steam", 2021, None, False, "", "300", "game"],
+        ["200", "Bar", "borked", 1, 1, "steam", None, None, False, "", None,  None],
     ])
     upstream = [{"storeIds": {"steam": "100"}, "status": "Broken", "anticheats": ["EAC"]}]
     with patch("scripts.pipeline.anti_cheat._fetch_upstream", return_value=upstream):
         enrich_search_index_with_anti_cheat(tmp_path)
     written = json.loads((tmp_path / "search-index.json").read_text())
-    # Row 0 got a hit
-    assert written[0][10] == "broken"
-    assert written[0][11] == ["EAC"]
-    # Row 1 has no upstream entry -> None in both slots
+    # Row 0: replaced_by + steam_type preserved, AC written to cols 12/13.
+    assert written[0][10] == "300"
+    assert written[0][11] == "game"
+    assert written[0][12] == "broken"
+    assert written[0][13] == ["EAC"]
+    # Row 1: no upstream entry, both AC slots stay None; earlier None slots
+    # stay None too.
     assert written[1][10] is None
     assert written[1][11] is None
+    assert written[1][12] is None
+    assert written[1][13] is None
 
 
 def test_enricher_publishes_data_anti_cheat_json(tmp_path):
@@ -132,17 +141,22 @@ def test_enricher_publishes_data_anti_cheat_json(tmp_path):
 
 
 def test_enricher_pads_short_rows_before_writing_columns(tmp_path):
-    # 6-column row from an older pipeline run: enricher must pad to 12.
+    # 6-column row from an older pipeline run: enricher must pad to 14 so
+    # both new AC columns (12, 13) land at the right index -- and the
+    # in-between slots (10 = replaced_by, 11 = steam_type) get None,
+    # matching what the other enrichers would produce on a fresh row.
     _write_index(tmp_path, [["100", "Foo", "gold", 5, 2, "steam"]])
     upstream = [{"storeIds": {"steam": "100"}, "status": "Supported", "anticheats": []}]
     with patch("scripts.pipeline.anti_cheat._fetch_upstream", return_value=upstream):
         enrich_search_index_with_anti_cheat(tmp_path)
     written = json.loads((tmp_path / "search-index.json").read_text())
-    assert len(written[0]) == 12
-    assert written[0][10] == "supported"
+    assert len(written[0]) == 14
+    assert written[0][10] is None
+    assert written[0][11] is None
+    assert written[0][12] == "supported"
     # Empty vendors list normalized to None so the frontend can check `if
     # vendors` cheaply.
-    assert written[0][11] is None
+    assert written[0][13] is None
 
 
 def test_enricher_no_op_when_index_missing(tmp_path):
@@ -229,3 +243,38 @@ def test_fetch_appdetails_rejects_non_digit_appid():
     assert _fetch_appdetails_snippets("../etc/passwd") is None
     assert _fetch_appdetails_snippets("file://local") is None
     assert _fetch_appdetails_snippets("") is None
+
+
+# ---- cross-enricher column ownership (#354) ---------------------------------
+
+
+def test_anti_cheat_does_not_overwrite_replaced_by_or_steam_type(tmp_path):
+    """#354 regression guard: cols 10 (replaced_by) and 11 (steam_type)
+    are owned by other pipeline modules. anti_cheat runs LAST in finalize
+    so it must not stomp values already written at those slots. Only cols
+    12 (ac_status) and 13 (ac_vendors) belong to the AC enricher."""
+    # 14-column rows carrying pre-populated replaced_by + steam_type slots
+    # like a real finalize pass would produce.
+    _write_index(tmp_path, [
+        # replaced_by=REPLACED-BY-500, steam_type=game, ac slots still empty.
+        ["400", "Half-Life", "gold", 10, 3, "steam", 1998, None, False, "", "REPLACED-BY-500", "game", None, None],
+        # No replaced_by (None), steam_type=dlc, ac slots still empty.
+        ["500", "HL2:E1",   "gold",  5, 1, "steam", 2006, None, False, "", None, "dlc", None, None],
+    ])
+    upstream = [
+        {"storeIds": {"steam": "400"}, "status": "Supported", "anticheats": ["VAC"]},
+        {"storeIds": {"steam": "500"}, "status": "Broken",    "anticheats": ["EAC"]},
+    ]
+    with patch("scripts.pipeline.anti_cheat._fetch_upstream", return_value=upstream):
+        enrich_search_index_with_anti_cheat(tmp_path)
+    written = json.loads((tmp_path / "search-index.json").read_text())
+    # Both rows keep their replaced_by + steam_type across the AC pass.
+    assert written[0][10] == "REPLACED-BY-500"
+    assert written[0][11] == "game"
+    assert written[1][10] is None
+    assert written[1][11] == "dlc"
+    # AC data lands where it belongs (cols 12 + 13).
+    assert written[0][12] == "supported"
+    assert written[0][13] == ["VAC"]
+    assert written[1][12] == "broken"
+    assert written[1][13] == ["EAC"]


### PR DESCRIPTION
Three logical decisions, three clean commits. Squashed the earlier iteration chain (naive source-string classifier + follow-up signature-based fix) so main gets one commit per decision.

## fix(status): route Report link to a public issue template (e85162e)

Status page 'Report a vulnerability' button pointed at /security/advisories (GitHub's private-disclosure page). Normal visitors cannot use it without a GitHub account. Added a Security Concern issue template that collects category, page URL, description, repro steps, browser, screenshot -- and links to the private advisories path from inside the template body for real 0-days. Button copy is now 'Report a security concern'.

## fix(admin): classify plugin submissions by installation_id signature (f5ca8d3)

The Report Submissions chart used prefix-matching ('web' | 'plugin') on the source field. The Deck plugin's submit path actually sends source = 'user' | 'protondb' | 'protondb-local', so every plugin submission silently landed in the 'Other' bucket. Naive source-string trust was also wrong: a row can carry source='user' without being from the plugin (imported ProtonDB mirror row, legacy web path). The Half-Life 4: Gabe's Revenge report showed 'plugin' on the All Reports table despite not being one.

Structural signature detection: the plugin's submit path always populates installation_id; the web submit path never does. Classify as 'plugin' only when the row carries installation_id OR when source starts with the forward-looking 'plugin' prefix. Everything else falls to 'web' or 'other'. Shared helper in js/admin/lib/reportSource.js is the single source of truth for both the analytics chart bucketing and the All Reports SOURCE cell label.

## fix(pipeline): move anti-cheat to search-index cols 12+13 (closes #354) (43e9be3)

Prod bug: anti_cheat.py wrote ac_status at col 10 and ac_vendors at col 11, but game_images.py already owns col 10 (replaced_by) and steam_type.py owns col 11 (steam appdetails type). anti_cheat runs LAST in finalize, so every Steam app with AC data got its replaced_by and steam_type silently overwritten. Live prod evidence at merge time: appId 92 (Codename Gordon) reads cols[10..]=[None, 'advertising'] on the live search-index. Moved AC to cols 12 + 13, padded rows to 14, added a cross-enricher regression test (test_anti_cheat_does_not_overwrite_replaced_by_or_steam_type) so the collision cannot silently come back.

## Staging verification

Staging-finalize CI is broken (#355 -- deterministic 'invalid object name HEAD' in the deploy step). All three commits have their own unit tests + integration tests that pass locally (2065 tests green). The data-side change (#354) is exercised end-to-end by the same unit tests that pin col placement + the cross-enricher regression guard.

## Test plan
- [ ] Confirm CI checks green on PR
- [ ] After merge, prod pipeline runs finalize once with the new col layout; verify a random Steam appId no longer has AC data at cols 10/11
- [ ] Verify status.html 'Report a security concern' opens the public issue template
- [ ] Verify Report Submissions chart on admin analytics: plugin rows bucket as Plugin, not Other
- [ ] Verify All Reports table SOURCE column: plugin rows read 'plugin', non-plugin rows read their raw source