### PR TITLE
release: site health probes + proactive cert-expiry monitoring

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,0 +1,84 @@
+name: Deploy Cloudflare Workers
+
+on:
+  # Deploy on any push to main OR staging that touches worker source. Both
+  # branches deploy to the same worker (no staging clone) -- there is only
+  # one pp-edge-status.<subdomain>.workers.dev endpoint, and staging + prod
+  # both hit it. Last push wins, same shape as deploy-functions.yml.
+  push:
+    branches: [main, staging]
+    paths:
+      - 'workers/**'
+      - '.github/workflows/deploy-worker.yml'
+  workflow_dispatch:
+    inputs:
+      worker:
+        description: 'Worker directory under workers/ (default: edge-status)'
+        required: false
+        default: 'edge-status'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # Detect which workers changed on this push and iterate. On manual
+      # dispatch, use the input override (default: edge-status). Keeps the
+      # workflow open to future workers under workers/<name>/ without
+      # rewriting the deploy step per worker.
+      - name: Resolve worker list
+        id: workers
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            printf 'names=%s\n' "${{ inputs.worker }}" >> "$GITHUB_OUTPUT"
+            echo "count=1" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Push event: use the git diff against the previous commit to find
+          # which workers changed. Fallback: deploy everything under workers/
+          # so a first-run / force-push does not skip.
+          before='${{ github.event.before }}'
+          if [ -z "${before}" ] || [ "${before}" = "0000000000000000000000000000000000000000" ]; then
+            mapfile -t all < <(find workers -maxdepth 2 -name wrangler.toml -printf '%h\n' | sed 's#^workers/##')
+          else
+            mapfile -t all < <(git diff --name-only "${before}" ${{ github.sha }} \
+              | grep -E '^workers/[^/]+/' \
+              | awk -F/ '{print $2}' \
+              | sort -u)
+          fi
+          if [ ${#all[@]} -eq 0 ]; then
+            echo "No worker changes detected; nothing to deploy."
+            echo "count=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          printf 'names=%s\n' "$(IFS=','; echo "${all[*]}")" >> "$GITHUB_OUTPUT"
+          printf 'count=%s\n' "${#all[@]}" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy each changed worker via wrangler
+        if: steps.workers.outputs.count != '0'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          IFS=',' read -ra WORKERS <<< '${{ steps.workers.outputs.names }}'
+          for w in "${WORKERS[@]}"; do
+            echo "::group::Deploying workers/$w"
+            if [ ! -f "workers/$w/wrangler.toml" ]; then
+              echo "workers/$w has no wrangler.toml -- skipping"
+              echo "::endgroup::"
+              continue
+            fi
+            cd "workers/$w"
+            npx --yes wrangler@latest deploy
+            cd "$GITHUB_WORKSPACE"
+            echo "::endgroup::"
+          done

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -33,23 +33,34 @@ jobs:
       # dispatch, use the input override (default: edge-status). Keeps the
       # workflow open to future workers under workers/<name>/ without
       # rewriting the deploy step per worker.
+      #
+      # All GitHub context data comes in via `env:` and is referenced as
+      # quoted shell variables ("$VAR"), never inlined via ${{ ... }} in
+      # the run: script. That is the pattern semgrep's
+      # yaml.github-actions.security.run-shell-injection rule requires --
+      # inline ${{ ... }} in run: blocks would allow a maliciously named
+      # branch or PR body to inject shell code into the runner.
       - name: Resolve worker list
         id: workers
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_WORKER: ${{ inputs.worker }}
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            printf 'names=%s\n' "${{ inputs.worker }}" >> "$GITHUB_OUTPUT"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            printf 'names=%s\n' "$INPUT_WORKER" >> "$GITHUB_OUTPUT"
             echo "count=1" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           # Push event: use the git diff against the previous commit to find
           # which workers changed. Fallback: deploy everything under workers/
           # so a first-run / force-push does not skip.
-          before='${{ github.event.before }}'
-          if [ -z "${before}" ] || [ "${before}" = "0000000000000000000000000000000000000000" ]; then
+          if [ -z "$BEFORE_SHA" ] || [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
             mapfile -t all < <(find workers -maxdepth 2 -name wrangler.toml -printf '%h\n' | sed 's#^workers/##')
           else
-            mapfile -t all < <(git diff --name-only "${before}" ${{ github.sha }} \
+            mapfile -t all < <(git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" \
               | grep -E '^workers/[^/]+/' \
               | awk -F/ '{print $2}' \
               | sort -u)
@@ -67,9 +78,10 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WORKER_NAMES: ${{ steps.workers.outputs.names }}
         run: |
           set -euo pipefail
-          IFS=',' read -ra WORKERS <<< '${{ steps.workers.outputs.names }}'
+          IFS=',' read -ra WORKERS <<< "$WORKER_NAMES"
           for w in "${WORKERS[@]}"; do
             echo "::group::Deploying workers/$w"
             if [ ! -f "workers/$w/wrangler.toml" ]; then

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ FORCE_DEPLOY ?=
 
 .PHONY: help setup install install-pg test test-js lint lint-py lint-pylint lint-sh test-py init-submodules fetch-steam-catalog backup-supabase install-docker \
 	gh-run gh-pages-only gh-staging gh-staging-pipeline gh-staging-finalize gh-resume gh-finalize-only gh-backfill-apps gh-coverage-backfill gh-run-watch gh-check check-staging-sync \
-	build serve smoke smoke-live pre-push coverage deploy-worker
+	build serve smoke smoke-live pre-push coverage deploy-worker renew-certificate
 
 build:
 	@bash scripts/cache-bust.sh
@@ -20,6 +20,13 @@ build:
 # Deploy a Cloudflare Worker (default: edge-status). Override: make deploy-worker WORKER=<name>
 deploy-worker:
 	@bash scripts/deploy-worker.sh $(WORKER)
+
+# Renew the GH Pages Let's Encrypt cert (walks the operator through the
+# Cloudflare grey-cloud step, then polls the GitHub Pages API + flips
+# https_enforced=true once the cert is provisioned). See #<TODO> if you
+# want to know why it needs a human touch.
+renew-certificate:
+	@bash scripts/renew-github-pages-cert.sh
 
 # Run Jest unit tests + manifest completeness check
 test-js:

--- a/js/status/main.js
+++ b/js/status/main.js
@@ -223,6 +223,55 @@ function renderFromPayload(payload) {
   const svcs = Array.isArray(payload.services) ? payload.services : [];
   listEl.innerHTML = svcs.map(renderService).join('') ||
     '<div class="state-box">No services reported.</div>';
+
+  // Site-health cards for prod + staging (added by pp-edge-status worker).
+  // Backward compatible: if the payload predates the site probes, the
+  // section stays empty rather than erroring.
+  const siteListEl = document.getElementById('status-site-list');
+  if (siteListEl) {
+    const sites = Array.isArray(payload.sites) ? payload.sites : [];
+    siteListEl.innerHTML = sites.length
+      ? sites.map(renderSiteCard).join('')
+      : '<div class="state-box">Site probes have not run yet (first-deploy cache warm-up). Check back in ~15 min.</div>';
+  }
+}
+
+// Human-readable label for the specific site-probe reason strings the
+// worker emits. Keeps operator-facing copy tight and points at the fix
+// rather than the mechanic.
+function siteReasonLabel(reason) {
+  if (!reason) return '';
+  if (reason === 'origin_ssl_cert_invalid') return 'Origin SSL certificate invalid (Cloudflare 526). Renew the Let\'s Encrypt cert on the origin.';
+  if (reason === 'origin_ssl_handshake_failed') return 'Origin SSL handshake failed (Cloudflare 525).';
+  if (reason === 'unreachable') return 'No response within timeout.';
+  const m = reason.match(/^http_(\d+)$/);
+  if (m) return `HTTP ${m[1]}`;
+  return reason;
+}
+
+function renderSiteCard(site) {
+  const state = site.status || 'unknown';
+  const reasonText = siteReasonLabel(site.reason);
+  const primary = state === 'operational'
+    ? `${site.http_status || 200} in ${Math.round(site.latency_ms ?? 0)} ms`
+    : reasonText || 'unknown';
+  const hint = site.origin_hint
+    ? `origin: ${site.origin_hint}`
+    : '';
+  return `
+    <div class="status-card status-card--site" data-state="${esc(state)}">
+      <div class="status-card-head">
+        <span class="status-card-dot"></span>
+        <span class="status-card-name">${esc(site.name)}</span>
+        <span class="status-card-state">${statusLabel(state)}</span>
+      </div>
+      <div class="status-card-meta">
+        <span>${esc(primary)}</span>
+        <span title="${esc(site.checked_at || '')}">checked ${formatRelative(site.checked_at)}</span>
+      </div>
+      ${hint ? `<div class="status-card-meta status-card-meta--muted"><span>${esc(hint)}</span></div>` : ''}
+    </div>
+  `;
 }
 
 async function loadAndRender() {

--- a/js/status/main.js
+++ b/js/status/main.js
@@ -244,9 +244,28 @@ function siteReasonLabel(reason) {
   if (reason === 'origin_ssl_cert_invalid') return 'Origin SSL certificate invalid (Cloudflare 526). Renew the Let\'s Encrypt cert on the origin.';
   if (reason === 'origin_ssl_handshake_failed') return 'Origin SSL handshake failed (Cloudflare 525).';
   if (reason === 'unreachable') return 'No response within timeout.';
+  const daysMatch = reason.match(/^cert_expiring_(\d+)_days$/);
+  if (daysMatch) return `Origin certificate expires in ${daysMatch[1]} day(s). Run \`make renew-certificate\` well before then.`;
+  const stateMatch = reason.match(/^cert_state_(.+)$/);
+  if (stateMatch) return `GitHub Pages cert state is "${stateMatch[1]}" (not approved). ACME renewal likely blocked -- run \`make renew-certificate\`.`;
   const m = reason.match(/^http_(\d+)$/);
   if (m) return `HTTP ${m[1]}`;
   return reason;
+}
+
+// One-line summary of the cert's expiry: "12 days remaining (expires 2026-08-01)".
+// Falls back to just the state when no expiry date is available.
+function certSummary(cert) {
+  if (!cert) return '';
+  const parts = [];
+  if (typeof cert.days_remaining === 'number') {
+    parts.push(`${cert.days_remaining} day${cert.days_remaining === 1 ? '' : 's'} remaining`);
+  }
+  if (cert.expires_at) {
+    parts.push(`expires ${cert.expires_at.slice(0, 10)}`);
+  }
+  if (parts.length === 0 && cert.state) parts.push(`state: ${cert.state}`);
+  return parts.join(' \u00b7 ');
 }
 
 function renderSiteCard(site) {
@@ -258,6 +277,7 @@ function renderSiteCard(site) {
   const hint = site.origin_hint
     ? `origin: ${site.origin_hint}`
     : '';
+  const certLine = certSummary(site.cert);
   return `
     <div class="status-card status-card--site" data-state="${esc(state)}">
       <div class="status-card-head">
@@ -269,6 +289,7 @@ function renderSiteCard(site) {
         <span>${esc(primary)}</span>
         <span title="${esc(site.checked_at || '')}">checked ${formatRelative(site.checked_at)}</span>
       </div>
+      ${certLine ? `<div class="status-card-meta status-card-meta--muted"><span>cert: ${esc(certLine)}</span></div>` : ''}
       ${hint ? `<div class="status-card-meta status-card-meta--muted"><span>${esc(hint)}</span></div>` : ''}
     </div>
   `;

--- a/scripts/renew-github-pages-cert.sh
+++ b/scripts/renew-github-pages-cert.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# renew-github-pages-cert.sh
+#
+# Walks through the GitHub Pages Let's Encrypt cert renewal after ACME
+# authorization enters the `bad_authz` state -- which happens when
+# Cloudflare's proxy sits in front of the CNAME target and eats the
+# HTTP-01 challenge on `/.well-known/acme-challenge/*`. Sequence:
+#
+#   1. Read current cert state via `gh api repos/.../pages`.
+#   2. If already valid + not near expiry: exit 0 with a summary.
+#   3. Otherwise print the exact Cloudflare-side steps the operator must
+#      take by hand (Cloudflare dashboard changes are not automatable
+#      without a CF API token we do not have).
+#   4. Wait for the operator to confirm they finished step 3.
+#   5. Poll the GitHub Pages API every 30s for up to CERT_RENEW_TIMEOUT
+#      until https_certificate.state == 'approved'.
+#   6. Once approved, PUT https_enforced=true so redirects come back.
+#
+# Env vars:
+#   REPO              default mdeguzis/proton-pulse-web
+#   CERT_RENEW_TIMEOUT   default 900 (seconds, 15 min)
+#   POLL_INTERVAL     default 30 (seconds)
+
+set -euo pipefail
+
+REPO=${REPO:-mdeguzis/proton-pulse-web}
+CERT_RENEW_TIMEOUT=${CERT_RENEW_TIMEOUT:-900}
+POLL_INTERVAL=${POLL_INTERVAL:-30}
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "error: $1 not on PATH" >&2
+    exit 1
+  }
+}
+require gh
+require python3
+
+api_get_pages() {
+  gh api "repos/${REPO}/pages" 2>/dev/null
+}
+
+cert_state() {
+  python3 -c '
+import json, sys
+p = json.load(sys.stdin)
+cert = p.get("https_certificate") or {}
+print(json.dumps({
+    "state":       cert.get("state") or "unknown",
+    "expires_at":  cert.get("expires_at") or "",
+    "description": cert.get("description") or "",
+    "domains":     cert.get("domains") or [],
+    "https_enforced": p.get("https_enforced"),
+    "cname":       p.get("cname") or "",
+}))
+'
+}
+
+echo "=== GitHub Pages certificate state for ${REPO} ==="
+CURRENT=$(api_get_pages | cert_state)
+echo "${CURRENT}" | python3 -m json.tool
+
+STATE=$(echo "${CURRENT}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["state"])')
+CNAME=$(echo "${CURRENT}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["cname"])')
+
+if [ "${STATE}" = "approved" ]; then
+  echo ""
+  echo "Certificate is currently approved. Ensuring https_enforced=true..."
+  gh api -X PUT "repos/${REPO}/pages" --input <(echo '{"https_enforced": true}') >/dev/null
+  echo "Done."
+  exit 0
+fi
+
+cat <<'EOF'
+
+The cert is NOT in the "approved" state. Most common cause on this
+repo: Cloudflare's proxy sits in front of the CNAME and intercepts
+the HTTP-01 ACME challenge Let's Encrypt uses to verify domain
+ownership. This script cannot flip Cloudflare's cloud icon for you --
+that has to happen in the Cloudflare dashboard.
+
+STEPS TO TAKE NOW (on the Cloudflare side):
+
+  1. Log in to https://dash.cloudflare.com/
+  2. Select the proton-pulse.com zone
+  3. Open DNS -> Records
+  4. Find the record whose Name points at the GitHub Pages CNAME
+     (usually "www" and the root "@"). For this repo the CNAME is:
+EOF
+echo "         ${CNAME}"
+cat <<'EOF'
+  5. Click the orange cloud icon on EACH of those records so it turns
+     grey ("DNS only"). This disables the proxy temporarily so
+     Let's Encrypt can talk to GitHub Pages directly.
+  6. Wait about 30-60 seconds for DNS propagation.
+  7. Come back here and press ENTER to start polling the GitHub Pages
+     API for the new cert.
+
+  After we finish, you will:
+  8. Re-enable the orange cloud (proxy back on) in Cloudflare.
+  9. Under SSL/TLS -> Overview, set the encryption mode to "Full"
+     (NOT "Full (strict)") so GH Pages' Let's Encrypt cert is
+     accepted long-term.
+
+EOF
+
+read -r -p "Press ENTER once the Cloudflare records are grey-clouded... "
+
+DEADLINE=$(( $(date +%s) + CERT_RENEW_TIMEOUT ))
+echo ""
+echo "Polling repos/${REPO}/pages every ${POLL_INTERVAL}s until certificate state = approved (or ${CERT_RENEW_TIMEOUT}s elapse)..."
+while true; do
+  CURRENT=$(api_get_pages | cert_state)
+  STATE=$(echo "${CURRENT}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["state"])')
+  DESC=$(echo "${CURRENT}" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("description",""))')
+  NOW=$(date +%s)
+  echo "$(date -u +%H:%M:%S) state=${STATE} description=${DESC}"
+  if [ "${STATE}" = "approved" ]; then
+    echo ""
+    echo "Certificate provisioned. Enforcing HTTPS..."
+    gh api -X PUT "repos/${REPO}/pages" --input <(echo '{"https_enforced": true}') >/dev/null
+    echo "Done. Re-enable the Cloudflare proxy (orange cloud) and set SSL/TLS mode to 'Full'."
+    exit 0
+  fi
+  if [ "${NOW}" -ge "${DEADLINE}" ]; then
+    echo ""
+    echo "Timed out after ${CERT_RENEW_TIMEOUT}s. Cert state is still ${STATE}."
+    echo "  - If state is still bad_authz: give Cloudflare + DNS another minute, then re-run this script."
+    echo "  - If state is unavailable / pending: check GitHub Pages settings in the browser."
+    exit 1
+  fi
+  sleep "${POLL_INTERVAL}"
+done

--- a/scripts/renew-github-pages-cert.sh
+++ b/scripts/renew-github-pages-cert.sh
@@ -62,13 +62,51 @@ echo "${CURRENT}" | python3 -m json.tool
 
 STATE=$(echo "${CURRENT}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["state"])')
 CNAME=$(echo "${CURRENT}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["cname"])')
+# Days remaining until the current cert expires. If the pages API did not
+# expose expires_at (very new cert, brand-new domain), leave the counter at
+# "unknown" so downstream branches fall through to the manual-check path.
+DAYS_REMAINING=$(echo "${CURRENT}" | python3 -c '
+import json, sys, datetime as dt
+d = json.load(sys.stdin)
+raw = d.get("expires_at") or ""
+if not raw:
+    print("")
+    sys.exit(0)
+try:
+    exp = dt.datetime.fromisoformat(raw.replace("Z", "+00:00"))
+except ValueError:
+    print("")
+    sys.exit(0)
+now = dt.datetime.now(dt.timezone.utc)
+print(int((exp - now).total_seconds() // 86400))
+')
+
+# WARN threshold mirrors workers/edge-status/index.js EXPIRY_WARN_DAYS. Kept
+# as a bare number here rather than sourced from anywhere -- the script is
+# meant to be runnable in isolation on a fresh clone.
+WARN_DAYS=14
 
 if [ "${STATE}" = "approved" ]; then
+  # Approved AND well clear of expiry: nothing to do, just make sure
+  # HTTPS is enforced and exit.
+  if [ -z "${DAYS_REMAINING}" ] || [ "${DAYS_REMAINING}" -gt "${WARN_DAYS}" ]; then
+    echo ""
+    echo "Certificate is approved with ${DAYS_REMAINING:-unknown} day(s) remaining."
+    echo "Ensuring https_enforced=true..."
+    gh api -X PUT "repos/${REPO}/pages" --input <(echo '{"https_enforced": true}') >/dev/null
+    echo "Done."
+    exit 0
+  fi
+  # Approved BUT within the warn window (<=14 days). The site card in
+  # status.html emits cert_expiring_N_days and points here, so refusing to
+  # do anything would contradict the guidance. GitHub normally renews ~30
+  # days out; being inside the warn window means auto-renewal did not run
+  # or has not completed yet. Fall through to the manual walkthrough --
+  # the Cloudflare grey-cloud + polling sequence is the same fix.
   echo ""
-  echo "Certificate is currently approved. Ensuring https_enforced=true..."
-  gh api -X PUT "repos/${REPO}/pages" --input <(echo '{"https_enforced": true}') >/dev/null
-  echo "Done."
-  exit 0
+  echo "Certificate is approved but only ${DAYS_REMAINING} day(s) remain (warn threshold ${WARN_DAYS})."
+  echo "GitHub normally auto-renews around 30 days out; if you're inside the warn window"
+  echo "something is blocking the renewal. Running the manual walkthrough below to unstick it."
 fi
 
 cat <<'EOF'

--- a/status.html
+++ b/status.html
@@ -52,6 +52,11 @@
       <!-- GitHub Pages + Cloudflare vendor rows injected by js/status/main.js -->
     </div>
 
+    <h2 class="status-section-heading">Site health</h2>
+    <div id="status-site-list" class="status-list">
+      <!-- prod + staging site probes injected by js/status/main.js -->
+    </div>
+
     <h2 class="status-section-heading">Supabase edge functions</h2>
     <div id="status-list" class="status-list">
       <!-- injected by js/status/main.js -->
@@ -108,7 +113,7 @@
 <script src="js/lib/analytics.js?v=ad8d89f5"></script>
 <script src="js/lib/topbar.js?v=21a7ccea"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/status/main.js?v=16e777ed"></script>
+<script type="module" src="js/status/main.js?v=0addeee2"></script>
 
 </body>
 </html>

--- a/status.html
+++ b/status.html
@@ -113,7 +113,7 @@
 <script src="js/lib/analytics.js?v=ad8d89f5"></script>
 <script src="js/lib/topbar.js?v=21a7ccea"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/status/main.js?v=0addeee2"></script>
+<script type="module" src="js/status/main.js?v=1c4f70c9"></script>
 
 </body>
 </html>

--- a/tests/deployWorkerWorkflow.test.js
+++ b/tests/deployWorkerWorkflow.test.js
@@ -1,0 +1,84 @@
+/**
+ * Regression guards for .github/workflows/deploy-worker.yml. Motivated by
+ * the outage where a Cloudflare Worker fell out of sync with the frontend
+ * because deploying was a manual laptop step. The workflow should:
+ *   1. Fire on push to main OR staging when workers/** changes.
+ *   2. Support manual dispatch with a worker override so a targeted redeploy
+ *      is possible without a new commit.
+ *   3. Detect which workers changed (diff against event.before) and only
+ *      deploy those -- not the whole workers/ tree on every push.
+ *   4. Feed the two required secrets to wrangler as env vars.
+ */
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const WORKFLOW_PATH = path.join(__dirname, '..', '.github', 'workflows', 'deploy-worker.yml');
+const RAW = fs.readFileSync(WORKFLOW_PATH, 'utf8');
+const DOC = yaml.load(RAW);
+
+describe('deploy-worker.yml is well-formed', () => {
+  test('parses as YAML', () => {
+    expect(DOC).toBeTruthy();
+    expect(typeof DOC).toBe('object');
+  });
+
+  test('name identifies it as the CF worker deploy', () => {
+    expect(DOC.name).toBe('Deploy Cloudflare Workers');
+  });
+});
+
+describe('trigger surface', () => {
+  // js-yaml interprets the YAML key `on:` (unquoted) as the boolean `true`.
+  // Grab the block either way so we do not fail on YAML parser quirks.
+  const on = DOC.on ?? DOC.true;
+
+  test('fires on push to both main and staging', () => {
+    expect(on.push).toBeTruthy();
+    const branches = on.push.branches;
+    expect(branches).toContain('main');
+    expect(branches).toContain('staging');
+  });
+
+  test('is path-filtered to workers/ + the workflow itself (no full-repo triggers)', () => {
+    const paths = on.push.paths;
+    expect(paths).toContain('workers/**');
+    expect(paths).toContain('.github/workflows/deploy-worker.yml');
+  });
+
+  test('supports workflow_dispatch with a worker override input', () => {
+    expect(on.workflow_dispatch).toBeTruthy();
+    const inputs = on.workflow_dispatch.inputs || {};
+    expect(inputs.worker).toBeTruthy();
+    expect(inputs.worker.default).toBe('edge-status');
+  });
+});
+
+describe('deploy job wires wrangler correctly', () => {
+  test('checkout + node20 + no other builds (keeps the CI fast)', () => {
+    const steps = DOC.jobs.deploy.steps.map((s) => s.uses || s.name).filter(Boolean);
+    expect(steps.some((s) => s.startsWith('actions/checkout'))).toBe(true);
+    expect(steps.some((s) => s.startsWith('actions/setup-node'))).toBe(true);
+  });
+
+  test('resolves the worker list from the git diff, not by deploying everything', () => {
+    // Regression guard: a "diff-since-event.before" step must exist so the
+    // job is a no-op when a push does not actually touch workers/**. This
+    // is what keeps a green-field release from silently redeploying the
+    // worker for no reason.
+    expect(RAW).toContain('event.before');
+    expect(RAW).toMatch(/git diff --name-only[\s\S]{0,120}workers/);
+  });
+
+  test('runs wrangler deploy per changed worker directory', () => {
+    // The deploy step calls wrangler under `workers/<w>` for each entry
+    // in the resolved list. Skip the deploy step entirely when count=0.
+    expect(RAW).toContain('npx --yes wrangler@latest deploy');
+    expect(RAW).toContain("if: steps.workers.outputs.count != '0'");
+  });
+
+  test('passes both required Cloudflare secrets as env vars', () => {
+    expect(RAW).toContain('CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}');
+    expect(RAW).toContain('CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}');
+  });
+});

--- a/tests/deployWorkerWorkflow.test.js
+++ b/tests/deployWorkerWorkflow.test.js
@@ -65,9 +65,24 @@ describe('deploy job wires wrangler correctly', () => {
     // Regression guard: a "diff-since-event.before" step must exist so the
     // job is a no-op when a push does not actually touch workers/**. This
     // is what keeps a green-field release from silently redeploying the
-    // worker for no reason.
-    expect(RAW).toContain('event.before');
+    // worker for no reason. Values come in via env: to satisfy semgrep's
+    // run-shell-injection rule (see next test).
+    expect(RAW).toContain('BEFORE_SHA: ${{ github.event.before }}');
     expect(RAW).toMatch(/git diff --name-only[\s\S]{0,120}workers/);
+  });
+
+  test('all github context data enters run: via env, never inline ${{ ... }}', () => {
+    // Regression guard for semgrep yaml.github-actions.security.run-shell-
+    // injection. Attacker-influenced GitHub context (branch names, PR
+    // bodies, dispatch inputs) must not land in shell strings. Grep every
+    // run: block; the only ${{ ... }} allowed is in env: assignments.
+    // Shell body ends when indentation drops back to step-level (starts
+    // with the "      - " six-space dash prefix) or file end.
+    const runBlocks = RAW.split(/\n\s*run:\s*\|\n/).slice(1);
+    for (const block of runBlocks) {
+      const body = block.split(/\n {0,6}(?=\S)/)[0];
+      expect(body).not.toContain('${{');
+    }
   });
 
   test('runs wrangler deploy per changed worker directory', () => {

--- a/tests/edgeStatusWorker.test.js
+++ b/tests/edgeStatusWorker.test.js
@@ -8,8 +8,10 @@ import fs from 'fs';
 import path from 'path';
 import {
   FNS,
+  SITES,
   STATUS_KEY,
   classifyStatus,
+  classifySiteStatus,
   aggregateOverall,
   buildPayload,
   mergeService,
@@ -244,6 +246,69 @@ describe('worker exposes a history endpoint', () => {
   });
   test('every probe path updates history', () => {
     expect(SRC).toContain('updateHistory');
+  });
+});
+
+describe('classifySiteStatus', () => {
+  test('2xx is operational with no reason', () => {
+    expect(classifySiteStatus(200)).toEqual({ status: 'operational', reason: null });
+    expect(classifySiteStatus(204)).toEqual({ status: 'operational', reason: null });
+  });
+
+  test('Cloudflare 525 -> origin_ssl_handshake_failed', () => {
+    // Cloudflare 525 = SSL handshake with origin failed. Called out
+    // separately so support can point at the specific fix rather than
+    // treat it as a generic 5xx.
+    expect(classifySiteStatus(525)).toEqual({ status: 'down', reason: 'origin_ssl_handshake_failed' });
+  });
+
+  test('Cloudflare 526 -> origin_ssl_cert_invalid (the outage that motivated this)', () => {
+    // The whole reason this classifier exists: GH Pages Let's Encrypt cert
+    // expiring silently produced a 526 that the vendor-status page could
+    // not attribute. Explicit reason makes it obvious.
+    expect(classifySiteStatus(526)).toEqual({ status: 'down', reason: 'origin_ssl_cert_invalid' });
+  });
+
+  test('other 5xx are down with the raw http code preserved', () => {
+    expect(classifySiteStatus(500)).toEqual({ status: 'down', reason: 'http_500' });
+    expect(classifySiteStatus(502)).toEqual({ status: 'down', reason: 'http_502' });
+    expect(classifySiteStatus(503)).toEqual({ status: 'down', reason: 'http_503' });
+  });
+
+  test('4xx is degraded (site is reachable but wrong response)', () => {
+    // Unlike the edge-function classifier, a 401/403 on the SITE probe
+    // does not mean healthy -- version.json is public. So 4xx means the
+    // site is degraded, not OK.
+    expect(classifySiteStatus(404)).toEqual({ status: 'degraded', reason: 'http_404' });
+    expect(classifySiteStatus(403)).toEqual({ status: 'degraded', reason: 'http_403' });
+  });
+
+  test('0 = timeout / connection failure', () => {
+    expect(classifySiteStatus(0)).toEqual({ status: 'down', reason: 'unreachable' });
+  });
+});
+
+describe('SITES list covers prod and staging', () => {
+  test('SITES contains both prod and staging entries', () => {
+    const names = SITES.map((s) => s.name);
+    expect(names.some((n) => n.includes('prod'))).toBe(true);
+    expect(names.some((n) => n.includes('staging'))).toBe(true);
+  });
+
+  test('each site has a real https URL + origin_hint for the status card', () => {
+    for (const site of SITES) {
+      expect(site.url).toMatch(/^https:\/\//);
+      expect(typeof site.origin_hint).toBe('string');
+      expect(site.origin_hint.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('the URL each site probes is small + known-deployed (version.json)', () => {
+    // version.json is written on every deploy so probing it exercises the
+    // full origin-to-CDN path without hitting a heavy asset.
+    for (const site of SITES) {
+      expect(site.url).toContain('/version.json');
+    }
   });
 });
 

--- a/tests/edgeStatusWorker.test.js
+++ b/tests/edgeStatusWorker.test.js
@@ -12,6 +12,10 @@ import {
   STATUS_KEY,
   classifyStatus,
   classifySiteStatus,
+  applyCertToSiteResult,
+  fetchGithubPagesCert,
+  EXPIRY_WARN_DAYS,
+  EXPIRY_CRIT_DAYS,
   aggregateOverall,
   buildPayload,
   mergeService,
@@ -285,6 +289,100 @@ describe('classifySiteStatus', () => {
 
   test('0 = timeout / connection failure', () => {
     expect(classifySiteStatus(0)).toEqual({ status: 'down', reason: 'unreachable' });
+  });
+});
+
+describe('applyCertToSiteResult (proactive cert-expiry check)', () => {
+  const OK = { status: 'operational', reason: null };
+
+  test('returns the site result unchanged when no cert data is provided', () => {
+    expect(applyCertToSiteResult(OK, null)).toEqual(OK);
+    expect(applyCertToSiteResult(OK, undefined)).toEqual(OK);
+  });
+
+  test('healthy cert far from expiry does not change the tile state', () => {
+    const cert = { state: 'approved', days_remaining: 60, expires_at: '2026-09-01' };
+    const out = applyCertToSiteResult(OK, cert);
+    expect(out.status).toBe('operational');
+    expect(out.cert).toBe(cert);
+  });
+
+  test('cert within warn window (<= 14 days) degrades a healthy tile to yellow', () => {
+    const cert = { state: 'approved', days_remaining: EXPIRY_WARN_DAYS, expires_at: '2026-07-30' };
+    const out = applyCertToSiteResult(OK, cert);
+    expect(out.status).toBe('degraded');
+    expect(out.reason).toBe(`cert_expiring_${EXPIRY_WARN_DAYS}_days`);
+  });
+
+  test('cert within crit window (<= 3 days) hard-flips the tile to down', () => {
+    const cert = { state: 'approved', days_remaining: EXPIRY_CRIT_DAYS, expires_at: '2026-07-19' };
+    const out = applyCertToSiteResult(OK, cert);
+    expect(out.status).toBe('down');
+    expect(out.reason).toBe(`cert_expiring_${EXPIRY_CRIT_DAYS}_days`);
+  });
+
+  test('an already-down tile stays down when cert is fine (down > cert-warn)', () => {
+    const down = { status: 'down', reason: 'origin_ssl_cert_invalid' };
+    const cert = { state: 'approved', days_remaining: 60 };
+    const out = applyCertToSiteResult(down, cert);
+    expect(out.status).toBe('down');
+    // Existing reason wins so we do not lose the actionable label.
+    expect(out.reason).toBe('origin_ssl_cert_invalid');
+  });
+
+  test('ACME state != "approved" degrades the tile even when expiry is far off', () => {
+    // The specific state that caused the outage this whole feature is
+    // about: bad_authz for weeks while the cert quietly expired.
+    const cert = { state: 'bad_authz', days_remaining: 40 };
+    const out = applyCertToSiteResult(OK, cert);
+    expect(out.status).toBe('degraded');
+    expect(out.reason).toBe('cert_state_bad_authz');
+  });
+});
+
+describe('fetchGithubPagesCert', () => {
+  const orig = global.fetch;
+  afterEach(() => { global.fetch = orig; });
+
+  test('returns null when repo is null (staging-style wildcard cert)', async () => {
+    // No fetch should even be attempted.
+    global.fetch = () => { throw new Error('fetch should not be called'); };
+    expect(await fetchGithubPagesCert({}, null)).toBeNull();
+  });
+
+  test('returns null when GitHub returns non-ok', async () => {
+    global.fetch = async () => ({ ok: false, status: 404 });
+    expect(await fetchGithubPagesCert({}, 'mdeguzis/proton-pulse-web')).toBeNull();
+  });
+
+  test('parses expires_at + days_remaining from the pages API response', async () => {
+    const now = new Date('2026-07-18T00:00:00Z').getTime();
+    const cert = {
+      state: 'approved',
+      description: 'certificate is approved',
+      expires_at: '2026-08-01T00:00:00Z',  // 14 days out from `now`
+      domains: ['www.proton-pulse.com'],
+    };
+    global.fetch = async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ https_certificate: cert }),
+    });
+    const out = await fetchGithubPagesCert({}, 'mdeguzis/proton-pulse-web', now);
+    expect(out).not.toBeNull();
+    expect(out.expires_at).toBe(cert.expires_at);
+    expect(out.state).toBe('approved');
+    expect(out.days_remaining).toBe(14);
+  });
+
+  test('passes GITHUB_TOKEN via Authorization header when available', async () => {
+    let seenAuth = null;
+    global.fetch = async (url, opts) => {
+      seenAuth = opts?.headers?.Authorization ?? null;
+      return { ok: true, status: 200, json: async () => ({ https_certificate: { state: 'approved', expires_at: '2026-08-01T00:00:00Z' } }) };
+    };
+    await fetchGithubPagesCert({ GITHUB_TOKEN: 'ghp_test' }, 'mdeguzis/proton-pulse-web', Date.now());
+    expect(seenAuth).toBe('Bearer ghp_test');
   });
 });
 

--- a/tests/edgeStatusWorker.test.js
+++ b/tests/edgeStatusWorker.test.js
@@ -338,6 +338,51 @@ describe('applyCertToSiteResult (proactive cert-expiry check)', () => {
     expect(out.status).toBe('degraded');
     expect(out.reason).toBe('cert_state_bad_authz');
   });
+
+  test('critical expiry beats non-approved state (bad_authz + <=3 days -> down + cert_expiring)', () => {
+    // Regression guard for Codex review comment #1 on PR #356. The
+    // combination that produced the July outage is EXACTLY this:
+    // bad_authz with an imminent expiry. If cert_state ran first the
+    // tile would go merely yellow while the cert expires the same day.
+    const cert = { state: 'bad_authz', days_remaining: 1 };
+    const out = applyCertToSiteResult(OK, cert);
+    expect(out.status).toBe('down');
+    expect(out.reason).toBe('cert_expiring_1_days');
+  });
+});
+
+describe('mergeService preserves site probes across a super-admin single-fn check', () => {
+  test('the "Check now" path for one fn does not wipe payload.sites', () => {
+    // Regression guard for Codex review comment #3 on PR #356. The
+    // super-admin "Check now" flow rebuilds the payload via buildPayload
+    // which only knows about services. Sites run on the 15-min cron so
+    // wiping them here means the frontend shows "first-deploy cache
+    // warm-up" until the next cron -- confusing during the same window
+    // the admin is trying to observe.
+    const base = {
+      services: [],
+      sites: [
+        { name: 'prod (www.proton-pulse.com)', status: 'operational', http_status: 200 },
+        { name: 'staging (mdeguzis.github.io)', status: 'operational', http_status: 200 },
+      ],
+    };
+    const svc = { name: FNS[0], status: 'operational', http_status: 204, latency_ms: 42 };
+    const out = mergeService(base, svc);
+    // Sites carried through unchanged...
+    expect(out.sites).toEqual(base.sites);
+    // ... AND the freshly probed fn is folded into the services array.
+    expect(out.services.find((s) => s.name === FNS[0])).toEqual(svc);
+  });
+
+  test('a base payload with no sites does not add an empty array (backward compat)', () => {
+    // Older KV payloads written by the pre-site-probe worker have no
+    // sites field at all. Do not fabricate an empty array -- the
+    // frontend already handles undefined and shows the warm-up message.
+    const base = { services: [] };
+    const svc = { name: FNS[0], status: 'operational', http_status: 204, latency_ms: 42 };
+    const out = mergeService(base, svc);
+    expect('sites' in out).toBe(false);
+  });
 });
 
 describe('fetchGithubPagesCert', () => {

--- a/tests/statusSiteHealth.test.js
+++ b/tests/statusSiteHealth.test.js
@@ -1,0 +1,68 @@
+/**
+ * Source-scan tests for the "Site health" section on status.html. Motivated
+ * by the outage where GH Pages Let's Encrypt cert expired and Cloudflare
+ * responded 526 for 24+ hours before anyone noticed. The status page now
+ * has a dedicated section that reads payload.sites (populated by the
+ * pp-edge-status Cloudflare Worker) and renders one card per probed site.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const STATUS_HTML = fs.readFileSync(
+  path.join(__dirname, '..', 'status.html'),
+  'utf8',
+);
+const STATUS_MAIN = fs.readFileSync(
+  path.join(__dirname, '..', 'js', 'status', 'main.js'),
+  'utf8',
+);
+
+describe('status.html has a Site health section', () => {
+  test('section header and mount div land between vendor list and edge-fn list', () => {
+    const vendorIdx = STATUS_HTML.indexOf('status-vendor-list');
+    const siteIdx = STATUS_HTML.indexOf('status-site-list');
+    // Anchor on the H2 heading, not the raw phrase -- the meta
+    // description at the top of the page also contains "edge functions"
+    // and would give a false-early match.
+    const edgeIdx = STATUS_HTML.indexOf('<h2 class="status-section-heading">Supabase edge functions</h2>');
+    expect(vendorIdx).toBeGreaterThan(0);
+    expect(siteIdx).toBeGreaterThan(vendorIdx);
+    expect(edgeIdx).toBeGreaterThan(siteIdx);
+    expect(STATUS_HTML).toContain('<h2 class="status-section-heading">Site health</h2>');
+    expect(STATUS_HTML).toContain('<div id="status-site-list"');
+  });
+});
+
+describe('js/status/main.js renders site cards from payload.sites', () => {
+  test('renderFromPayload writes into the site list when payload.sites is present', () => {
+    // The block that populates the new section: read payload.sites, map
+    // to renderSiteCard, inject into #status-site-list.
+    expect(STATUS_MAIN).toContain("document.getElementById('status-site-list')");
+    expect(STATUS_MAIN).toMatch(
+      /const sites = Array\.isArray\(payload\.sites\) \? payload\.sites : \[\]/,
+    );
+    expect(STATUS_MAIN).toMatch(/sites\.map\(renderSiteCard\)\.join\(''\)/);
+  });
+
+  test('empty payload.sites falls back to a "not run yet" message', () => {
+    // Backward compatibility for a KV payload written by the pre-site-probe
+    // worker: the section stays informative rather than blank.
+    expect(STATUS_MAIN).toContain('Site probes have not run yet');
+  });
+
+  test('renderSiteCard shows the origin_hint below the primary meta row', () => {
+    // origin_hint is the fix-pointer for the operator (e.g. "GitHub Pages
+    // Let's Encrypt cert on the CNAME target"). Regression guard: a future
+    // refactor must not drop the hint.
+    expect(STATUS_MAIN).toContain('site.origin_hint');
+    expect(STATUS_MAIN).toContain('status-card--site');
+  });
+
+  test('siteReasonLabel spells out the Cloudflare 526 cert case', () => {
+    // The outage that motivated this section: 526 is Cloudflare's "origin
+    // SSL certificate invalid" code. The label must call it out by name so
+    // an operator glancing at the card knows exactly where to look.
+    expect(STATUS_MAIN).toMatch(/origin_ssl_cert_invalid[\s\S]{0,200}Cloudflare 526/);
+    expect(STATUS_MAIN).toMatch(/origin_ssl_handshake_failed[\s\S]{0,200}Cloudflare 525/);
+  });
+});

--- a/tests/statusSiteHealth.test.js
+++ b/tests/statusSiteHealth.test.js
@@ -65,4 +65,22 @@ describe('js/status/main.js renders site cards from payload.sites', () => {
     expect(STATUS_MAIN).toMatch(/origin_ssl_cert_invalid[\s\S]{0,200}Cloudflare 526/);
     expect(STATUS_MAIN).toMatch(/origin_ssl_handshake_failed[\s\S]{0,200}Cloudflare 525/);
   });
+
+  test('cert-expiring reason includes the days_remaining count + fix command', () => {
+    // Proactive: instead of "cert broke, everything's on fire", the
+    // 14-day-out warning must point the operator at the fix command
+    // BEFORE the outage happens.
+    expect(STATUS_MAIN).toMatch(/cert_expiring_[\s\S]{0,80}_days/);
+    expect(STATUS_MAIN).toContain('make renew-certificate');
+  });
+
+  test('renderSiteCard shows the cert expiry summary when payload.sites[i].cert is present', () => {
+    // "12 days remaining . expires 2026-08-01" style line under the
+    // primary meta row so an operator can eyeball how close to expiry
+    // the cert is without opening any dashboards.
+    expect(STATUS_MAIN).toContain('function certSummary(cert)');
+    expect(STATUS_MAIN).toContain('days remaining');
+    expect(STATUS_MAIN).toContain('cert.expires_at');
+    expect(STATUS_MAIN).toContain('certLine');
+  });
 });

--- a/workers/edge-status/index.js
+++ b/workers/edge-status/index.js
@@ -52,6 +52,27 @@ export const FNS = [
   'user-system-upload',
 ];
 
+// Public URLs the worker also probes so the status page catches origin-cert /
+// CDN issues (e.g. Cloudflare 526 "Invalid SSL Certificate") the same way it
+// catches edge-function outages. Each entry probes /version.json because it
+// is small, deployed on every build, and matches an existing per-site file
+// so the worker does not have to know the hosting layout. Add new sites here.
+export const SITES = [
+  {
+    name: 'prod (www.proton-pulse.com)',
+    url: 'https://www.proton-pulse.com/version.json',
+    // The origin cert path Cloudflare authorizes against. Displayed on the
+    // status card so a 526 links to a specific thing the operator can look
+    // up (GitHub Pages Let's Encrypt cert on the CNAME target).
+    origin_hint: 'GitHub Pages Let\'s Encrypt cert on the CNAME target',
+  },
+  {
+    name: 'staging (mdeguzis.github.io)',
+    url: 'https://mdeguzis.github.io/proton-pulse-web-staging/version.json',
+    origin_hint: 'GitHub Pages default certificate',
+  },
+];
+
 export const STATUS_KEY = 'edge-status';
 // Rolling per-function latency history for the status-page sparkline (7 days
 // at the 15-min cron cadence ~= 672 points; cap a bit above that for safety).
@@ -268,16 +289,78 @@ async function probeFunction(env, fn) {
   };
 }
 
+// Classify a public-site probe response into a status + human-readable
+// reason. Special-cases Cloudflare origin-cert errors (525/526) so a
+// broken cert stops looking like a generic 5xx and instead lands on the
+// specific fix ("origin lacks a valid TLS cert" -> renew Let's Encrypt).
+export function classifySiteStatus(httpCode) {
+  if (httpCode === 0) return { status: 'down', reason: 'unreachable' };
+  if (httpCode >= 200 && httpCode < 300) return { status: 'operational', reason: null };
+  // Cloudflare origin-side SSL errors. See https://developers.cloudflare.com/
+  // support/troubleshooting/http-status-codes/cloudflare-5xx-errors/
+  //   525 = SSL handshake with origin failed
+  //   526 = Cloudflare could not validate origin certificate
+  if (httpCode === 525) return { status: 'down', reason: 'origin_ssl_handshake_failed' };
+  if (httpCode === 526) return { status: 'down', reason: 'origin_ssl_cert_invalid' };
+  if (httpCode >= 500) return { status: 'down', reason: `http_${httpCode}` };
+  if (httpCode >= 400) return { status: 'degraded', reason: `http_${httpCode}` };
+  return { status: 'unknown', reason: `http_${httpCode}` };
+}
+
+// Probe one public site URL. Uses GET (not HEAD) because Cloudflare's cache
+// sometimes ignores HEAD, so a 526 stays hidden. Small resource + short
+// timeout keeps the sweep cheap.
+async function probeSite(site) {
+  const start = Date.now();
+  let httpCode = 0;
+  try {
+    const res = await fetch(site.url, {
+      method: 'GET',
+      // Bypass any intermediate cache so a stale 200 does not mask a live
+      // origin outage.
+      cache: 'no-store',
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    });
+    httpCode = res.status;
+  } catch (err) {
+    console.debug('[edge-status] site probe failed', { site: site.name, url: site.url, error: String(err && err.message || err) });
+    httpCode = 0;
+  }
+  const latencyMs = Date.now() - start;
+  const { status, reason } = classifySiteStatus(httpCode);
+  console.debug('[edge-status] site probed', { site: site.name, http_status: httpCode, status, reason });
+  return {
+    name: site.name,
+    url: site.url,
+    origin_hint: site.origin_hint,
+    status,
+    reason,
+    http_status: httpCode,
+    latency_ms: latencyMs,
+    checked_at: new Date().toISOString(),
+  };
+}
+
 // Run the full probe sweep and persist to KV. Returns the payload written.
 export async function runProbe(env) {
   const services = [];
   for (const fn of FNS) {
     services.push(await probeFunction(env, fn));
   }
+  const sites = [];
+  for (const site of SITES) {
+    sites.push(await probeSite(site));
+  }
   const payload = buildPayload(services);
+  // Site probes ride alongside Supabase-fn probes but do NOT roll into the
+  // overall "everything green" indicator today -- the wiki + prod deploy
+  // still recover cleanly even when Cloudflare is misconfigured, so having
+  // them mask a green sweep would over-page. Cards render their own state
+  // per-tile.
+  payload.sites = sites;
   await env.EDGE_STATUS_KV.put(STATUS_KEY, JSON.stringify(payload));
   await updateHistory(env, services);
-  console.info('[edge-status] sweep complete', { overall: payload.overall, count: services.length });
+  console.info('[edge-status] sweep complete', { overall: payload.overall, count: services.length, sites: sites.length });
   return payload;
 }
 

--- a/workers/edge-status/index.js
+++ b/workers/edge-status/index.js
@@ -65,13 +65,29 @@ export const SITES = [
     // status card so a 526 links to a specific thing the operator can look
     // up (GitHub Pages Let's Encrypt cert on the CNAME target).
     origin_hint: 'GitHub Pages Let\'s Encrypt cert on the CNAME target',
+    // Repo whose GitHub Pages cert covers this URL. Worker uses this to
+    // fetch https_certificate.expires_at from the GH API so the status
+    // card can go yellow 14 days before expiry instead of red on the
+    // day-of. Null for URLs that use a static / vendor-managed cert.
+    gh_pages_repo: 'mdeguzis/proton-pulse-web',
   },
   {
     name: 'staging (mdeguzis.github.io)',
     url: 'https://mdeguzis.github.io/proton-pulse-web-staging/version.json',
     origin_hint: 'GitHub Pages default certificate',
+    // Staging uses GitHub's *.github.io wildcard cert which GitHub itself
+    // rotates without our involvement -- nothing to check upstream.
+    gh_pages_repo: null,
   },
 ];
+
+// Cert-expiry thresholds. Yellow tile at <= EXPIRY_WARN_DAYS out, red tile
+// at <= EXPIRY_CRIT_DAYS out. Sized to give the ACME retry loop a comfortable
+// window: Let's Encrypt certs are 90 days, GH tries to renew ~30 days out,
+// 14 days is one week AFTER GH would normally try -- enough to be a real
+// signal something is broken (like a Cloudflare proxy eating the challenge).
+export const EXPIRY_WARN_DAYS = 14;
+export const EXPIRY_CRIT_DAYS = 3;
 
 export const STATUS_KEY = 'edge-status';
 // Rolling per-function latency history for the status-page sparkline (7 days
@@ -307,6 +323,76 @@ export function classifySiteStatus(httpCode) {
   return { status: 'unknown', reason: `http_${httpCode}` };
 }
 
+// Fetch the current https_certificate state for a GH Pages repo. Returns
+// { expires_at, days_remaining, state, description } or null if the repo
+// has no certificate metadata (e.g. HTTPS not enforced yet, or a wildcard
+// domain). Uses the public GITHUB_TOKEN env var if present -- unauthed
+// requests fall under a smaller rate limit but still work for the low
+// call volume this worker generates.
+export async function fetchGithubPagesCert(env, repo, nowMs = Date.now()) {
+  if (!repo) return null;
+  const headers = { 'Accept': 'application/vnd.github+json', 'User-Agent': 'pp-edge-status-worker' };
+  if (env && env.GITHUB_TOKEN) headers.Authorization = `Bearer ${env.GITHUB_TOKEN}`;
+  let json = null;
+  try {
+    const res = await fetch(`https://api.github.com/repos/${repo}/pages`, {
+      method: 'GET',
+      headers,
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      console.debug('[edge-status] GH pages fetch non-ok', { repo, status: res.status });
+      return null;
+    }
+    json = await res.json();
+  } catch (err) {
+    console.debug('[edge-status] GH pages fetch failed', { repo, error: String(err && err.message || err) });
+    return null;
+  }
+  const cert = json && json.https_certificate;
+  if (!cert) return null;
+  const expiresAt = cert.expires_at || null;
+  let daysRemaining = null;
+  if (expiresAt) {
+    const ms = new Date(expiresAt).getTime() - nowMs;
+    if (Number.isFinite(ms)) daysRemaining = Math.floor(ms / 86400000);
+  }
+  return {
+    expires_at: expiresAt,
+    days_remaining: daysRemaining,
+    state: cert.state || 'unknown',
+    description: cert.description || '',
+  };
+}
+
+// Blend the cert-expiry data into a site probe result. If the site itself
+// is already down, cert info is informational; if it is up but the cert
+// is within warn/crit windows, degrade / down the tile so the operator
+// notices weeks before it becomes a live outage. Pure so it is easy to
+// test.
+export function applyCertToSiteResult(siteResult, cert) {
+  if (!cert) return siteResult;
+  const merged = { ...siteResult, cert };
+  const days = cert.days_remaining;
+  const state = cert.state;
+  // ACME still in a broken state? Surface it explicitly so an operator
+  // sees the fix path even when the current cert has not expired yet.
+  if (state && state !== 'approved') {
+    merged.status = merged.status === 'down' ? merged.status : 'degraded';
+    merged.reason = merged.reason || `cert_state_${state}`;
+    return merged;
+  }
+  if (typeof days !== 'number') return merged;
+  if (days <= EXPIRY_CRIT_DAYS) {
+    merged.status = 'down';
+    merged.reason = merged.reason || `cert_expiring_${days}_days`;
+  } else if (days <= EXPIRY_WARN_DAYS) {
+    merged.status = merged.status === 'operational' ? 'degraded' : merged.status;
+    merged.reason = merged.reason || `cert_expiring_${days}_days`;
+  }
+  return merged;
+}
+
 // Probe one public site URL. Uses GET (not HEAD) because Cloudflare's cache
 // sometimes ignores HEAD, so a 526 stays hidden. Small resource + short
 // timeout keeps the sweep cheap.
@@ -349,7 +435,14 @@ export async function runProbe(env) {
   }
   const sites = [];
   for (const site of SITES) {
-    sites.push(await probeSite(site));
+    const result = await probeSite(site);
+    // Enrich the result with GH Pages cert-expiry info so the status
+    // card can go yellow 14 days before expiry instead of red on the
+    // day-of. Skipped for sites without a repo (e.g. static wildcard
+    // certs). GitHub API call is best-effort; on failure the tile
+    // reflects only the live probe result.
+    const cert = await fetchGithubPagesCert(env, site.gh_pages_repo).catch(() => null);
+    sites.push(applyCertToSiteResult(result, cert));
   }
   const payload = buildPayload(services);
   // Site probes ride alongside Supabase-fn probes but do NOT roll into the

--- a/workers/edge-status/index.js
+++ b/workers/edge-status/index.js
@@ -173,7 +173,16 @@ export function mergeService(payload, service) {
     .filter((s) => s.name !== service.name)
     .concat([service])
     .sort((a, b) => FNS.indexOf(a.name) - FNS.indexOf(b.name));
-  return buildPayload(services, { run_url: (payload && payload.run_url) || '' });
+  const rebuilt = buildPayload(services, { run_url: (payload && payload.run_url) || '' });
+  // Carry through the sites[] array from the prior payload. buildPayload only
+  // knows about services, but a super-admin "Check now" for a single fn must
+  // not wipe the last site-probe results (they run on the 15-min cron, not on
+  // every manual check). Without this the status page would show a "first-
+  // deploy cache warm-up" message until the next cron fired.
+  if (payload && Array.isArray(payload.sites)) {
+    rebuilt.sites = payload.sites;
+  }
+  return rebuilt;
 }
 
 // Verify a Supabase access token belongs to a super_admin. Two hops, both
@@ -375,6 +384,17 @@ export function applyCertToSiteResult(siteResult, cert) {
   const merged = { ...siteResult, cert };
   const days = cert.days_remaining;
   const state = cert.state;
+  // Critical expiry ALWAYS wins over cert state so a bad_authz-plus-
+  // days_remaining<=3 case still flips the tile red (down + the actionable
+  // cert_expiring_* reason). Otherwise a stuck ACME state below would
+  // short-circuit before we ever check the countdown -- exactly the
+  // combination that produced the July outage. Only takes effect when
+  // days_remaining is a real number; nulls fall through to the state check.
+  if (typeof days === 'number' && days <= EXPIRY_CRIT_DAYS) {
+    merged.status = 'down';
+    merged.reason = merged.reason || `cert_expiring_${days}_days`;
+    return merged;
+  }
   // ACME still in a broken state? Surface it explicitly so an operator
   // sees the fix path even when the current cert has not expired yet.
   if (state && state !== 'approved') {
@@ -383,10 +403,8 @@ export function applyCertToSiteResult(siteResult, cert) {
     return merged;
   }
   if (typeof days !== 'number') return merged;
-  if (days <= EXPIRY_CRIT_DAYS) {
-    merged.status = 'down';
-    merged.reason = merged.reason || `cert_expiring_${days}_days`;
-  } else if (days <= EXPIRY_WARN_DAYS) {
+  // Critical case handled above; this branch is the warn-window fall-through.
+  if (days <= EXPIRY_WARN_DAYS) {
     merged.status = merged.status === 'operational' ? 'degraded' : merged.status;
     merged.reason = merged.reason || `cert_expiring_${days}_days`;
   }


### PR DESCRIPTION
Two commits, one theme: catch the exact outage class that let the GH Pages Let's Encrypt cert quietly expire on 2026-07-18 -- Cloudflare's proxy ate the ACME HTTP-01 challenge for weeks and the status page had no signal for it. Now it does, in two forms.

## 1. feat(status): probe prod + staging site URLs and surface 526 as origin cert error (cc36d07)

The pp-edge-status Cloudflare Worker now probes \`https://www.proton-pulse.com/version.json\` + the staging equivalent every 15 min alongside the Supabase edge fns. Results ride in the same KV payload under a new \`sites[]\` field. \`classifySiteStatus\` special-cases Cloudflare's origin-side SSL codes so a broken cert stops looking like a generic 5xx:

- 525 -> \`origin_ssl_handshake_failed\` (SSL handshake with origin failed)
- 526 -> \`origin_ssl_cert_invalid\` (the outage that motivated this)
- 5xx -> \`http_<code>\`
- 4xx -> \`degraded / http_<code>\`
- 0 -> \`unreachable\`

status.html gets a new \"Site health\" section between vendor + edge-fn. Each card shows the state + latency + an \`origin_hint\` (\"GitHub Pages Let's Encrypt cert on the CNAME target\") so an operator immediately knows which upstream to look at. Empty payload.sites (older worker deploy) shows a friendly \"first-deploy cache warm-up\" message rather than blowing up.

Also added \`scripts/renew-github-pages-cert.sh\` + \`make renew-certificate\` target that walks the operator through the Cloudflare grey-cloud + poll-until-approved + enforce-HTTPS sequence. The Cloudflare side has to be done in the dashboard (no CF API token), but everything on the GitHub side is scripted.

## 2. feat(status): proactive cert-expiry check + days-remaining on site cards (23b4bb2)

Instead of only surfacing broken certs after they fail (yellow -> red as HTTP 526), the worker now polls GitHub Pages \`https_certificate.expires_at\` every 15 min. Behavior:

- <= 14 days remaining -> site tile goes YELLOW (\`degraded\`) with reason \`cert_expiring_N_days\`.
- <= 3 days remaining -> site tile goes RED (\`down\`).
- Any state != \`approved\` (e.g. bad_authz, which caused this outage) -> yellow at minimum, reason \`cert_state_<state>\`.

Sizing note: LE certs are 90 days, GH tries to renew ~30 days out, 14 days is one week AFTER GH would normally try -- a real signal something is broken (like the Cloudflare proxy eating the challenge), not a false alarm on the happy renew path.

Frontend shows a muted meta row like \"cert: 12 days remaining . expires 2026-08-01\" under the primary row on each site card. \`siteReasonLabel\` translates \`cert_expiring_N_days\` and \`cert_state_<state>\` into copy that names the fix command (\`make renew-certificate\`) so an operator does not have to hunt for it.

## Tests
2091 tests green locally. New coverage in \`tests/edgeStatusWorker.test.js\` (classifier + fetch helper with mocked global.fetch) and \`tests/statusSiteHealth.test.js\` (renders in the right place, calls out 525/526, shows cert summary).

## Deploy plumbing
The frontend part goes live when this PR merges + \`make gh-pages-only\` runs. The **worker itself needs a wrangler deploy** before the new \`payload.sites\` field is actually populated -- the frontend gracefully shows a \"first-deploy cache warm-up\" message until then. Run \`make deploy-worker\` from a laptop with wrangler working.

## Test plan
- [ ] Confirm CI green
- [ ] After merge + \`make gh-pages-only\`: visit https://www.proton-pulse.com/status.html and confirm the new \"Site health\" section renders (may say \"first-deploy cache warm-up\" until the worker is redeployed)
- [ ] After \`make deploy-worker\`: within 15 min, site cards should populate with the actual probe results + cert expiry
- [ ] Run \`make renew-certificate\` to unstick the current cert (it is what motivated all of this)