### PR TITLE
Fix stacked top-nav dropdowns when switching by hover

### DIFF
--- a/js/lib/topbar.js
+++ b/js/lib/topbar.js
@@ -794,16 +794,36 @@
 
   function wireDropdowns() {
     const dropdowns = document.querySelectorAll('.nav-dropdown');
+    function closeOtherDropdowns(active, fromPointer) {
+      dropdowns.forEach(function (other) {
+        if (other === active) return;
+        other.classList.remove('is-open');
+        const otherToggle = other.querySelector('.nav-dropdown-toggle');
+        if (otherToggle) {
+          otherToggle.setAttribute('aria-expanded', 'false');
+          // Hover should take over from click-pin state; blur focused sibling
+          // toggles so :focus-within does not keep stale panels visible.
+          if (fromPointer && other.contains(document.activeElement)) {
+            const active = document.activeElement;
+            if (active && typeof active.blur === 'function') active.blur();
+            else otherToggle.blur();
+          }
+        }
+      });
+    }
     dropdowns.forEach(function (dd) {
       const toggle = dd.querySelector('.nav-dropdown-toggle');
       if (!toggle) return;
+      dd.addEventListener('mouseenter', function () {
+        // If one dropdown was pinned open by click, hovering a sibling should
+        // clear that pin so only one panel can be visible at a time.
+        closeOtherDropdowns(dd, true);
+      });
       toggle.addEventListener('click', function (e) {
         e.preventDefault();
         const wasOpen = dd.classList.contains('is-open');
         // close any other open dropdown first
-        dropdowns.forEach(function (other) {
-          if (other !== dd) other.classList.remove('is-open');
-        });
+        closeOtherDropdowns(dd, false);
         dd.classList.toggle('is-open', !wasOpen);
         toggle.setAttribute('aria-expanded', String(!wasOpen));
       });

--- a/tests/topbarDropdownStacking.test.js
+++ b/tests/topbarDropdownStacking.test.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const path = require('path');
+
+const SRC = fs.readFileSync(
+  path.join(__dirname, '..', 'js', 'lib', 'topbar.js'),
+  'utf8',
+);
+
+describe('topbar desktop dropdown pin behavior', () => {
+  test('hovering a sibling dropdown clears pinned is-open state from others', () => {
+    expect(SRC).toMatch(
+      /function closeOtherDropdowns\(active,\s*fromPointer\)[\s\S]*?if \(other === active\) return;[\s\S]*?other\.classList\.remove\('is-open'\)/,
+    );
+    expect(SRC).toMatch(
+      /if \(fromPointer && other\.contains\(document\.activeElement\)\)[\s\S]*?const active = document\.activeElement;[\s\S]*?active && typeof active\.blur === 'function'[\s\S]*?active\.blur\(\)/,
+    );
+    expect(SRC).toMatch(
+      /dd\.addEventListener\('mouseenter',[\s\S]*?closeOtherDropdowns\(dd,\s*true\)/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary\n- fix desktop top-nav dropdown wiring so hovering a sibling clears any click-pinned sibling state\n- when clearing a sibling from pointer hover, blur active focused elements inside that sibling to prevent stale :focus-within from keeping it visible\n- add regression test coverage for the sibling-hover close behavior in wireDropdowns()\n\n## Testing\n- npm test -- tests/topbarDropdownStacking.test.js tests/topbarMobileNav.test.js\n\nCloses #439