### PR TITLE
Promote staging -> main: non-destructive unpublish + two regression fixes

### DIFF
--- a/js/profile/api/configs.js
+++ b/js/profile/api/configs.js
@@ -107,12 +107,32 @@ export async function fetchReportHistory(reportId, session) {
 }
 
 export async function unpublishReport(session, publishedId) {
+  // #408: hide, never DELETE. Deleting was fine for plugin reports (their
+  // cloud-sync twin survives in user_proton_configs) but a web-submitted
+  // report has no twin -- Unpublish permanently destroyed it. is_hidden=true
+  // pulls the row from every public read via RLS ("public read non-hidden
+  // configs": only the owner still sees it) while keeping it recoverable.
   const url = `${SUPABASE_URL}/rest/v1/user_configs?id=eq.${encodeURIComponent(publishedId)}`;
   const r = await fetch(url, {
-    method: 'DELETE',
+    method: 'PATCH',
     headers: { ...supabaseHeaders(session), Prefer: 'return=minimal' },
+    body: JSON.stringify({ is_hidden: true }),
   });
   if (!r.ok) throw new Error(`Unpublish failed: HTTP ${r.status}`);
+}
+
+export async function republishReport(session, publishedId) {
+  // #408: inverse of unpublishReport for rows hidden by their owner. Note a
+  // moderator hide also uses is_hidden -- but those rows carry is_flagged,
+  // and the UI only offers Publish on unflagged rows, so an owner cannot
+  // un-hide a moderated report this way (and RLS admins can re-hide anyway).
+  const url = `${SUPABASE_URL}/rest/v1/user_configs?id=eq.${encodeURIComponent(publishedId)}`;
+  const r = await fetch(url, {
+    method: 'PATCH',
+    headers: { ...supabaseHeaders(session), Prefer: 'return=minimal' },
+    body: JSON.stringify({ is_hidden: false }),
+  });
+  if (!r.ok) throw new Error(`Publish failed: HTTP ${r.status}`);
 }
 
 export async function patchUserConfig(reportId, fields, session) {

--- a/js/profile/components/edit-modals.js
+++ b/js/profile/components/edit-modals.js
@@ -5,11 +5,11 @@ import {
   escapeHtml, formatSystemUpdated, enabledVarsToText, textToEnabledVars,
   parseUploadedSystem, isGenericSystemLabel, inferSystemLabel,
   validateSysinfoText, validateDeviceId,
-} from '../utils.js?v=78ac95ab';
+} from '../utils.js?v=320d6b78';
 import {
   fetchCloudConfig, patchCloudConfig, fetchFullUserConfig,
   fetchReportHistory, patchUserConfig,
-} from '../api/configs.js?v=0c5650ed';
+} from '../api/configs.js?v=2f08c67b';
 import { updateSystem } from '../api/systems.js?v=770d14b7';
 import { notesFormattingHelpHtml } from '../../shared/submit.js?v=49306cae';
 

--- a/js/profile/components/library.js
+++ b/js/profile/components/library.js
@@ -6,7 +6,7 @@
 // steam-type-cache.json so users can see what's actually in their
 // collection at a glance.
 import { SupaAuth } from '../config.js?v=87cd0f3d';
-import { formatSystemUpdated, escapeHtml } from '../utils.js?v=78ac95ab';
+import { formatSystemUpdated, escapeHtml } from '../utils.js?v=320d6b78';
 import { fetchMyLibraryRow, syncMyLibrary } from '../api/steam-library.js?v=d03f2631';
 import { fetchMyWishlistRow, syncMyWishlist } from '../api/steam-wishlist.js?v=989d8088';
 import { computeTypeBreakdown } from '../lib/steam-type-breakdown.js?v=c6959bfe';

--- a/js/profile/components/my-hardware.js
+++ b/js/profile/components/my-hardware.js
@@ -8,7 +8,7 @@ import {
   parseSteamSystemInfo, inferGpuVendor,
   getMyHwSourceMeta, setMyHwSourceMeta, getMyHwFieldOrigins,
   setMyHwFieldOrigins, setMyHwFieldOrigin,
-} from '../utils.js?v=78ac95ab';
+} from '../utils.js?v=320d6b78';
 
 /**
  * Initialise the My Hardware pane. Call once after DOM is ready.

--- a/js/profile/components/my-reports.js
+++ b/js/profile/components/my-reports.js
@@ -5,11 +5,11 @@ import {
   getProtonPulseUserIdFromSession, escapeHtml, formatSystemUpdated,
   getWebClientIdProfile, getMyReportBadges, flaggedMessageHtml,
   mergeMyReportRows,
-} from '../utils.js?v=78ac95ab';
+} from '../utils.js?v=320d6b78';
 import {
   fetchMyUserConfigs, fetchMyCloudConfigs, deleteMyReportsEverywhere,
-  unpublishReport,
-} from '../api/configs.js?v=0c5650ed';
+  unpublishReport, republishReport,
+} from '../api/configs.js?v=2f08c67b';
 import { dataUrl } from '../../lib/data-url.js?v=0de73aed';
 import { showEditCloudConfigModal, showEditReportModal } from './edit-modals.js?v=79558c3c';
 
@@ -105,15 +105,21 @@ export function initMyReports(ctx) {
             <p>${flaggedMessageHtml(row.flagged_reason)}</p>
           </details>`
         : '';
-      const isLive = row.published_id && !row.pending;
+      const isLive = row.published_id && !row.pending && !row.hidden;
       const actions = [
         isLive
           ? `<a class="profile-configs-view-link" href="${escapeHtml(viewHref)}">View</a>`
           : `<span class="profile-configs-view-link profile-configs-view-disabled" title="Not published yet">View</span>`,
-        row.cloud && row.unpublished
-          ? `<a class="profile-configs-action profile-configs-publish-btn" href="submit.html?app=${escapeHtml(String(row.app_id))}&fromCloud=1&return=profile.html%23section-my-reports">Publish</a>`
-          : '',
-        row.published_id
+        // #408: an owner-hidden report re-publishes in place (PATCH
+        // is_hidden=false) -- no round-trip through the submit form. Flagged
+        // rows are moderator-hidden; those go through edit-and-resubmit, so
+        // no republish button for them.
+        row.hidden && row.published_id && !row.flagged
+          ? `<button type="button" class="profile-configs-action profile-configs-publish-btn profile-configs-republish-btn" data-published-id="${escapeHtml(String(row.published_id))}">Publish</button>`
+          : row.cloud && row.unpublished
+            ? `<a class="profile-configs-action profile-configs-publish-btn" href="submit.html?app=${escapeHtml(String(row.app_id))}&fromCloud=1&return=profile.html%23section-my-reports">Publish</a>`
+            : '',
+        row.published_id && !row.hidden
           ? `<button type="button" class="profile-configs-action profile-configs-unpublish-btn" data-published-id="${escapeHtml(String(row.published_id))}">${row.pending ? 'Cancel' : 'Unpublish'}</button>`
           : '',
         row.published_id
@@ -247,10 +253,20 @@ export function initMyReports(ctx) {
         return;
       }
 
+      if (action.classList.contains('profile-configs-republish-btn')) {
+        const publishedId = action.dataset.publishedId;
+        if (!publishedId) return;
+        action.textContent = 'Publishing...';
+        await republishReport(s, publishedId);
+        showMyConfigsStatus('Published', true);
+        await refreshMyConfigs();
+        return;
+      }
+
       if (action.classList.contains('profile-configs-unpublish-btn')) {
         const publishedId = action.dataset.publishedId;
         if (!publishedId) return;
-        if (!window.confirm('Remove this report from the public game page? Your cloud config will be kept.')) return;
+        if (!window.confirm('Hide this report from the public game page? You can publish it again from here any time.')) return;
         action.textContent = 'Unpublishing...';
         await unpublishReport(s, publishedId);
         showMyConfigsStatus('Unpublished', true);

--- a/js/profile/components/systems.js
+++ b/js/profile/components/systems.js
@@ -6,7 +6,7 @@ import {
   getProtonPulseUserIdFromSession, parseSteamSystemInfo, inferGpuVendor,
   parseUploadedSystem, isGenericSystemLabel, inferSystemLabel,
   summarizeSystem, escapeHtml, formatSystemUpdated,
-} from '../utils.js?v=78ac95ab';
+} from '../utils.js?v=320d6b78';
 import {
   listUserSystems, setDefaultSystem, clearDefaultSystem,
   updateSystemLabel, deleteSystem,

--- a/js/profile/main.js
+++ b/js/profile/main.js
@@ -9,17 +9,17 @@ import {
   getProtonPulseUserIdFromSession, getShowUsername, setShowUsername,
   escapeHtml, formatSystemUpdated, getWebClientIdProfile,
   getPluginLinkCodeFromLocation, getSteamIdFromSession,
-} from './utils.js?v=78ac95ab';
+} from './utils.js?v=320d6b78';
 import {
   deleteAllMyData, fetchAllMyData, checkMyDataExists,
-} from './api/configs.js?v=0c5650ed';
+} from './api/configs.js?v=2f08c67b';
 import {
   listLinkedPlugins, completePluginLink, removePluginLink,
 } from './api/plugin-links.js?v=05003ae3';
 import { setShowAdult, pullShowAdult, readShowAdultLocal } from '../lib/user-prefs.js?v=5d9472de';
 import { initMyHardware } from './components/my-hardware.js?v=34fd810c';
 import { initSystems } from './components/systems.js?v=382fb770';
-import { initMyReports } from './components/my-reports.js?v=18b605b2';
+import { initMyReports } from './components/my-reports.js?v=9124ca19';
 import { initLibrary } from './components/library.js?v=fedd0b3a';
 
 (async function () {

--- a/js/profile/main.js
+++ b/js/profile/main.js
@@ -353,7 +353,11 @@ import { initLibrary } from './components/library.js?v=fedd0b3a';
       if (user) {
         showUser(user, session);
         void refreshLinkedPlugins();
-        void library.loadCached();
+        // #266 renamed loadCached to per-section loaders; this call site was
+        // missed and threw on every auth event, silently skipping the cached
+        // library/wishlist render on sign-in.
+        void library.loadLibraryCached?.();
+        void library.loadWishlistCached?.();
       } else {
         showSignedOut();
       }

--- a/js/profile/system-edit.js
+++ b/js/profile/system-edit.js
@@ -3,7 +3,7 @@ import {
   getProtonPulseUserIdFromSession, parseSteamSystemInfo, inferGpuVendor, inferCpuVendor,
   parseUploadedSystem, isGenericSystemLabel, inferSystemLabel, escapeHtml,
   validateSysinfoText, validateDeviceId,
-} from './utils.js?v=78ac95ab';
+} from './utils.js?v=320d6b78';
 import { supabaseHeaders } from './api/supabase.js?v=4889c5e6';
 import { supabaseUserSystemsUrl, listUserSystems, updateSystem } from './api/systems.js?v=770d14b7';
 

--- a/js/profile/utils.js
+++ b/js/profile/utils.js
@@ -565,6 +565,7 @@ export function mergeMyReportRows(publishedRows, cloudRows) {
         cloud: false,
         published: false,
         unpublished: false,
+        hidden: false,
         flagged: false,
         flagged_reason: null,
       });
@@ -576,7 +577,12 @@ export function mergeMyReportRows(publishedRows, cloudRows) {
     const mergedRow = ensureRow(row.app_id);
     mergedRow.title = row.title || mergedRow.title;
     mergedRow.rating = row.rating || mergedRow.rating;
-    mergedRow.published = true;
+    // #408: an is_hidden row is owner-unpublished (or moderator-hidden) --
+    // it exists but is not publicly visible, so it must NOT count as
+    // published or the row shows a green Published badge while the game
+    // page shows nothing.
+    mergedRow.hidden = mergedRow.hidden || Boolean(row.is_hidden);
+    mergedRow.published = mergedRow.published || !row.is_hidden;
     mergedRow.flagged = mergedRow.flagged || Boolean(row.is_flagged);
     mergedRow.flagged_reason = mergedRow.flagged_reason || row.flagged_reason || null;
     mergedRow.published_at = row.created_at || mergedRow.published_at;
@@ -601,7 +607,10 @@ export function mergeMyReportRows(publishedRows, cloudRows) {
 
   for (const row of merged.values()) {
     row.published = row.published || row.cloud_published;
-    row.unpublished = row.cloud && !row.cloud_published && !row.published;
+    // Unpublished = exists somewhere but is not publicly visible: either a
+    // cloud config never published, or (#408) a published row the owner hid.
+    row.unpublished = (row.cloud && !row.cloud_published && !row.published)
+      || (row.hidden && !row.published);
   }
 
   return Array.from(merged.values()).sort((a, b) => {

--- a/profile.html
+++ b/profile.html
@@ -371,6 +371,6 @@
 <script src="js/lib/analytics.js?v=4b6a7264"></script>
 <script src="js/lib/topbar.js?v=e200a908"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/profile/main.js?v=997804d8"></script>
+<script type="module" src="js/profile/main.js?v=512ce309"></script>
 </body>
 </html>

--- a/supabase/migrations/20260726020000_fix_history_snapshot_secdef_regression.sql
+++ b/supabase/migrations/20260726020000_fix_history_snapshot_secdef_regression.sql
@@ -1,0 +1,41 @@
+-- Fix: the 2026-07-07 migrations (add_fps_metrics, add_run_type) redefined
+-- snapshot_user_configs_before_update() to copy the new columns but dropped
+-- the SECURITY DEFINER + search_path hardening that 20260616000100 added.
+-- Regression symptom: any owner UPDATE on user_configs 403s, because the
+-- trigger's INSERT into user_configs_history runs as the calling role and
+-- that table's RLS only has a SELECT policy. This re-broke report edits and
+-- broke the new is_hidden unpublish flow (#408).
+--
+-- Same fix as 20260616000100, now with the full current column list. Rule
+-- for future column additions: keep SECURITY DEFINER + SET search_path = ''
+-- when redefining this function.
+CREATE OR REPLACE FUNCTION public.snapshot_user_configs_before_update()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path = ''
+AS $function$
+declare
+  table_size_mb float;
+begin
+  insert into public.user_configs_history
+    (config_id, app_id, rating, proton_version, os, notes, config_key,
+     fps_min, fps_avg, fps_max, run_type, recorded_at)
+  values
+    (old.id, old.app_id, old.rating, old.proton_version, old.os, old.notes, old.config_key,
+     old.fps_min, old.fps_avg, old.fps_max, old.run_type, now());
+
+  -- Prune oldest rows when table exceeds 50 MB
+  select pg_total_relation_size('public.user_configs_history') / 1048576.0 into table_size_mb;
+  if table_size_mb > 50 then
+    delete from public.user_configs_history
+    where id in (
+      select id from public.user_configs_history
+      order by recorded_at asc
+      limit 200
+    );
+  end if;
+
+  return new;
+end;
+$function$;

--- a/tests/profileUnpublish.test.js
+++ b/tests/profileUnpublish.test.js
@@ -60,7 +60,7 @@ function mockFetch(responses = []) {
 // ---------------------------------------------------------------------------
 
 describe('unpublishReport', () => {
-  test('sends DELETE to user_configs with correct id filter', async () => {
+  test('PATCHes is_hidden=true -- NEVER DELETE (#408: web reports have no cloud twin)', async () => {
     const fetch = mockFetch([{ url: 'user_configs', status: 204 }]);
     const ctx   = makeCtx(fetch);
     await vm.runInContext(`unpublishReport(${JSON.stringify(SESSION)}, ${PUBLISHED_ID})`, ctx);
@@ -68,7 +68,20 @@ describe('unpublishReport', () => {
     expect(fetch).toHaveBeenCalledTimes(1);
     const [url, opts] = fetch.mock.calls[0];
     expect(url).toMatch(`user_configs?id=eq.${PUBLISHED_ID}`);
-    expect(opts.method).toBe('DELETE');
+    expect(opts.method).toBe('PATCH');
+    expect(JSON.parse(opts.body)).toEqual({ is_hidden: true });
+  });
+
+  test('republishReport PATCHes is_hidden=false on the same row (#408)', async () => {
+    const fetch = mockFetch([{ url: 'user_configs', status: 204 }]);
+    const ctx   = makeCtx(fetch);
+    await vm.runInContext(`republishReport(${JSON.stringify(SESSION)}, ${PUBLISHED_ID})`, ctx);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetch.mock.calls[0];
+    expect(url).toMatch(`user_configs?id=eq.${PUBLISHED_ID}`);
+    expect(opts.method).toBe('PATCH');
+    expect(JSON.parse(opts.body)).toEqual({ is_hidden: false });
   });
 
   test('sends Prefer: return=minimal header', async () => {

--- a/tests/profileUtilsCoverage.test.js
+++ b/tests/profileUtilsCoverage.test.js
@@ -318,6 +318,27 @@ describe('mergeMyReportRows', () => {
       cloud: true, published: false, unpublished: true,
     }));
   });
+  test('owner-hidden web report stays in the list as unpublished (#408)', () => {
+    // Web reports have no cloud twin. When the owner unpublishes
+    // (is_hidden=true) the row must NOT vanish or read as Published.
+    const out = utils.mergeMyReportRows([
+      { id: 142, app_id: 'pgwiki:Riddick', title: 'Riddick', rating: 'platinum', is_hidden: true, created_at: '2026-07-25T00:00:00Z' },
+    ], []);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toEqual(expect.objectContaining({
+      hidden: true, published: false, unpublished: true, published_id: 142,
+    }));
+  });
+  test('hidden published row + published cloud twin still counts as published', () => {
+    // Plugin flow: cloud config is still is_published even if the web row
+    // was hidden -- published wins so the badge matches the game page.
+    const out = utils.mergeMyReportRows(
+      [{ id: 9, app_id: '730', title: 'CS2', is_hidden: true, created_at: '2026-06-01T00:00:00Z' }],
+      [{ app_id: 730, app_name: 'CS2', updated_at: '2026-06-02T00:00:00Z', is_published: true }],
+    );
+    expect(out[0].published).toBe(true);
+    expect(out[0].unpublished).toBe(false);
+  });
   test('sorted by updated_at descending', () => {
     const out = utils.mergeMyReportRows([
       { app_id: '1', title: 'A', updated_at: '2026-01-01T00:00:00Z' },


### PR DESCRIPTION
Three commits, verified end-to-end on staging (v1.13.0 - cd69931b6).

- fix(profile): unpublish hides the report instead of deleting it (#408). Unpublish is now PATCH is_hidden=true; web reports survive and can be republished in place from My Reports. The old DELETE path destroyed web-submitted reports permanently (no cloud twin). Prod still serves the destructive path until this merges.
- fix(profile): loadCached call site missed in the #266 library split. Every auth event on the profile page threw and skipped the cached library render.
- fix(db): restore SECURITY DEFINER on the history snapshot trigger. The July 7 fps/run_type migrations dropped it, so every owner UPDATE on user_configs 403ed since then (report edits included). Migration 20260726020000 is already applied to the live database; this commit records it in the repo.

Tests: unpublish suite now pins PATCH-and-never-DELETE plus republish; merge-logic tests cover hidden rows. 2,368 JS passing.