### PR TITLE
Promote staging: confidence filter + coverage/data-index modernization + shared filter modal + card-size unification

### DIFF
--- a/.github/workflows/publish-shell.yml
+++ b/.github/workflows/publish-shell.yml
@@ -122,6 +122,24 @@ jobs:
               echo "skipping $f (absent on live site or HTML fallback)"
             fi
           done
+          # coverage.html + data-index.html are the two pipeline-rendered HTML
+          # pages linked from the Browse nav (#447). They obviously start with
+          # '<' so the JSON preservation loop above rejects them. Fetch each
+          # separately and keep only if the <title> is NOT the marketing
+          # homepage fallback, which is how CF Pages responds when the file
+          # is missing. Without this the nav items land on the SPA fallback
+          # instead of the real report.
+          HTML_FILES=(coverage.html data-index.html)
+          for f in "${HTML_FILES[@]}"; do
+            if curl -sfL --max-time 30 "$LIVE_BASE/$f" -o "/tmp/shell-out/$f" \
+               && [ -s "/tmp/shell-out/$f" ] \
+               && ! grep -q '<title>Proton Pulse | Smart Proton Launch Configurations' "/tmp/shell-out/$f"; then
+              echo "preserved $f from $LIVE_BASE"
+            else
+              rm -f "/tmp/shell-out/$f"
+              echo "skipping $f (absent on live site or SPA marketing fallback)"
+            fi
+          done
           # Plugin-repo-sourced files that the FULL pipeline curls from
           # decky-proton-pulse. They may be absent on a fresh staging site
           # that has never run a full pipeline. Fetch them as a fallback so

--- a/about.html
+++ b/about.html
@@ -440,7 +440,7 @@
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script type="module" src="js/lib/log-buffer.js?v=6d7ce577"></script>
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
-<script src="js/lib/topbar.js?v=8c197a9d"></script>
+<script src="js/lib/topbar.js?v=81be41f0"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/about/version.js?v=dd0d91d0"></script>
 <script src="js/about/jump-nav.js?v=ebc19086"></script>

--- a/admin.html
+++ b/admin.html
@@ -378,7 +378,7 @@
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script type="module" src="js/lib/log-buffer.js?v=6d7ce577"></script>
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
-<script src="js/lib/topbar.js?v=8c197a9d"></script>
+<script src="js/lib/topbar.js?v=81be41f0"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/admin/main.js?v=23a73442"></script>
 </body>

--- a/app.html
+++ b/app.html
@@ -16,11 +16,11 @@
 <link rel="stylesheet" href="css/shared/base.css?v=9e119a4e">
 <link rel="stylesheet" href="css/shared/topbar.css?v=e911094d">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
-<link rel="stylesheet" href="css/shared/filters.css?v=31464f82">
+<link rel="stylesheet" href="css/shared/filters.css?v=f7ac5796">
 <link rel="stylesheet" href="css/shared/cards.css?v=696d0204">
 <link rel="stylesheet" href="css/app/game-header.css?v=e93037b2">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=efaf20fe">
+<link rel="stylesheet" href="css/app/reports.css?v=58f2ef97">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">
 <link rel="stylesheet" href="css/app/home.css?v=7110134a">
 </head>

--- a/app.html
+++ b/app.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=9e119a4e">
 <link rel="stylesheet" href="css/shared/topbar.css?v=e911094d">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
-<link rel="stylesheet" href="css/shared/filters.css?v=2af967b6">
+<link rel="stylesheet" href="css/shared/filters.css?v=31464f82">
 <link rel="stylesheet" href="css/shared/cards.css?v=696d0204">
 <link rel="stylesheet" href="css/app/game-header.css?v=e93037b2">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">

--- a/app.html
+++ b/app.html
@@ -58,7 +58,7 @@
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script type="module" src="js/lib/log-buffer.js?v=6d7ce577"></script>
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
-<script src="js/lib/topbar.js?v=8c197a9d"></script>
+<script src="js/lib/topbar.js?v=81be41f0"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
 <!-- #153: markdown-it renders the Notes field on report cards. renderNotes

--- a/confidence.html
+++ b/confidence.html
@@ -204,7 +204,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=8c197a9d"></script>
+<script src="js/lib/topbar.js?v=81be41f0"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/confidence.html
+++ b/confidence.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=696d0204">
 <link rel="stylesheet" href="css/app/game-header.css?v=e93037b2">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=efaf20fe">
+<link rel="stylesheet" href="css/app/reports.css?v=58f2ef97">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">
 <link rel="stylesheet" href="css/app/home.css?v=7110134a">
 <style>

--- a/css/app/reports.css
+++ b/css/app/reports.css
@@ -129,61 +129,9 @@
   border-color: var(--accent);
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 22%, transparent);
 }
-.filter-panel-footer {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-top: 12px;
-  padding-top: 10px;
-  border-top: 1px solid var(--border);
-}
-/* Save filters and Clear filters share one pill shape: same size, text size,
-   and border thickness. Only the colors differ. */
-.filter-save-btn,
-.filter-clear-btn {
-  font-size: 0.72rem;
-  font-weight: 600;
-  font-family: inherit;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  padding: 6px 14px;
-  border-radius: 999px;
-  border-width: 1.5px;
-  border-style: solid;
-  cursor: pointer;
-  transition: color .1s, border-color .1s, background .1s;
-}
-/* Save + Clear are solid accent-filled pills so they read as normal action
-   buttons. Collapse stays orange as the standout; these two are the neutral
-   "do the thing" pair. */
-.filter-save-btn,
-.filter-clear-btn {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: #0a0c10;
-}
-.filter-save-btn:hover,
-.filter-clear-btn:hover { filter: brightness(1.08); }
-/* #415 slice 1: dirty state shows a bright accent fill (there is unsaved
-   change); clean state is a muted outline so a page whose filters already
-   match the persisted snapshot does not scream at the viewer. is-active
-   retained as an alias for the older solid-accent style. */
-.filter-save-btn.is-active,
-.filter-save-btn.is-dirty {
-  background: var(--accent-hi);
-  border-color: var(--accent-hi);
-  color: #0a0c10;
-}
-.filter-save-btn.is-clean {
-  background: transparent;
-  border-color: var(--border);
-  color: var(--muted);
-}
-.filter-save-btn.is-clean:hover {
-  color: var(--text);
-  border-color: var(--accent);
-  filter: none;
-}
+/* .filter-panel-footer / .filter-save-btn / .filter-clear-btn moved to
+   css/shared/filters.css (#458) so the coverage report inherits them
+   without pulling in the browse-specific rules below. */
 /* #415 slice 2: Apply-across-site checkbox lives inside the same footer as
    the Save + Clear buttons. Muted color so it does not compete with the
    action pair; label stays clickable across its whole surface. */
@@ -216,92 +164,17 @@
 .filter-persist:hover { color: var(--text); }
 .filter-persist input { accent-color: var(--accent); cursor: pointer; }
 
-/* Browse-page filter panel: lay the groups (Sort / Tier / Source) out side by
-   side so the popover is compact instead of one tall vertical column. Wraps to
-   a single column on narrow screens.
-   Drawer animation (#415 slice 2b): display MUST stay flex regardless of
-   .open. Toggling display:block <-> flex mid-transition caused a hard
-   reflow that flashed a stacked-block layout ("portrait mode") on the
-   way down. Content is clipped by max-height:0 + overflow:hidden while
-   closed, so the flex layout is invisible until the panel opens. */
-.filter-panel--stack {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  align-items: flex-start;
-  gap: 16px 24px;
-}
-/* Mobile modal treatment on --stack (from shared/filters.css) forces
-   display:block !important when .open. Match that in the closed state
-   too so the transition never sees a flex->block flip mid-collapse. */
+/* .filter-panel--stack layout + widening + .filter-collapse-btn / caret +
+   .filter-panel-footer--stack moved to css/shared/filters.css (#458). Mobile
+   footer flex-wrap for .filter-share-toggle stays here because share-toggle
+   is browse/game-page specific. */
 @media (max-width: 720px) {
-  .filter-panel--stack {
-    display: block;
-  }
-}
-.filter-panel--stack .filter-item { gap: 4px; min-width: 130px; }
-.filter-panel--stack .pg-filter-group { min-width: 120px; }
-.filter-panel-footer--stack {
-  flex-basis: 100%;
-  width: 100%;
-  margin-top: 2px;
-  padding-top: 12px;
-  border-top: 1px solid var(--border);
-  justify-content: flex-end;
-  gap: 8px;
-}
-/* Mobile footer: Collapse + Apply-across-site + Save + Clear all in one
-   row was too crowded on phones (label text overlapped the buttons).
-   Wrap the "Apply across the site" checkbox onto its own row above the
-   three buttons so each control has room to breathe. */
-@media (max-width: 720px) {
-  .filter-panel-footer,
-  .filter-panel-footer--stack {
-    flex-wrap: wrap;
-    row-gap: 10px;
-  }
   .filter-panel-footer .filter-share-toggle,
   .filter-panel-footer--stack .filter-share-toggle {
     flex-basis: 100%;
     order: -1;
     white-space: normal;
   }
-}
-/* Collapse button sits on the left of the footer while Save + Clear stay
-   on the right (justify-content:flex-end on the row + margin-right:auto on
-   the collapse pushes it to the opposite edge). Uses the same pill shape
-   as the other footer buttons so the row reads as three peer actions. */
-.filter-collapse-btn {
-  margin-right: auto;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 0.72rem;
-  font-weight: 600;
-  font-family: inherit;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  padding: 6px 14px;
-  border-radius: 999px;
-  /* Steam warm-orange fill so Collapse reads as the primary "shrink this
-     back down" action, distinct from Save and Clear which are neutral. */
-  border: 1.5px solid #d97706;
-  background: #d97706;
-  color: #0a0c10;
-  cursor: pointer;
-  transition: color .1s, border-color .1s, background .1s, filter .1s;
-}
-.filter-collapse-btn:hover {
-  filter: brightness(1.08);
-}
-.filter-collapse-caret {
-  font-size: 0.72rem;
-  line-height: 1;
-  display: inline-block;
-  transform: translateY(-1px);
-}
-@media (max-width: 560px) {
-  .filter-panel--stack.open { flex-direction: column; gap: 14px; }
 }
 .filter-panel--stack .home-filter-select {
   background: var(--bg);
@@ -375,64 +248,12 @@
   .filter-item--mobile-only { display: flex; flex-direction: column; gap: 4px; }
 }
 
-/* Desktop: the narrow row-wrap of groups made the variable-width pills wrap
-   raggedly. On wider screens lay the panel out as a single vertical column of
-   full-width groups, each group an even pill grid so they align in tidy
-   columns. Mobile keeps the compact stack from the max-width:560 rule above. */
-/* Desktop dropdown (>560px) has two regimes so a narrow desktop window does not
-   cram the groups into 2-3 thin masonry columns (#417 "stack when thin"):
-     - wide (>=900px): balanced masonry columns (CSS multi-column). The tall Tier
-       group no longer leaves empty pockets -- shorter groups pack in beside it.
-     - thin (561-899px): a single full-width column, one group per row.
-   Both keep their layout on the base .filter-panel--stack (NOT gated on .open)
-   so removing .open on close never snaps the layout mid-collapse -- that was the
-   #415 slice 2b "narrow vertical" flash, where the panel fell back to the base
-   display:flex shrink-to-fit (~459px) for the whole 360ms clip-path collapse. */
-@media (min-width: 900px) {
-  .filter-panel--stack {
-    display: block;
-    columns: 5 200px;
-    column-gap: 26px;
-    width: min(calc(100vw - 2 * var(--content-pad)), calc(var(--content-max) - 2 * var(--content-pad)));
-    min-width: 0;
-    max-width: none;
-  }
-  .filter-panel--stack .filter-item,
-  .filter-panel--stack .pg-filter-group { break-inside: avoid; }
-  .filter-panel--stack .filter-panel-footer--stack { column-span: all; break-inside: avoid; }
-}
-@media (min-width: 561px) and (max-width: 899px) {
-  .filter-panel--stack {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-    width: min(560px, calc(100vw - 2 * var(--content-pad)));
-    min-width: 0;
-    max-width: none;
-  }
-  .filter-panel--stack .filter-item,
-  .filter-panel--stack .pg-filter-group { width: 100%; }
-}
-/* Inner layout shared by both desktop regimes (>560px). */
+/* Desktop widening + squircle chips for .filter-panel--stack moved to
+   css/shared/filters.css (#458). Browse-only .home-filter-select sizing
+   inside the stack stays here since .home-filter-select is browse chrome. */
 @media (min-width: 561px) {
-  .filter-panel--stack .filter-item,
-  .filter-panel--stack .pg-filter-group { margin-bottom: 16px; min-width: 0; }
   .filter-panel--stack .home-filter-select { width: 100%; box-sizing: border-box; }
-  /* Pills wrap at their natural width so long labels ("Unsupported",
-     "Not Rated Yet") never clip. */
-  .filter-panel--stack .pg-filter-group {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    align-content: start;
-  }
-  .filter-panel--stack .pg-filter-group-label { flex-basis: 100%; }
-  .filter-panel--stack .filter-panel-footer--stack { margin: 4px 0 0; }
 }
-
-/* Squircle chips in the browse filter popover (picked over the pill shape).
-   Scoped to the filter panel so other pg-filter pills keep their look. */
-.filter-panel--stack .pg-filter { border-radius: 7px; }
 
 /* .filter-checks / .filter-check removed -- filter groups now use
    .pg-filter-group + .pg-filter pill buttons (css/shared/filters.css) */

--- a/css/shared/filters.css
+++ b/css/shared/filters.css
@@ -426,3 +426,42 @@
   background: rgba(10,12,16,0.22);
   color: #0a0c10;
 }
+
+/* ── Range slider pair ────────────────────────────────────────────────────
+   Two stacked native <input type="range"> controls for numeric min/max
+   filters. Introduced for the game-page confidence filter (#445). Reuses
+   the shared filter variables so light + dark themes stay in sync; native
+   thumbs pick up --accent via `accent-color`. */
+.filter-range {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 4px 0;
+}
+.filter-range-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.78rem;
+  color: var(--muted);
+}
+.filter-range-row-label {
+  min-width: 32px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--strong);
+}
+.filter-range-input {
+  flex: 1;
+  min-width: 0;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+.filter-range-value {
+  min-width: 44px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  color: var(--strong);
+  font-weight: 600;
+}

--- a/css/shared/filters.css
+++ b/css/shared/filters.css
@@ -427,6 +427,173 @@
   color: #0a0c10;
 }
 
+/* ── Shared modal footer + buttons (#458) ─────────────────────────────────
+   The .filter-panel-footer / .filter-panel--stack layout + the Collapse /
+   Save / Clear button styling used to live in css/app/reports.css. Both
+   browse + game pages loaded reports.css so they inherited these rules.
+   Coverage now uses the same modal chrome but must not pull in the
+   app-page CSS -- so the truly shared bits moved here. Browse-specific
+   selectors (.home-filter-select, .home-filter-text, .filter-item--
+   mobile-only) stay in reports.css. */
+.filter-panel-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+}
+.filter-save-btn,
+.filter-clear-btn {
+  font-size: 0.72rem;
+  font-weight: 600;
+  font-family: inherit;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 6px 14px;
+  border-radius: 999px;
+  border-width: 1.5px;
+  border-style: solid;
+  cursor: pointer;
+  transition: color .1s, border-color .1s, background .1s;
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #0a0c10;
+}
+.filter-save-btn:hover,
+.filter-clear-btn:hover { filter: brightness(1.08); }
+/* #415 slice 1: dirty state shows a bright accent fill (there is unsaved
+   change); clean state is a muted outline so a page whose filters already
+   match the persisted snapshot does not scream at the viewer. */
+.filter-save-btn.is-active,
+.filter-save-btn.is-dirty {
+  background: var(--accent-hi);
+  border-color: var(--accent-hi);
+  color: #0a0c10;
+}
+.filter-save-btn.is-clean {
+  background: transparent;
+  border-color: var(--border);
+  color: var(--muted);
+}
+.filter-save-btn.is-clean:hover {
+  color: var(--text);
+  border-color: var(--accent);
+  filter: none;
+}
+/* .filter-panel--stack drawer layout. Two regimes on desktop keep the pill
+   groups tidy at both narrow (single column) and wide (masonry) widths.
+   Content is clipped by the shared filter-panel opacity/clip-path when the
+   panel is closed; the layout stays put so a mid-collapse reflow does not
+   flash a stacked-block "portrait" flicker (#415 slice 2b). */
+.filter-panel--stack {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 16px 24px;
+}
+@media (max-width: 720px) {
+  .filter-panel--stack { display: block; }
+}
+.filter-panel--stack .filter-item { gap: 4px; min-width: 130px; }
+.filter-panel--stack .pg-filter-group { min-width: 120px; }
+.filter-panel-footer--stack {
+  flex-basis: 100%;
+  width: 100%;
+  margin-top: 2px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+  justify-content: flex-end;
+  gap: 8px;
+}
+@media (max-width: 720px) {
+  .filter-panel-footer,
+  .filter-panel-footer--stack {
+    flex-wrap: wrap;
+    row-gap: 10px;
+  }
+}
+/* Collapse button sits on the left of the footer while Save + Clear stay
+   on the right (justify-content:flex-end on the row + margin-right:auto on
+   the collapse pushes it to the opposite edge). Steam warm-orange fill so
+   Collapse reads as the primary "shrink this back down" action, distinct
+   from Save + Clear which are neutral accent-filled peers. */
+.filter-collapse-btn {
+  margin-right: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  font-family: inherit;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1.5px solid #d97706;
+  background: #d97706;
+  color: #0a0c10;
+  cursor: pointer;
+  transition: color .1s, border-color .1s, background .1s, filter .1s;
+}
+.filter-collapse-btn:hover { filter: brightness(1.08); }
+.filter-collapse-caret {
+  font-size: 0.72rem;
+  line-height: 1;
+  display: inline-block;
+  transform: translateY(-1px);
+}
+@media (max-width: 560px) {
+  .filter-panel--stack.open { flex-direction: column; gap: 14px; }
+}
+/* Desktop widening: >=900px lays the groups out as a balanced masonry
+   (CSS multi-column) so a wide monitor uses horizontal space instead of
+   scrolling a tall thin column. 561-899px is a single full-width column,
+   one group per row. Uses --content-pad + --content-max from base.css so
+   the panel width mirrors the page content width. */
+@media (min-width: 900px) {
+  .filter-panel--stack {
+    display: block;
+    columns: 5 200px;
+    column-gap: 26px;
+    width: min(calc(100vw - 2 * var(--content-pad)), calc(var(--content-max) - 2 * var(--content-pad)));
+    min-width: 0;
+    max-width: none;
+  }
+  .filter-panel--stack .filter-item,
+  .filter-panel--stack .pg-filter-group { break-inside: avoid; }
+  .filter-panel--stack .filter-panel-footer--stack { column-span: all; break-inside: avoid; }
+}
+@media (min-width: 561px) and (max-width: 899px) {
+  .filter-panel--stack {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    width: min(560px, calc(100vw - 2 * var(--content-pad)));
+    min-width: 0;
+    max-width: none;
+  }
+  .filter-panel--stack .filter-item,
+  .filter-panel--stack .pg-filter-group { width: 100%; }
+}
+@media (min-width: 561px) {
+  .filter-panel--stack .filter-item,
+  .filter-panel--stack .pg-filter-group { margin-bottom: 16px; min-width: 0; }
+  .filter-panel--stack .pg-filter-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-content: start;
+  }
+  .filter-panel--stack .pg-filter-group-label { flex-basis: 100%; }
+  .filter-panel--stack .filter-panel-footer--stack { margin: 4px 0 0; }
+}
+/* Squircle chips inside the .filter-panel--stack modal (browse pick over
+   the default pill shape). Scoped to the panel so other .pg-filter pills
+   elsewhere keep the pill look. */
+.filter-panel--stack .pg-filter { border-radius: 7px; }
+
 /* ── Range slider pair ────────────────────────────────────────────────────
    Two stacked native <input type="range"> controls for numeric min/max
    filters. Introduced for the game-page confidence filter (#445). Reuses

--- a/game-stats.html
+++ b/game-stats.html
@@ -699,7 +699,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=8c197a9d"></script>
+<script src="js/lib/topbar.js?v=81be41f0"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/game-stats.html
+++ b/game-stats.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/cards.css?v=696d0204">
 <link rel="stylesheet" href="css/app/game-header.css?v=e93037b2">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=efaf20fe">
+<link rel="stylesheet" href="css/app/reports.css?v=58f2ef97">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">
 <link rel="stylesheet" href="css/app/home.css?v=7110134a">
 <style>

--- a/gh-pages-manifest.txt
+++ b/gh-pages-manifest.txt
@@ -151,6 +151,7 @@ js/lib/data-url.js
 js/lib/cert.js
 js/lib/tile-pad.js
 js/lib/pagination-prefs.js
+js/lib/card-size.js
 js/lib/adult-filter.js
 js/lib/delisted-filter.js
 js/lib/user-prefs.js

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=9e119a4e">
 <link rel="stylesheet" href="css/shared/topbar.css?v=e911094d">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
-<link rel="stylesheet" href="css/shared/filters.css?v=2af967b6">
+<link rel="stylesheet" href="css/shared/filters.css?v=31464f82">
 <link rel="stylesheet" href="css/shared/cards.css?v=696d0204">
 <link rel="stylesheet" href="css/index/index.css?v=c710f2a7">
 </head>

--- a/index.html
+++ b/index.html
@@ -223,7 +223,7 @@
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script type="module" src="js/lib/log-buffer.js?v=6d7ce577"></script>
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
-<script src="js/lib/topbar.js?v=8c197a9d"></script>
+<script src="js/lib/topbar.js?v=81be41f0"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/index/main.js?v=64b17460"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=9e119a4e">
 <link rel="stylesheet" href="css/shared/topbar.css?v=e911094d">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
-<link rel="stylesheet" href="css/shared/filters.css?v=31464f82">
+<link rel="stylesheet" href="css/shared/filters.css?v=f7ac5796">
 <link rel="stylesheet" href="css/shared/cards.css?v=696d0204">
 <link rel="stylesheet" href="css/index/index.css?v=c710f2a7">
 </head>
@@ -225,6 +225,6 @@
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
 <script src="js/lib/topbar.js?v=8c197a9d"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/index/main.js?v=70566a62"></script>
+<script type="module" src="js/index/main.js?v=64b17460"></script>
 </body>
 </html>

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -2,7 +2,7 @@
 
 import { appIdToDir } from '../../lib/app-id.js?v=6159afa9';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=b4fbb7ef';
-import { populateScoringTooltip, pulseTierFromReports } from '../../shared/scoring.js?v=852c9d97';
+import { populateScoringTooltip, pulseTierFromReports, estimateScore } from '../../shared/scoring.js?v=852c9d97';
 import { computeCompatTrend, computeConfidence, RECENT_DAYS, PRIOR_WINDOW_DAYS } from '../../lib/scoring/gameStats.js?v=6a63af50';
 import { getWebClientId } from '../../shared/submit.js?v=ba876a15';
 import { fetchAppDepotInfo, fetchAppMetadata, fetchAppNews, fetchDeckStatusForApp, fetchMinRequirements, fetchLinuxNativeSupport } from '../api/deck-status.js?v=0bbdc652';
@@ -1150,7 +1150,13 @@ export async function renderGamePage(appId) {
     if (filterConfidenceMin > 0 || filterConfidenceMax < 100) {
       arr = arr.filter(r => {
         if (r._kind !== 'report') return false;
-        const s = Math.min(100, Math.max(0, Number(r.score) || 0));
+        // Match report-card.js's display formula (r.score || estimateScore(r))
+        // so the number that gates the row is the same number the card shows.
+        // Without the estimateScore fallback, ProtonDB-mirrored reports with
+        // no persisted score were dropped even when their displayed pill sat
+        // well inside the range. #461.
+        const raw = Number(r.score) || estimateScore(r);
+        const s = Math.min(100, Math.max(0, Number(raw) || 0));
         return s >= filterConfidenceMin && s <= filterConfidenceMax;
       });
     }

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -989,6 +989,11 @@ export async function renderGamePage(appId) {
   // Minimum reporter playtime in minutes (0 = any). Useful to skip "launched
   // it once" reports that don't reflect real-use compatibility
   let filterMinPlaytime = persistedFilters.minPlaytime || 0;
+  // Confidence range 0-100 (#445). Defaults 0/100 = no filter. When narrowed
+  // (min>0 or max<100) the filter step drops configs entirely, matching how
+  // filterRating drops non-report rows -- configs carry no score.
+  let filterConfidenceMin = Number.isFinite(persistedFilters.confidenceMin) ? persistedFilters.confidenceMin : 0;
+  let filterConfidenceMax = Number.isFinite(persistedFilters.confidenceMax) ? persistedFilters.confidenceMax : 100;
   let filterMine = false;
 
   // Unified source filter across configs + reports: 'pulse-config', 'pulse-report',
@@ -1012,6 +1017,7 @@ export async function renderGamePage(appId) {
       gpu: filterGpu, arch: filterArch, os: filterOs, rating: filterRating,
       runType: filterRunType, device: filterDevice,
       minPlaytime: filterMinPlaytime, source: filterSource,
+      confidenceMin: filterConfidenceMin, confidenceMax: filterConfidenceMax,
     };
   }
 
@@ -1031,8 +1037,14 @@ export async function renderGamePage(appId) {
     const persisted = _getPersistedSnapshot();
     const current = _filterSnapshot();
     if (!persisted) {
-      // No snapshot yet: dirty when any filter differs from the empty default
-      return Object.values(current).some(v => v && v !== 0);
+      // No snapshot yet: dirty when any filter differs from its default.
+      // confidenceMin defaults to 0 (clean) and confidenceMax defaults to 100
+      // (clean) -- treat those explicitly since 100 is truthy.
+      return Object.entries(current).some(([k, v]) => {
+        if (k === 'confidenceMin') return v !== 0;
+        if (k === 'confidenceMax') return v !== 100;
+        return v && v !== 0;
+      });
     }
     // Compare each field to the persisted equivalent, normalising arrays and
     // missing keys to '' so old + new formats match cleanly.
@@ -1133,6 +1145,13 @@ export async function renderGamePage(appId) {
         if (r.durationMinutes != null) return r.durationMinutes >= filterMinPlaytime;
         const m = DUR_MIN[r.duration];
         return m != null && m >= filterMinPlaytime;
+      });
+    }
+    if (filterConfidenceMin > 0 || filterConfidenceMax < 100) {
+      arr = arr.filter(r => {
+        if (r._kind !== 'report') return false;
+        const s = Math.min(100, Math.max(0, Number(r.score) || 0));
+        return s >= filterConfidenceMin && s <= filterConfidenceMax;
       });
     }
     // Rating filter only makes sense for reports. Configs don't carry a rating,
@@ -1493,8 +1512,25 @@ export async function renderGamePage(appId) {
                 <option value="600" ${filterMinPlaytime===600?'selected':''}>10h+</option>
               </select>
             </div>`;
+          const confidenceRange = `
+            <div class="filter-item">
+              <label class="home-filter-label">Confidence</label>
+              <div class="filter-range">
+                <div class="filter-range-row">
+                  <span class="filter-range-row-label">Min</span>
+                  <input id="fConfidenceMin" class="filter-range-input" type="range" min="0" max="100" step="1" value="${filterConfidenceMin}" aria-label="Minimum confidence percent">
+                  <span class="filter-range-value" id="fConfidenceMinValue">${filterConfidenceMin}%</span>
+                </div>
+                <div class="filter-range-row">
+                  <span class="filter-range-row-label">Max</span>
+                  <input id="fConfidenceMax" class="filter-range-input" type="range" min="0" max="100" step="1" value="${filterConfidenceMax}" aria-label="Maximum confidence percent">
+                  <span class="filter-range-value" id="fConfidenceMaxValue">${filterConfidenceMax}%</span>
+                </div>
+              </div>
+            </div>`;
 
-          const activeCount = [filterGpu, filterArch, filterOs, filterRating, filterRunType, filterSource, filterDevice, filterMinPlaytime > 0 ? '1' : ''].filter(Boolean).length;
+          const confRangeActive = filterConfidenceMin > 0 || filterConfidenceMax < 100;
+          const activeCount = [filterGpu, filterArch, filterOs, filterRating, filterRunType, filterSource, filterDevice, filterMinPlaytime > 0 ? '1' : '', confRangeActive ? '1' : ''].filter(Boolean).length;
           const anyActive = activeCount > 0;
 
           return `
@@ -1508,7 +1544,7 @@ export async function renderGamePage(appId) {
                 <span class="filter-panel-mobile-title">Filters</span>
                 <button type="button" class="filter-panel-close" aria-label="Close filters">&times;</button>
               </div>
-              ${srcSel}${gpuSel}${archSel}${osSel}${ratingSel}${runTypeSel}${deviceSel}${playtimeSel}
+              ${srcSel}${gpuSel}${archSel}${osSel}${ratingSel}${runTypeSel}${deviceSel}${playtimeSel}${confidenceRange}
               <div class="filter-panel-footer filter-panel-footer--stack">
                 <button class="filter-collapse-btn" id="gp-filter-collapse" type="button" aria-label="Collapse filters">
                   <span class="filter-collapse-caret" aria-hidden="true">&#x25B2;</span>
@@ -1669,8 +1705,12 @@ export async function renderGamePage(appId) {
     }
 
     function _debugSnapshot(label, extra) {
-      const active = { gpu: filterGpu, arch: filterArch, os: filterOs, rating: filterRating, runType: filterRunType, source: filterSource, device: filterDevice, minPlaytime: filterMinPlaytime };
-      const nonBlank = Object.fromEntries(Object.entries(active).filter(([, v]) => v !== '' && v !== 0));
+      const active = { gpu: filterGpu, arch: filterArch, os: filterOs, rating: filterRating, runType: filterRunType, source: filterSource, device: filterDevice, minPlaytime: filterMinPlaytime, confidenceMin: filterConfidenceMin, confidenceMax: filterConfidenceMax };
+      const nonBlank = Object.fromEntries(Object.entries(active).filter(([k, v]) => {
+        if (k === 'confidenceMin') return v !== 0;
+        if (k === 'confidenceMax') return v !== 100;
+        return v !== '' && v !== 0;
+      }));
       const parts = [label, `filters=${JSON.stringify(nonBlank)}`];
       if (extra) parts.push(extra);
       const line = parts.join(' · ');
@@ -1783,7 +1823,8 @@ export async function renderGamePage(appId) {
       // Filter chrome: active count on the toggle button + optional
       // "N of M shown" counter. Both live outside .cards so we update them
       // directly rather than re-rendering the reports-controls-row.
-      const activeCount = [filterGpu, filterArch, filterOs, filterRating, filterRunType, filterSource, filterDevice, filterMinPlaytime > 0 ? '1' : ''].filter(Boolean).length;
+      const _confRangeActive = filterConfidenceMin > 0 || filterConfidenceMax < 100;
+      const activeCount = [filterGpu, filterArch, filterOs, filterRating, filterRunType, filterSource, filterDevice, filterMinPlaytime > 0 ? '1' : '', _confRangeActive ? '1' : ''].filter(Boolean).length;
       const tb = document.getElementById('filterToggle');
       if (tb) {
         tb.classList.toggle('has-filters', activeCount > 0);
@@ -1866,6 +1907,8 @@ export async function renderGamePage(appId) {
       _syncSelect('fSource',   filterSource);
       _syncSelect('fDevice',   filterDevice);
       _syncSelect('fPlaytime', filterMinPlaytime || 0);
+      _syncSelect('fConfidenceMin', filterConfidenceMin);
+      _syncSelect('fConfidenceMax', filterConfidenceMax);
     }
 
     // Every change also writes into the module-level cache so navigating
@@ -1879,6 +1922,46 @@ export async function renderGamePage(appId) {
     el.querySelector('#fSource')?.addEventListener('change', e => { filterSource = e.target.value; _cacheField('source', filterSource); _debugSnapshot('change fSource -> ' + JSON.stringify(e.target.value)); _updateSaveButtonState(); refreshReports(); });
     el.querySelector('#fDevice')?.addEventListener('change', e => { filterDevice = e.target.value; _cacheField('device', filterDevice); _debugSnapshot('change fDevice -> ' + JSON.stringify(e.target.value)); _updateSaveButtonState(); refreshReports(); });
     el.querySelector('#fPlaytime')?.addEventListener('change', e => { filterMinPlaytime = parseInt(e.target.value, 10) || 0; _cacheField('minPlaytime', filterMinPlaytime); _debugSnapshot('change fPlaytime -> ' + JSON.stringify(e.target.value)); _updateSaveButtonState(); refreshReports(); });
+    // Confidence range sliders: use 'input' so dragging updates live, not just
+    // on release. Each slider enforces the invariant that min <= max by nudging
+    // the other slider when the user crosses over. Value labels update inline
+    // even mid-drag; refreshReports() re-runs the report list against the new
+    // bounds. #445.
+    const _clampConfidence = (v) => Math.max(0, Math.min(100, parseInt(v, 10) || 0));
+    el.querySelector('#fConfidenceMin')?.addEventListener('input', e => {
+      filterConfidenceMin = _clampConfidence(e.target.value);
+      if (filterConfidenceMin > filterConfidenceMax) {
+        filterConfidenceMax = filterConfidenceMin;
+        const maxEl = document.getElementById('fConfidenceMax');
+        if (maxEl) maxEl.value = String(filterConfidenceMax);
+        _cacheField('confidenceMax', filterConfidenceMax);
+      }
+      const minLbl = document.getElementById('fConfidenceMinValue');
+      if (minLbl) minLbl.textContent = filterConfidenceMin + '%';
+      const maxLbl = document.getElementById('fConfidenceMaxValue');
+      if (maxLbl) maxLbl.textContent = filterConfidenceMax + '%';
+      _cacheField('confidenceMin', filterConfidenceMin);
+      _debugSnapshot('input fConfidenceMin -> ' + filterConfidenceMin);
+      _updateSaveButtonState();
+      refreshReports();
+    });
+    el.querySelector('#fConfidenceMax')?.addEventListener('input', e => {
+      filterConfidenceMax = _clampConfidence(e.target.value);
+      if (filterConfidenceMax < filterConfidenceMin) {
+        filterConfidenceMin = filterConfidenceMax;
+        const minEl = document.getElementById('fConfidenceMin');
+        if (minEl) minEl.value = String(filterConfidenceMin);
+        _cacheField('confidenceMin', filterConfidenceMin);
+      }
+      const minLbl = document.getElementById('fConfidenceMinValue');
+      if (minLbl) minLbl.textContent = filterConfidenceMin + '%';
+      const maxLbl = document.getElementById('fConfidenceMaxValue');
+      if (maxLbl) maxLbl.textContent = filterConfidenceMax + '%';
+      _cacheField('confidenceMax', filterConfidenceMax);
+      _debugSnapshot('input fConfidenceMax -> ' + filterConfidenceMax);
+      _updateSaveButtonState();
+      refreshReports();
+    });
 
     // Collapse: close the modal so the user sees the filtered reports. Uses
     // panelEl() so it finds the panel whether it is still in el or portalled
@@ -1934,6 +2017,8 @@ export async function renderGamePage(appId) {
       filterSource = '';
       filterDevice = '';
       filterMinPlaytime = 0;
+      filterConfidenceMin = 0;
+      filterConfidenceMax = 100;
       // Also wipe the module-level session cache so navigating to another
       // game page picks up the clear state, not the pre-clear filter set.
       if (_ephemeralGameFilters) {
@@ -1945,6 +2030,8 @@ export async function renderGamePage(appId) {
         _ephemeralGameFilters.source = '';
         _ephemeralGameFilters.device = '';
         _ephemeralGameFilters.minPlaytime = 0;
+        _ephemeralGameFilters.confidenceMin = 0;
+        _ephemeralGameFilters.confidenceMax = 100;
       }
       for (const id of ['fGpu', 'fArch', 'fOs', 'fRating', 'fRunType', 'fSource', 'fDevice']) {
         const s = document.getElementById(id);
@@ -1952,6 +2039,14 @@ export async function renderGamePage(appId) {
       }
       const p = document.getElementById('fPlaytime');
       if (p) p.value = '0';
+      const cmin = document.getElementById('fConfidenceMin');
+      if (cmin) cmin.value = '0';
+      const cmax = document.getElementById('fConfidenceMax');
+      if (cmax) cmax.value = '100';
+      const cminLbl = document.getElementById('fConfidenceMinValue');
+      if (cminLbl) cminLbl.textContent = '0%';
+      const cmaxLbl = document.getElementById('fConfidenceMaxValue');
+      if (cmaxLbl) cmaxLbl.textContent = '100%';
       _updateSaveButtonState();
       refreshReports();
     });

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -21,6 +21,7 @@ import { loadDeckStatusMap } from '../api/deck-status.js?v=0bbdc652';
 import { readShowOwnerBadgesLocal, pullShowOwnerBadges } from '../../lib/user-prefs.js?v=09b673c8';
 import { pageNavHtml, wirePageNav } from '../lib/page-nav.js?v=2cdc55e4';
 import { synthesizeMyLibrary } from '../lib/my-library-synth.js?v=58a32db3';
+import { initCardSizeToggle, setCardSizeButtonsEnabled } from '../../lib/card-size.js?v=3402f405';
 
 // #323 followup helpers: every place that used to call
 // getMyLibraryAppIds / getMyWishlistAppIds directly now goes through these
@@ -1247,9 +1248,9 @@ export async function renderHomePage() {
     });
 
     // S/M/L only make sense for the card (grid) view; disable them in list mode.
+    // Delegates to the shared helper so home + index share one implementation.
     function _setSizeEnabled(enabled) {
-      document.querySelectorAll('.home-size-btn').forEach(b => { b.disabled = !enabled; });
-      document.getElementById('home-size-toggle')?.classList.toggle('home-size-toggle--disabled', !enabled);
+      setCardSizeButtonsEnabled(enabled, '.home-size-btn', 'home-size-toggle');
     }
 
     // Layout: 'list' (horizontal cards, default) or 'grid' (Steam-style
@@ -1284,36 +1285,15 @@ export async function renderHomePage() {
       });
     });
 
-    // Card size (S/M/L) is a saved user preference. Applies the cards--<size>
-    // class to both card lists; default medium.
-    const SIZE_KEY = 'pp:grid-size';
-    const SIZES = ['sm', 'md', 'lg', 'xl'];
-    // Desktop has the room for larger cards, so the default steps up to 'lg'
-    // there; mobile stays on 'md' to keep more rows on screen.
-    const _DEFAULT_SIZE = window.matchMedia('(min-width: 760px)').matches ? 'lg' : 'md';
-    function _savedSize() {
-      try { const s = localStorage.getItem(SIZE_KEY); return SIZES.includes(s) ? s : _DEFAULT_SIZE; } catch { return _DEFAULT_SIZE; }
-    }
-    function applyGridSize(size) {
-      ['cards-recent', 'cards-popular'].forEach(id => {
-        const el2 = document.getElementById(id);
-        if (el2) { SIZES.forEach(s => el2.classList.remove(`cards--${s}`)); el2.classList.add(`cards--${size}`); }
-      });
-      document.querySelectorAll('.home-size-btn').forEach(b => b.classList.toggle('active', b.dataset.size === size));
-      // The size class changes the column count, so re-render both grids to
-      // refill whole rows for the new width. Without this the last row goes
-      // ragged on a size change until the next full re-render.
-      applyRecentFilters();
-      applyPopularFilters();
-    }
-    document.querySelectorAll('.home-size-btn').forEach(btn => {
-      btn.addEventListener('click', () => {
-        const size = btn.dataset.size;
-        try { localStorage.setItem(SIZE_KEY, size); } catch { /* ignore */ }
-        applyGridSize(size);
-      });
+    // Card size (S/M/L/XL) via the shared card-size helper. Two containers
+    // (cards-recent + cards-popular) each get the cards--<size> class; on
+    // change the two card sections re-render so the last row refills to
+    // whole rows for the new column width. #459.
+    const applyGridSize = initCardSizeToggle({
+      containers: [document.getElementById('cards-recent'), document.getElementById('cards-popular')],
+      buttonSelector: '.home-size-btn',
+      onApply: () => { applyRecentFilters(); applyPopularFilters(); },
     });
-    applyGridSize(_savedSize());
     applyLayout(_savedLayout()); // restore saved list/grid before first render
 
     _restoreFilters(); // re-apply a saved filter set (if any) before first render

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=852c9d97';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=003f23c0';
-import { renderGamePage } from './game-page.js?v=aca7af03';
+import { renderGamePage } from './game-page.js?v=c08dc5e0';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId, fetchDataWithProdFallback } from '../config.js?v=a75604f5';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=4630c3d5';
 import { renderGameCard } from '../lib/card.js?v=db950b95';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=852c9d97';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=003f23c0';
-import { renderGamePage } from './game-page.js?v=69a7b46b';
+import { renderGamePage } from './game-page.js?v=aca7af03';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId, fetchDataWithProdFallback } from '../config.js?v=a75604f5';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=4630c3d5';
 import { renderGameCard } from '../lib/card.js?v=db950b95';

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,7 +1,7 @@
 // router (entry) for the app page. Relocated from app.js.
 
 import { pcgwSlugToPwId } from '../lib/app-id.js?v=6159afa9';
-import { renderGamePage } from './components/game-page.js?v=69a7b46b';
+import { renderGamePage } from './components/game-page.js?v=aca7af03';
 import { renderHomePage } from './components/home.js?v=dab92eb0';
 import { renderSearchPage } from './components/search.js?v=091f940b';
 

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,7 +1,7 @@
 // router (entry) for the app page. Relocated from app.js.
 
 import { pcgwSlugToPwId } from '../lib/app-id.js?v=6159afa9';
-import { renderGamePage } from './components/game-page.js?v=aca7af03';
+import { renderGamePage } from './components/game-page.js?v=c08dc5e0';
 import { renderHomePage } from './components/home.js?v=7b74784f';
 import { renderSearchPage } from './components/search.js?v=091f940b';
 

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -2,7 +2,7 @@
 
 import { pcgwSlugToPwId } from '../lib/app-id.js?v=6159afa9';
 import { renderGamePage } from './components/game-page.js?v=aca7af03';
-import { renderHomePage } from './components/home.js?v=dab92eb0';
+import { renderHomePage } from './components/home.js?v=7b74784f';
 import { renderSearchPage } from './components/search.js?v=091f940b';
 
 export function getRoute() {

--- a/js/index/main.js
+++ b/js/index/main.js
@@ -6,6 +6,7 @@ import { filterAdult } from '../lib/adult-filter.js?v=e4e9d845';
 import { filterDelisted } from '../lib/delisted-filter.js?v=42858e22';
 import { renderGameCard } from '../app/lib/card.js?v=db950b95';
 import { browseGames, getGamesByIds } from '../app/api/search-games.js?v=0e14d3ff';
+import { initCardSizeToggle, setCardSizeButtonsEnabled } from '../lib/card-size.js?v=3402f405';
 
 // Homepage-only logic. Universal nav chrome (banner, nav row, mobile drawer,
 // search dropdown, auth indicator) lives in topbar.js.
@@ -415,37 +416,20 @@ import { browseGames, getGamesByIds } from '../app/api/search-games.js?v=0e14d3f
       btn.addEventListener('click', () => toggleStore(btn.dataset.store));
     });
 
-    // S/M/L card size (saved preference, shared key with app page)
-    const SIZE_KEY = 'pp:grid-size';
-    const SIZES = ['sm', 'md', 'lg', 'xl'];
-    // Default 'lg' on desktop so wider viewports get roomier cards by default;
-    // mobile stays on 'md' to keep more rows on screen.
-    const DEFAULT_SIZE = window.matchMedia('(min-width: 760px)').matches ? 'lg' : 'md';
-    function savedSize() {
-      try { const s = localStorage.getItem(SIZE_KEY); return SIZES.includes(s) ? s : DEFAULT_SIZE; } catch { return DEFAULT_SIZE; }
-    }
-    function applySize(size) {
-      SIZES.forEach(s => list.classList.remove(`cards--${s}`));
-      list.classList.add(`cards--${size}`);
-      document.querySelectorAll('.pg-size-btn').forEach(b => b.classList.toggle('active', b.dataset.size === size));
-      // The size class changes the column count, so the previously rendered
-      // item count no longer fills whole rows -- the last row goes ragged and
-      // the grid only looked even because of the initial full-rows render.
-      // Refill to whole rows for the new width and re-render so S/M/L/XL each
-      // land an even 5 rows without needing a page refresh.
-      shownCount = pageSizeForFullRows(list, targetRowsForViewport());
-      renderPopular();
-    }
-    function setSizeEnabled(enabled) {
-      document.querySelectorAll('.pg-size-btn').forEach(b => { b.disabled = !enabled; });
-      document.getElementById('pg-size-toggle')?.classList.toggle('pg-size-toggle--disabled', !enabled);
-    }
-    document.querySelectorAll('.pg-size-btn').forEach(btn => {
-      btn.addEventListener('click', () => {
-        try { localStorage.setItem(SIZE_KEY, btn.dataset.size); } catch { /* ignore */ }
-        applySize(btn.dataset.size);
-      });
+    // S/M/L/XL card size (saved preference, shared key with app page) via the
+    // shared card-size helper. #459. The size class changes column count, so
+    // onApply refills the visible grid to whole rows for the new width.
+    const applySize = initCardSizeToggle({
+      containers: [list],
+      buttonSelector: '.pg-size-btn',
+      onApply: () => {
+        shownCount = pageSizeForFullRows(list, targetRowsForViewport());
+        renderPopular();
+      },
     });
+    function setSizeEnabled(enabled) {
+      setCardSizeButtonsEnabled(enabled, '.pg-size-btn', 'pg-size-toggle');
+    }
 
     // Layout: 'list' (horizontal cards, the new default) or 'grid'
     // (Steam-style vertical tile grid). Both layouts use the same card
@@ -476,7 +460,7 @@ import { browseGames, getGamesByIds } from '../app/api/search-games.js?v=0e14d3f
     });
 
     updateRatingCounts(); // seed the rating chip counts for the default (Steam)
-    applySize(savedSize());
+    // initCardSizeToggle already applied the saved size on mount above.
     applyLayout(savedLayout());
   } catch (err) {
     console.debug('[popular-games] failed to load most_played.json', { error: String(err) });

--- a/js/lib/card-size.js
+++ b/js/lib/card-size.js
@@ -1,0 +1,85 @@
+// Shared S/M/L/XL card-size toggle used by the home landing (js/index/main.js)
+// and the app browse page (js/app/components/home.js). Both pages previously
+// carried near-identical duplicate implementations -- one XL parity fix had
+// to be applied twice. #459 folds the shared bits here so the two pages
+// consume the same constants + apply pipeline, and only the button selector
+// / container elements differ per page.
+
+export const CARD_SIZES = ['sm', 'md', 'lg', 'xl'];
+export const CARD_SIZE_KEY = 'pp:grid-size';
+
+// Desktop has the room for larger cards, so the default steps up to 'lg'
+// there; mobile stays on 'md' to keep more rows on screen. matchMedia is
+// guarded so this module is safe to import in a jsdom test environment.
+export function defaultCardSize() {
+  try {
+    if (typeof window !== 'undefined' && window.matchMedia) {
+      return window.matchMedia('(min-width: 760px)').matches ? 'lg' : 'md';
+    }
+  } catch { /* no-op */ }
+  return 'md';
+}
+
+export function savedCardSize() {
+  try {
+    const s = localStorage.getItem(CARD_SIZE_KEY);
+    return CARD_SIZES.includes(s) ? s : defaultCardSize();
+  } catch {
+    return defaultCardSize();
+  }
+}
+
+export function saveCardSize(size) {
+  try { localStorage.setItem(CARD_SIZE_KEY, size); } catch { /* ignore */ }
+}
+
+// Swap the cards--<size> class on every provided container. Null entries in
+// the list are skipped so callers can pass getElementById results directly
+// without null-checking each one.
+export function applyCardSize(size, containers) {
+  for (const el of containers) {
+    if (!el) continue;
+    for (const s of CARD_SIZES) el.classList.remove(`cards--${s}`);
+    el.classList.add(`cards--${size}`);
+  }
+}
+
+// Reflect the current size on the button row (adds `active` to the matching
+// data-size button, removes from the others). Caller supplies the selector
+// so home (.home-size-btn) and index (.pg-size-btn) stay independent.
+export function syncCardSizeButtons(size, buttonSelector) {
+  document.querySelectorAll(buttonSelector).forEach(b =>
+    b.classList.toggle('active', b.dataset.size === size));
+}
+
+// Enable / disable the button row. `toggleId` is the id of the wrapping
+// container; the corresponding `${toggleId}--disabled` modifier is toggled
+// so page CSS can style the disabled state (dim, un-hover, etc.).
+export function setCardSizeButtonsEnabled(enabled, buttonSelector, toggleId) {
+  document.querySelectorAll(buttonSelector).forEach(b => { b.disabled = !enabled; });
+  if (toggleId) {
+    document.getElementById(toggleId)?.classList.toggle(`${toggleId}--disabled`, !enabled);
+  }
+}
+
+// One-liner init: wires click handlers, applies the saved size on mount,
+// returns the apply function so the caller can trigger it after a layout
+// change. onApply fires after the class + button sync so callers can
+// re-render their grids to refill rows for the new column width.
+export function initCardSizeToggle({ containers, buttonSelector, onApply }) {
+  const apply = (size) => {
+    applyCardSize(size, containers);
+    syncCardSizeButtons(size, buttonSelector);
+    if (typeof onApply === 'function') onApply(size);
+  };
+  document.querySelectorAll(buttonSelector).forEach(btn => {
+    btn.addEventListener('click', () => {
+      const size = btn.dataset.size;
+      if (!CARD_SIZES.includes(size)) return;
+      saveCardSize(size);
+      apply(size);
+    });
+  });
+  apply(savedCardSize());
+  return apply;
+}

--- a/js/lib/topbar.js
+++ b/js/lib/topbar.js
@@ -968,11 +968,21 @@
     });
     // Accordion parents (Browse / Resources): toggle their sub-list open;
     // clicking a parent must NOT close the whole drawer, so it's handled
-    // before the link handler below and stops there.
+    // before the link handler below and stops there. Opening a group
+    // auto-closes any other expanded group (#460) so two accordions can
+    // never both push their items down the drawer at once.
     drawer.querySelectorAll('.mnav-parent').forEach(function (btn) {
       btn.addEventListener('click', function () {
         const group = btn.closest('.mnav-group');
         const expanded = btn.getAttribute('aria-expanded') === 'true';
+        if (!expanded) {
+          drawer.querySelectorAll('.mnav-group.mnav-open').forEach(function (openGroup) {
+            if (openGroup === group) return;
+            openGroup.classList.remove('mnav-open');
+            const openBtn = openGroup.querySelector('.mnav-parent');
+            if (openBtn) openBtn.setAttribute('aria-expanded', 'false');
+          });
+        }
         btn.setAttribute('aria-expanded', expanded ? 'false' : 'true');
         if (group) group.classList.toggle('mnav-open', !expanded);
       });

--- a/lookup.html
+++ b/lookup.html
@@ -122,7 +122,7 @@
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script type="module" src="js/lib/log-buffer.js?v=6d7ce577"></script>
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
-<script src="js/lib/topbar.js?v=8c197a9d"></script>
+<script src="js/lib/topbar.js?v=81be41f0"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/lookup/main.js?v=8d9f5128"></script>
 </body>

--- a/options.html
+++ b/options.html
@@ -328,7 +328,7 @@
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script type="module" src="js/lib/log-buffer.js?v=6d7ce577"></script>
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
-<script src="js/lib/topbar.js?v=8c197a9d"></script>
+<script src="js/lib/topbar.js?v=81be41f0"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/options/main.js?v=67ecae23"></script>
 </body>

--- a/privacy.html
+++ b/privacy.html
@@ -197,7 +197,7 @@
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script type="module" src="js/lib/log-buffer.js?v=6d7ce577"></script>
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
-<script src="js/lib/topbar.js?v=8c197a9d"></script>
+<script src="js/lib/topbar.js?v=81be41f0"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -381,7 +381,7 @@
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script type="module" src="js/lib/log-buffer.js?v=6d7ce577"></script>
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
-<script src="js/lib/topbar.js?v=8c197a9d"></script>
+<script src="js/lib/topbar.js?v=81be41f0"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/profile/main.js?v=512ce309"></script>
 </body>

--- a/scoring.html
+++ b/scoring.html
@@ -495,7 +495,7 @@ h2 small {
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script type="module" src="js/lib/log-buffer.js?v=6d7ce577"></script>
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
-<script src="js/lib/topbar.js?v=8c197a9d"></script>
+<script src="js/lib/topbar.js?v=81be41f0"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/scripts/pipeline/finalize.py
+++ b/scripts/pipeline/finalize.py
@@ -66,6 +66,91 @@ from .stats import write_stats_json
 from .validate_app_ids import validate_steam_app_ids
 
 
+# CSS + JS the pipeline-generated top-level pages (data-index.html,
+# coverage.html) share with the rest of the site. Historically these pages
+# linked bare "site.css" + "topbar.js" at the repo root, which worked before
+# the CSS/JS reorg into css/shared/ + js/lib/. Post-reorg the requests 404
+# and CF Pages serves the SPA fallback -- pages render unstyled with no
+# topbar (#448). Keep this list in the same order as about.html so the
+# cascade matches every other page.
+_SHARED_CSS = (
+    "css/shared/base.css",
+    "css/shared/topbar.css",
+    "css/shared/site.css",
+    "css/shared/cards.css",
+)
+# Trailing scripts: topbar.js needs the ring buffer + analytics loaded first,
+# and the supabase client is a hard dep of the topbar user chip. Mirrors the
+# tail of about.html. No ?v= cache-bust suffix -- these pages are pipeline-
+# regenerated on every finalize, so a fresh file goes out the moment content
+# changes; source pages keep their cache-bust for editor-time churn.
+_SHARED_SCRIPTS = (
+    ('<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/'
+     'dist/umd/supabase.min.js"></script>'),
+    '<script src="js/lib/supabase-client.js"></script>',
+    '<script type="module" src="js/lib/log-buffer.js"></script>',
+    '<script src="js/lib/analytics.js"></script>',
+    '<script src="js/lib/topbar.js"></script>',
+    '<script src="js/lib/toast.js"></script>',
+)
+# Same Content-Security-Policy the shipped HTML files declare. Pipeline pages
+# are same-origin and pull the same third-party CDN (Supabase) plus the same
+# image + connect origins, so they must inherit the same CSP or the browser
+# blocks their scripts.
+_SHARED_CSP = (
+    "default-src 'self'; "
+    "script-src 'self' https://static.cloudflareinsights.com 'unsafe-inline' "
+    "https://cdn.jsdelivr.net; "
+    "style-src 'self' 'unsafe-inline'; "
+    "img-src 'self' https://*.steamstatic.com https://avatars.steamstatic.com "
+    "https://cdn.cloudflare.steamstatic.com https://media.steampowered.com "
+    "https://*.gog.com https://*.gog-statics.com https://cdn.steamgriddb.com "
+    "https://cdn2.steamgriddb.com https://www.steamgriddb.com "
+    "https://images.pcgamingwiki.com https://cdn1.epicgames.com "
+    "https://cdn2.unrealengine.com data:; "
+    "connect-src 'self' https://cloudflareinsights.com "
+    "https://data.proton-pulse.com https://staging-data.proton-pulse.com "
+    "https://ilsgdshkaocrmibwdezk.supabase.co "
+    "https://pp-edge-status.mdeguzis.workers.dev; "
+    "font-src 'self'; frame-src 'none'; object-src 'none';"
+)
+
+
+def _pipeline_page_head(title: str, extra_style: str = "") -> list[str]:
+    """Return the standard <head> block for a pipeline-generated top-level HTML page.
+
+    Emits the same CSP + shared CSS + meta tags as about.html so the pages
+    inherit the site theme and security posture. extra_style is inlined into
+    the head so page-specific rules (table layouts, filter chrome) can live
+    next to the standard shell.
+    """
+    lines = [
+        "<!DOCTYPE html>",
+        '<html lang="en">',
+        "<head>",
+        '<meta charset="utf-8">',
+        f'<meta http-equiv="Content-Security-Policy" content="{_SHARED_CSP}">',
+        '<meta name="viewport" content="width=device-width, initial-scale=1">',
+        '<meta name="color-scheme" content="dark">',
+        f"<title>{title}</title>",
+    ]
+    for href in _SHARED_CSS:
+        lines.append(f'<link rel="stylesheet" href="{href}">')
+    if extra_style:
+        lines.append(f"<style>{extra_style}</style>")
+    lines.append("</head>")
+    return lines
+
+
+def _pipeline_page_scripts() -> list[str]:
+    """Return the trailing shared script tags for a pipeline-generated page.
+
+    Placed just before </body> so the topbar script fires after the DOM the
+    rest of the page has emitted -- same ordering as about.html.
+    """
+    return list(_SHARED_SCRIPTS)
+
+
 def log_summary(
     parsed_count: int,
     data_output_path: Path,
@@ -325,20 +410,8 @@ def generate_index_html(index_keys: set, output_path: Path) -> None:
     .json-pane .tok-nl { color: var(--muted); }
 """
 
-    lines = [
-        "<!DOCTYPE html>",
-        '<html lang="en">',
-        "<head>",
-        '  <meta charset="utf-8">',
-        '  <meta name="viewport" content="width=device-width, initial-scale=1">',
-        '  <meta name="color-scheme" content="dark">',
-        "  <title>Data Index - Proton Pulse</title>",
-        '  <link rel="stylesheet" href="site.css">',
-        f'  <style>{page_style}</style>',
-        "</head>",
+    lines = _pipeline_page_head("Data Index - Proton Pulse", extra_style=page_style) + [
         "<body>",
-        # topbar.js injects the shared banner + nav at body start
-        '<script src="topbar.js"></script>',
         '<div class="main-content"><div class="main-inner">',
 
         # ── grid view ──
@@ -599,11 +672,9 @@ def generate_index_html(index_keys: set, output_path: Path) -> None:
   routeFromHash();
 })();
 </script>""",
-        '<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>',
-        '<script src="supabase-client.js"></script>',
-        "</body>",
-        "</html>",
     ]
+    lines += _pipeline_page_scripts()
+    lines += ["</body>", "</html>"]
 
     index_file = output_path / "data-index.html"
     index_file.write_text("\n".join(lines) + "\n")
@@ -1478,50 +1549,42 @@ def generate_coverage_report(
             f'{1 if steam_catalog_hit else 0},"{" ".join(flags)}",{1 if indexed else 0}]'
         )
 
-    html = f"""<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Coverage Report - Proton Pulse</title>
-<meta name="color-scheme" content="dark">
-<link rel="stylesheet" href="site.css">
-<style>
+    coverage_style = """
 /* coverage page only - table + stats layout that lives below the shared topbar */
-table {{ border-collapse: collapse; width: 100%; }}
-th, td {{ border: 1px solid var(--border); padding: 6px 10px; text-align: left; }}
-th {{ background: var(--s2); color: var(--text); cursor: pointer; user-select: none; position: relative; padding-right: 22px; transition: background .12s, color .12s; }}
-th:hover {{ background: var(--s3); color: var(--accent-hi); }}
-th::after {{ content: '\\2195'; position: absolute; right: 6px; top: 50%; transform: translateY(-50%); color: var(--muted); font-size: 0.85em; opacity: 0.4; }}
-th.sort-asc::after {{ content: '\\25B2'; color: var(--accent); opacity: 1; }}
-th.sort-desc::after {{ content: '\\25BC'; color: var(--accent); opacity: 1; }}
-tr:nth-child(even) {{ background: var(--s1); }}
-tr:nth-child(odd) {{ background: rgba(0,0,0,0.1); }}
-.yes {{ color: var(--green-hi); font-weight: bold; }}
-.no {{ color: var(--muted); }}
-.stats {{ display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 14px; margin-bottom: 1.5em; }}
-@media (max-width: 1100px) {{ .stats {{ grid-template-columns: repeat(2, minmax(0, 1fr)); }} }}
-@media (max-width: 640px) {{ .stats {{ grid-template-columns: 1fr; }} }}
-.stat-card {{ background: linear-gradient(180deg, rgba(27,40,56,0.55), rgba(11,17,22,0.45)); border: 1px solid var(--border); padding: 14px 18px; clip-path: polygon(0 0, 100% 0, 100% calc(100% - 10px), calc(100% - 10px) 100%, 0 100%); }}
-.stat-card .label {{ font-family: var(--mono); font-size: 0.72rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.14em; }}
-.stat-card .value {{ font-family: var(--mono); font-size: 1.7rem; font-weight: 600; color: var(--accent-hi); margin: 4px 0; text-shadow: 0 0 14px var(--accent-glow); }}
-.stat-card .detail {{ font-size: 0.78rem; color: var(--muted); }}
-.pct {{ color: var(--green-hi); }}
-.filters {{ margin-bottom: 1em; display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }}
-#filter {{ padding: 8px 10px; width: 320px; background: rgba(11,17,22,0.6); color: var(--text); border: 1px solid var(--border2); }}
-#filter:focus {{ border-color: var(--accent); outline: none; box-shadow: 0 0 0 3px var(--accent-soft); }}
-.toggle {{ padding: 6px 14px; border: 1px solid var(--border2); background: transparent; color: var(--muted); cursor: pointer; font-weight: 600; text-transform: uppercase; font-size: 0.78rem; letter-spacing: 0.04em; transition: color .12s, border-color .12s, background .12s; }}
-.toggle:hover {{ color: var(--text); border-color: var(--accent); }}
-.toggle.active {{ background: var(--accent-soft); color: var(--accent-hi); border-color: var(--accent); }}
-.pager {{ margin: 1em 0; display: flex; gap: 8px; align-items: center; }}
-.pager button {{ padding: 6px 14px; background: rgba(11,17,22,0.6); color: var(--text); border: 1px solid var(--border2); cursor: pointer; font-family: inherit; font-size: 0.82rem; }}
-.pager button:hover {{ background: var(--s2); border-color: var(--accent); }}
-.coverage-meta {{ color: var(--muted); margin-bottom: 1em; font-family: var(--mono); font-size: 0.8rem; letter-spacing: 0.04em; }}
-</style>
-</head>
+table { border-collapse: collapse; width: 100%; }
+th, td { border: 1px solid var(--border); padding: 6px 10px; text-align: left; }
+th { background: var(--s2); color: var(--text); cursor: pointer; user-select: none; position: relative; padding-right: 22px; transition: background .12s, color .12s; }
+th:hover { background: var(--s3); color: var(--accent-hi); }
+th::after { content: '\\2195'; position: absolute; right: 6px; top: 50%; transform: translateY(-50%); color: var(--muted); font-size: 0.85em; opacity: 0.4; }
+th.sort-asc::after { content: '\\25B2'; color: var(--accent); opacity: 1; }
+th.sort-desc::after { content: '\\25BC'; color: var(--accent); opacity: 1; }
+tr:nth-child(even) { background: var(--s1); }
+tr:nth-child(odd) { background: rgba(0,0,0,0.1); }
+.yes { color: var(--green-hi); font-weight: bold; }
+.no { color: var(--muted); }
+.stats { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 14px; margin-bottom: 1.5em; }
+@media (max-width: 1100px) { .stats { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+@media (max-width: 640px) { .stats { grid-template-columns: 1fr; } }
+.stat-card { background: linear-gradient(180deg, rgba(27,40,56,0.55), rgba(11,17,22,0.45)); border: 1px solid var(--border); padding: 14px 18px; clip-path: polygon(0 0, 100% 0, 100% calc(100% - 10px), calc(100% - 10px) 100%, 0 100%); }
+.stat-card .label { font-family: var(--mono); font-size: 0.72rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.14em; }
+.stat-card .value { font-family: var(--mono); font-size: 1.7rem; font-weight: 600; color: var(--accent-hi); margin: 4px 0; text-shadow: 0 0 14px var(--accent-glow); }
+.stat-card .detail { font-size: 0.78rem; color: var(--muted); }
+.pct { color: var(--green-hi); }
+.filters { margin-bottom: 1em; display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+#filter { padding: 8px 10px; width: 320px; background: rgba(11,17,22,0.6); color: var(--text); border: 1px solid var(--border2); }
+#filter:focus { border-color: var(--accent); outline: none; box-shadow: 0 0 0 3px var(--accent-soft); }
+.toggle { padding: 6px 14px; border: 1px solid var(--border2); background: transparent; color: var(--muted); cursor: pointer; font-weight: 600; text-transform: uppercase; font-size: 0.78rem; letter-spacing: 0.04em; transition: color .12s, border-color .12s, background .12s; }
+.toggle:hover { color: var(--text); border-color: var(--accent); }
+.toggle.active { background: var(--accent-soft); color: var(--accent-hi); border-color: var(--accent); }
+.pager { margin: 1em 0; display: flex; gap: 8px; align-items: center; }
+.pager button { padding: 6px 14px; background: rgba(11,17,22,0.6); color: var(--text); border: 1px solid var(--border2); cursor: pointer; font-family: inherit; font-size: 0.82rem; }
+.pager button:hover { background: var(--s2); border-color: var(--accent); }
+.coverage-meta { color: var(--muted); margin-bottom: 1em; font-family: var(--mono); font-size: 0.8rem; letter-spacing: 0.04em; }
+"""
+    head_html = "\n".join(_pipeline_page_head("Coverage Report - Proton Pulse", extra_style=coverage_style))
+    scripts_html = "\n".join(_pipeline_page_scripts())
+    html = f"""{head_html}
 <body>
-<!-- shared topbar (banner + nav + drawer) injected by topbar.js -->
-<script src="topbar.js"></script>
 <div class="main-content"><div class="main-inner">
 <h1 style="font-family:var(--font-display);text-transform:uppercase;letter-spacing:0.02em;margin-bottom:0.4em">Coverage Report</h1>
 <p class="coverage-meta">// Generated: {now}</p>
@@ -1730,6 +1793,7 @@ apply(false);
 updateSortIndicator();
 </script>
 </div></div>
+{scripts_html}
 </body></html>
 """
     report_file = output_path / "coverage.html"

--- a/scripts/pipeline/finalize.py
+++ b/scripts/pipeline/finalize.py
@@ -1455,6 +1455,24 @@ def generate_nonsteam_images(output_path: Path) -> None:
     )
 
 
+def _coverage_store_for(app_id: str) -> str:
+    """Bucket a coverage-report app id into a store label.
+
+    Steam ids are numeric, non-Steam ids are namespaced 'gog:'/'epic:'/'pgwiki:'.
+    Anything unrecognized falls back to 'other' so a stray id never crashes
+    the store filter chip. #450.
+    """
+    if app_id.isdigit():
+        return "steam"
+    if app_id.startswith("gog:"):
+        return "gog"
+    if app_id.startswith("epic:"):
+        return "epic"
+    if app_id.startswith("pgwiki:"):
+        return "pgwiki"
+    return "other"
+
+
 def generate_coverage_report(
     index_keys: set,
     backfilled_keys: set,
@@ -1463,6 +1481,9 @@ def generate_coverage_report(
     steam_catalog: dict[str, str] | None = None,
     protondb_signal_catalog: dict[str, str] | None = None,
     protondb_counts: dict | None = None,
+    gog_catalog: dict[str, str] | None = None,
+    epic_catalog: dict[str, str] | None = None,
+    pcgwiki_catalog: dict[str, str] | None = None,
 ) -> None:
     indexed_app_ids = {app_id for app_id, _ in index_keys}
     all_app_ids = set(indexed_app_ids)
@@ -1471,10 +1492,21 @@ def generate_coverage_report(
     steam_catalog_app_ids = set((steam_catalog or {}).keys())
     steam_protondb_overlap = steam_catalog_app_ids & protondb_signal_app_ids
 
+    # Non-Steam catalog entries live under namespaced ids so they never
+    # collide with numeric Steam app ids. Store keys use raw ids that we
+    # namespace here into the same format the rest of the pipeline uses.
+    # #450: coverage was Steam-only until this change.
+    gog_app_ids = {f"gog:{pid}" for pid in (gog_catalog or {}).keys()}
+    epic_app_ids = {f"epic:{ns}" for ns in (epic_catalog or {}).keys()}
+    pcgwiki_app_ids = set((pcgwiki_catalog or {}).keys())  # already carry the pgwiki: prefix
+
     if steam_catalog:
         all_app_ids.update(steam_catalog.keys())
     all_app_ids.update(protondb_signal_app_ids)
     all_app_ids.update(state_backfill_app_ids)
+    all_app_ids.update(gog_app_ids)
+    all_app_ids.update(epic_app_ids)
+    all_app_ids.update(pcgwiki_app_ids)
 
     log(f"[coverage] Indexed app IDs           : {len(indexed_app_ids):,}")
     log(f"[coverage] Backfill app IDs          : {len(state_backfill_app_ids):,}")
@@ -1482,7 +1514,25 @@ def generate_coverage_report(
     if steam_catalog:
         log(f"[coverage] Steam catalog app IDs     : {len(steam_catalog_app_ids):,}")
         log(f"[coverage] Steam ∩ ProtonDB signals  : {len(steam_protondb_overlap):,}")
+    if gog_app_ids:
+        log(f"[coverage] GOG catalog app IDs       : {len(gog_app_ids):,}")
+    if epic_app_ids:
+        log(f"[coverage] Epic catalog app IDs      : {len(epic_app_ids):,}")
+    if pcgwiki_app_ids:
+        log(f"[coverage] PCGWiki catalog app IDs   : {len(pcgwiki_app_ids):,}")
     log(f"[coverage] Final coverage universe   : {len(all_app_ids):,}")
+
+    # Non-Steam title lookup: use the catalog dict for the matching store.
+    # These titles never override an indexed local title; they're the
+    # fallback when _resolve_coverage_title returns "" for a namespaced id.
+    def _non_steam_title(app_id: str) -> tuple[str, str]:
+        if app_id.startswith("gog:"):
+            return (gog_catalog or {}).get(app_id[4:], ""), "gog-catalog"
+        if app_id.startswith("epic:"):
+            return (epic_catalog or {}).get(app_id[5:], ""), "epic-catalog"
+        if app_id.startswith("pgwiki:"):
+            return (pcgwiki_catalog or {}).get(app_id, ""), "pcgwiki-catalog"
+        return "", "none"
 
     rows = []
     for app_id in sorted(all_app_ids, key=lambda a: (0, int(a)) if a.isdigit() else (1, a)):
@@ -1498,8 +1548,12 @@ def generate_coverage_report(
             protondb_signal_catalog=protondb_signal_catalog,
             steam_catalog=steam_catalog,
         )
+        if not title:
+            title, title_source = _non_steam_title(app_id)
+        store = _coverage_store_for(app_id)
         rows.append((
             app_id,
+            store,
             title,
             title_source,
             official,
@@ -1510,8 +1564,8 @@ def generate_coverage_report(
         ))
 
     now = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
-    official_count = sum(1 for row in rows if row[3])
-    backfill_count = sum(1 for row in rows if row[4])
+    official_count = sum(1 for row in rows if row[4])
+    backfill_count = sum(1 for row in rows if row[5])
     indexed_count = len(indexed_app_ids)
     steam_count = len(steam_catalog_app_ids) if steam_catalog else 0
     protondb_unique_games = (protondb_counts or {}).get("uniqueGames", 0) if protondb_counts else 0
@@ -1519,13 +1573,20 @@ def generate_coverage_report(
     pct_of_protondb_total = (indexed_count / protondb_unique_games * 100) if protondb_unique_games else 0
     pct_of_steam = (indexed_count / steam_count * 100) if steam_count else 0
     protondb_pct_of_steam = (protondb_unique_games / steam_count * 100) if (steam_count and protondb_unique_games) else 0
+    store_counts = {"steam": 0, "gog": 0, "epic": 0, "pgwiki": 0, "other": 0}
+    for row in rows:
+        store_counts[row[1]] = store_counts.get(row[1], 0) + 1
 
-    # Build JS data array instead of HTML rows
+    # Build JS data array. The store field is index 1 so it drives the store
+    # filter chip without a second lookup. bad-appid used to key on "not
+    # numeric" which now matches every legitimate non-Steam id -- switched
+    # to detecting truly malformed values (empty, whitespace, unrecognised
+    # namespace) so gog:/epic:/pgwiki: rows do NOT get flagged.
     # Format:
-    # [appId, title, titleSource, official, backfill, protondbSignal, steamCatalog, "flags", indexed]
+    # [appId, store, title, titleSource, official, backfill, protondbSignal, steamCatalog, "flags", indexed]
     js_rows = []
-    for app_id, title, title_source, official, backfill, protondb_signal, steam_catalog_hit, indexed in rows:
-        flags = []
+    for app_id, store, title, title_source, official, backfill, protondb_signal, steam_catalog_hit, indexed in rows:
+        flags = [f"store-{store}"]
         if official:
             flags.append("official")
         if backfill:
@@ -1536,7 +1597,7 @@ def generate_coverage_report(
             flags.append("steam-catalog")
         if not title:
             flags.append("missing-title")
-        if not app_id.isdigit():
+        if store == "other" or not app_id.strip():
             flags.append("bad-appid")
         if not official and not backfill and not indexed:
             flags.append("no-data")
@@ -1544,7 +1605,7 @@ def generate_coverage_report(
         safe_title = title.replace("\\", "\\\\").replace('"', '\\"').replace("\n", " ")
         safe_title_source = title_source.replace("\\", "\\\\").replace('"', '\\"')
         js_rows.append(
-            f'["{app_id}","{safe_title}","{safe_title_source}",'
+            f'["{app_id}","{store}","{safe_title}","{safe_title_source}",'
             f'{1 if official else 0},{1 if backfill else 0},{1 if protondb_signal else 0},'
             f'{1 if steam_catalog_hit else 0},"{" ".join(flags)}",{1 if indexed else 0}]'
         )
@@ -1570,12 +1631,13 @@ tr:nth-child(odd) { background: rgba(0,0,0,0.1); }
 .stat-card .value { font-family: var(--mono); font-size: 1.7rem; font-weight: 600; color: var(--accent-hi); margin: 4px 0; text-shadow: 0 0 14px var(--accent-glow); }
 .stat-card .detail { font-size: 0.78rem; color: var(--muted); }
 .pct { color: var(--green-hi); }
-.filters { margin-bottom: 1em; display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
-#filter { padding: 8px 10px; width: 320px; background: rgba(11,17,22,0.6); color: var(--text); border: 1px solid var(--border2); }
+/* Filter chrome: shared .pg-filter pill styling comes from css/shared/filters.css,
+   so the coverage page picks up the same pill look the home + game pages use.
+   Only page-scoped rules here: the search input + the group container spacing. */
+.filter-groups { display: flex; flex-direction: column; gap: 10px; margin-bottom: 1em; }
+.filter-groups .pg-filter-group { padding: 4px 0; }
+#filter { padding: 8px 10px; width: 320px; background: rgba(11,17,22,0.6); color: var(--text); border: 1px solid var(--border2); font-family: inherit; font-size: 0.88rem; }
 #filter:focus { border-color: var(--accent); outline: none; box-shadow: 0 0 0 3px var(--accent-soft); }
-.toggle { padding: 6px 14px; border: 1px solid var(--border2); background: transparent; color: var(--muted); cursor: pointer; font-weight: 600; text-transform: uppercase; font-size: 0.78rem; letter-spacing: 0.04em; transition: color .12s, border-color .12s, background .12s; }
-.toggle:hover { color: var(--text); border-color: var(--accent); }
-.toggle.active { background: var(--accent-soft); color: var(--accent-hi); border-color: var(--accent); }
 .pager { margin: 1em 0; display: flex; gap: 8px; align-items: center; }
 .pager button { padding: 6px 14px; background: rgba(11,17,22,0.6); color: var(--text); border: 1px solid var(--border2); cursor: pointer; font-family: inherit; font-size: 0.82rem; }
 .pager button:hover { background: var(--s2); border-color: var(--accent); }
@@ -1620,14 +1682,24 @@ tr:nth-child(odd) { background: rgba(0,0,0,0.1); }
   <div class="detail">Total apps tracked in this report</div>
 </div>
 </div>
-<div class="filters">
-<input id="filter" placeholder="Filter by App ID or title\u2026" oninput="onFilter()">
-<button class="toggle active" data-src="all" onclick="toggleSrc('all')">All</button>
-<button class="toggle" data-src="official" onclick="toggleSrc('official')">Official dump only</button>
-<button class="toggle" data-src="backfill" onclick="toggleSrc('backfill')">Live backfill only</button>
-<button class="toggle" data-src="no-data" onclick="toggleSrc('no-data')">No data</button>
-<button class="toggle" data-src="missing-title" onclick="toggleSrc('missing-title')">Missing title</button>
-<button class="toggle" data-src="bad-appid" onclick="toggleSrc('bad-appid')">Bad App ID</button>
+<div class="filter-groups">
+<div><input id="filter" placeholder="Filter by App ID or title\u2026" oninput="onFilter()"></div>
+<div class="pg-filter-group" id="store-filter" aria-label="Filter by store">
+  <span class="pg-filter-group-label">Store</span>
+  <button class="pg-filter pg-filter--active" type="button" data-src="all">All</button>
+  <button class="pg-filter" type="button" data-src="store-steam">Steam ({store_counts["steam"]:,})</button>
+  <button class="pg-filter" type="button" data-src="store-gog">GOG ({store_counts["gog"]:,})</button>
+  <button class="pg-filter" type="button" data-src="store-epic">Epic ({store_counts["epic"]:,})</button>
+  <button class="pg-filter" type="button" data-src="store-pgwiki">PCGWiki ({store_counts["pgwiki"]:,})</button>
+</div>
+<div class="pg-filter-group" id="source-filter" aria-label="Filter by data source">
+  <span class="pg-filter-group-label">Data source</span>
+  <button class="pg-filter" type="button" data-src="official">Official dump only</button>
+  <button class="pg-filter" type="button" data-src="backfill">Live backfill only</button>
+  <button class="pg-filter" type="button" data-src="no-data">No data</button>
+  <button class="pg-filter" type="button" data-src="missing-title">Missing title</button>
+  <button class="pg-filter" type="button" data-src="bad-appid">Bad App ID</button>
+</div>
 </div>
 <div class="pager">
 <button onclick="goPage(-1)">&larr; Prev</button>
@@ -1637,12 +1709,13 @@ tr:nth-child(odd) { background: rgba(0,0,0,0.1); }
 <table id="coverage">
 <thead><tr>
 <th onclick="doSort(0)">App ID</th>
-<th onclick="doSort(1)">Title (ProtonDB)</th>
-<th onclick="doSort(2)">Title Source</th>
-<th onclick="doSort(3)">Official ProtonDB Dump</th>
-<th onclick="doSort(4)">Live Backfill</th>
-<th onclick="doSort(5)">Seen on ProtonDB</th>
-<th onclick="doSort(6)">Seen in Steam Catalog</th>
+<th onclick="doSort(1)">Store</th>
+<th onclick="doSort(2)">Title (ProtonDB)</th>
+<th onclick="doSort(3)">Title Source</th>
+<th onclick="doSort(4)">Official ProtonDB Dump</th>
+<th onclick="doSort(5)">Live Backfill</th>
+<th onclick="doSort(6)">Seen on ProtonDB</th>
+<th onclick="doSort(7)">Seen in Steam Catalog</th>
 <th>Indexed</th>
 </tr></thead>
 <tbody id="tbody"></tbody>
@@ -1671,7 +1744,17 @@ const TITLE_SOURCE_LABELS={{
   "steam-store-empty-name":"Steam Store (empty name)",
   "steam-store-unsuccessful":"Steam Store (unsuccessful)",
   "steam-store-error":"Steam Store (error)",
+  "gog-catalog":"GOG Catalog",
+  "epic-catalog":"Epic Catalog",
+  "pcgwiki-catalog":"PCGamingWiki Catalog",
   "none":"None"
+}};
+const STORE_LABELS={{
+  "steam":"Steam",
+  "gog":"GOG",
+  "epic":"Epic",
+  "pgwiki":"PCGamingWiki",
+  "other":"Other"
 }};
 
 function getStateFromUrl(){{
@@ -1709,18 +1792,28 @@ function saveStateToUrl(){{
 function toggleSrc(s){{
   if(s==="all"){{activeSrc.clear();activeSrc.add("all")}}
   else{{activeSrc.delete("all");activeSrc.has(s)?activeSrc.delete(s):activeSrc.add(s);if(!activeSrc.size)activeSrc.add("all")}}
-  document.querySelectorAll(".toggle").forEach(b=>b.classList.toggle("active",activeSrc.has(b.dataset.src)));
+  document.querySelectorAll(".pg-filter").forEach(b=>b.classList.toggle("pg-filter--active",activeSrc.has(b.dataset.src)));
   apply();
 }}
+// Delegated click wiring for the new .pg-filter pills. The toggle() call
+// above still owns the state math; the pills only need to route clicks
+// into it. Uses event delegation so both filter groups pick up their
+// clicks from one listener.
+document.addEventListener("click",e=>{{
+  const btn=e.target.closest(".filter-groups .pg-filter");
+  if(!btn||!btn.dataset.src)return;
+  toggleSrc(btn.dataset.src);
+}});
 function onFilter(){{clearTimeout(filterTimer);filterTimer=setTimeout(()=>apply(),200)}}
 function apply(resetPage=true){{
   const q=document.getElementById("filter").value.toLowerCase();
   const all=activeSrc.has("all");
   filtered=DATA.filter(r=>{{
-    if(!all&&![...activeSrc].some(s=>r[7].split(" ").includes(s)))return false;
+    // Flags moved from index 7 to 8 with the store column addition (#450).
+    if(!all&&![...activeSrc].some(s=>r[8].split(" ").includes(s)))return false;
     if(q){{
       const queryIsNumeric=/^\\d+$/.test(q);
-      const haystack=(r[0]+" "+r[1]).toLowerCase();
+      const haystack=(r[0]+" "+r[2]).toLowerCase();
       if(queryIsNumeric){{
         if(r[0]!==q)return false;
       }} else if(!haystack.includes(q)) return false;
@@ -1744,9 +1837,11 @@ function updateSortIndicator(){{
 }}
 function doSortFiltered(){{
   const c=sortCol,d=sortAsc;
+  // Numeric-yes/no columns moved to 4..7 (was 3..6) after adding the store
+  // column. App ID sort still lives at col 0 and is numeric-parse aware.
   filtered.sort((a,b)=>{{
     if(c===0)return d*(parseInt(a[0]||"0")-parseInt(b[0]||"0"));
-    if(c>=3&&c<=6)return d*(b[c]-a[c]);
+    if(c>=4&&c<=7)return d*(b[c]-a[c]);
     return d*String(a[c]).localeCompare(String(b[c]));
   }});
 }}
@@ -1767,17 +1862,20 @@ function render(){{
   document.getElementById("pageInfo2").textContent=info;
   const h=[];
   for(const r of safeSlice){{
-    const id=r[0],t=r[1],ts=r[2],o=r[3],b=r[4],ps=r[5],sc=r[6],ix=r[8];
-    const isNum=id.length>0&&[...id].every(c=>c>='0'&&c<='9');
-    const ac=isNum?`<a href="https://store.steampowered.com/app/${{id}}">${{id}}</a>`:id;
-    const tc=isNum&&t?`<a href="https://www.protondb.com/app/${{id}}">${{t}}</a>`:(t||"");
+    // New schema: [id, store, title, titleSource, official, backfill,
+    // protondbSignal, steamCatalog, flags, indexed]
+    const id=r[0],store=r[1],t=r[2],ts=r[3],o=r[4],b=r[5],ps=r[6],sc=r[7],ix=r[9];
+    const isSteam=store==="steam";
+    const ac=isSteam?`<a href="https://store.steampowered.com/app/${{id}}">${{id}}</a>`:id;
+    const tc=isSteam&&t?`<a href="https://www.protondb.com/app/${{id}}">${{t}}</a>`:(t||"");
+    const sl=STORE_LABELS[store]||store;
     const oc=o?'<span class="yes">yes</span>':'<span class="no">no</span>';
     const bc=b?'<span class="yes">yes</span>':'<span class="no">no</span>';
     const psc=ps?'<span class="yes">yes</span>':'<span class="no">no</span>';
     const scc=sc?'<span class="yes">yes</span>':'<span class="no">no</span>';
     const tsc=TITLE_SOURCE_LABELS[ts]||ts.replace(/-/g,' ');
     const ixc=ix?`<a href="data/${{id}}/">index</a>`:'<span class="no">\u2014</span>';
-    h.push(`<tr><td>${{ac}}</td><td>${{tc}}</td><td>${{tsc}}</td><td>${{oc}}</td><td>${{bc}}</td><td>${{psc}}</td><td>${{scc}}</td><td>${{ixc}}</td></tr>`);
+    h.push(`<tr><td>${{ac}}</td><td>${{sl}}</td><td>${{tc}}</td><td>${{tsc}}</td><td>${{oc}}</td><td>${{bc}}</td><td>${{psc}}</td><td>${{scc}}</td><td>${{ixc}}</td></tr>`);
   }}
   tb.innerHTML=h.join("");
   saveStateToUrl();
@@ -1788,7 +1886,7 @@ activeSrc=initialState.src;
 sortCol=initialState.sort;
 sortAsc=initialState.dir;
 page=initialState.page;
-document.querySelectorAll(".toggle").forEach(b=>b.classList.toggle("active",activeSrc.has(b.dataset.src)));
+document.querySelectorAll(".pg-filter").forEach(b=>b.classList.toggle("pg-filter--active",activeSrc.has(b.dataset.src)));
 apply(false);
 updateSortIndicator();
 </script>
@@ -2125,6 +2223,16 @@ def finalize_output(output_dir, skip_probe: bool = False):
     enrich_nonsteam_app_metadata(data_output_path)
     generate_nonsteam_metadata(output_path)
     phase("Coverage report")
+    # Load the published PCGWiki catalog snapshot so coverage can include
+    # PCGWiki entries alongside Steam/GOG/Epic (#450). refresh_catalog is a
+    # cheap read against the pipeline output dir; failures fall back to an
+    # empty dict so a missing snapshot never breaks the coverage report.
+    pcgwiki_catalog_for_coverage: dict[str, str] = {}
+    try:
+        from .pcgamingwiki_catalog import refresh_catalog as _refresh_pcgwiki
+        pcgwiki_catalog_for_coverage = _refresh_pcgwiki(output_path)
+    except Exception as exc:
+        log(f"[coverage] PCGWiki catalog unavailable: {exc}")
     generate_coverage_report(
         full_index_keys,
         state["backfilled_keys"],
@@ -2136,6 +2244,9 @@ def finalize_output(output_dir, skip_probe: bool = False):
             **(protondb_probe_catalog or {}),
         },
         protondb_counts=protondb_counts,
+        gog_catalog=gog_catalog,
+        epic_catalog=epic_catalog,
+        pcgwiki_catalog=pcgwiki_catalog_for_coverage,
     )
     # Walk the data tree (post pulse merge) and emit stats.json that powers the
     # /stats.html page. Tiny output regardless of dataset size since everything

--- a/scripts/pipeline/finalize.py
+++ b/scripts/pipeline/finalize.py
@@ -338,7 +338,11 @@ def generate_index_html(index_keys: set, output_path: Path) -> None:
     sample_entries = []
     for app_id, name in sample_apps.items():
         if app_id in app_years:
-            sample_entries.append(f'<a href="data/{app_id}/latest.json">{name}</a> ({app_id})')
+            # Hash-link into the master/detail view rather than a raw JSON
+            # download. Raw-JSON links 404 on CF Pages (per-game data lives in
+            # R2, not on Pages) and read as a broken page instead of a shortcut
+            # to the app's detail view. #451.
+            sample_entries.append(f'<a href="#/{app_id}">{name}</a> ({app_id})')
 
     # Page-specific styles. Site-wide identity comes from site.css; this block only
     # adds what data-index needs (grid rows, detail split, json tinting). All colors
@@ -574,15 +578,33 @@ def generate_index_html(index_keys: set, output_path: Path) -> None:
   // scripts/pipeline/pulse.py), so we just render whatever is in the file.
   // Each record carries a source field ("protondb" or "pulse") so consumers
   // can filter cleanly.
+  // Per-game data buckets can live on a separate host (R2) when the deploy
+  // target is Cloudflare -- data-config.json.dataBase carries that base URL.
+  // Fetch once at page load; empty on gh-pages deploys so data stays same
+  // origin there. Any data/ fetch below prefixes with this base when set.
+  // #451 -- without this the master/detail view hit the CF Pages SPA
+  // fallback for every latest.json and printed a JSON.parse error.
+  let dataBasePromise = fetch('data-config.json', { cache: 'no-store' })
+    .then(r => r.ok ? r.json() : {})
+    .catch(() => ({}))
+    .then(cfg => (cfg && cfg.dataBase) ? String(cfg.dataBase).replace(/\\/$/, '') : '');
+
+  function dataFileUrl(path) {
+    // path is 'data/{id}/{file}' -- return a Promise that resolves to the
+    // fully-qualified URL, prefixed with dataBase when Cloudflare-hosted.
+    return dataBasePromise.then(base => base ? base + '/' + path : path);
+  }
+
   let activeFetch = null;
   function loadYear(appId, file) {
-    pathEl.textContent = '/data/' + appId + '/' + file;
+    const displayPath = '/data/' + appId + '/' + file;
+    pathEl.textContent = displayPath;
     statusEl.textContent = 'loading';
     contentEl.textContent = '';
-    const url = 'data/' + appId + '/' + file;
     const token = Symbol();
     activeFetch = token;
-    fetch(url).then(r => r.ok ? r.json() : Promise.reject(r.status))
+    dataFileUrl('data/' + appId + '/' + file)
+      .then(url => fetch(url).then(r => r.ok ? r.json() : Promise.reject(r.status)))
       .then(data => {
         if (activeFetch !== token) return;
         const list = Array.isArray(data) ? data : [];
@@ -596,7 +618,7 @@ def generate_index_html(index_keys: set, output_path: Path) -> None:
       .catch(err => {
         if (activeFetch !== token) return;
         statusEl.textContent = 'error';
-        contentEl.textContent = 'Failed to load ' + url + ' (' + err + ')';
+        contentEl.textContent = 'Failed to load ' + displayPath + ' (' + err + ')';
       });
   }
 
@@ -1874,7 +1896,11 @@ function render(){{
     const psc=ps?'<span class="yes">yes</span>':'<span class="no">no</span>';
     const scc=sc?'<span class="yes">yes</span>':'<span class="no">no</span>';
     const tsc=TITLE_SOURCE_LABELS[ts]||ts.replace(/-/g,' ');
-    const ixc=ix?`<a href="data/${{id}}/">index</a>`:'<span class="no">\u2014</span>';
+    // Route Indexed clicks through data-index.html's master/detail view --
+    // linking to a raw data/{id}/ path 404s on CF Pages because per-game
+    // data lives on R2, not on Pages, and R2 does not auto-serve directory
+    // indexes anyway. #451.
+    const ixc=ix?`<a href="data-index.html#/${{id}}">index</a>`:'<span class="no">\u2014</span>';
     h.push(`<tr><td>${{ac}}</td><td>${{sl}}</td><td>${{tc}}</td><td>${{tsc}}</td><td>${{oc}}</td><td>${{bc}}</td><td>${{psc}}</td><td>${{scc}}</td><td>${{ixc}}</td></tr>`);
   }}
   tb.innerHTML=h.join("");

--- a/scripts/pipeline/finalize.py
+++ b/scripts/pipeline/finalize.py
@@ -358,13 +358,13 @@ def generate_index_html(index_keys: set, output_path: Path) -> None:
     .pager button:hover:not(:disabled) { background: var(--s2); border-color: var(--accent); }
     .pager button:disabled { opacity: 0.4; cursor: not-allowed; }
     #index-page-info { color: var(--muted); }
-    ul#index-results { list-style: none; padding: 0; margin: 12px 0; display: grid; grid-template-columns: repeat(auto-fill, minmax(360px, 1fr)); gap: 8px; }
-    ul#index-results > li { display: contents; }
-    ul#index-results a.row { display: flex; align-items: center; gap: 12px; padding: 10px 14px; background: linear-gradient(180deg, rgba(27,40,56,0.5), rgba(11,17,22,0.4)); border: 1px solid var(--border); color: var(--text); transition: border-color .12s, background .12s, transform .12s, box-shadow .12s; }
+    ul#index-results { list-style: none; padding: 0; margin: 12px 0; display: flex; flex-direction: column; gap: 6px; }
+    ul#index-results > li { display: block; }
+    ul#index-results a.row { display: flex; align-items: center; gap: 14px; padding: 12px 16px; background: linear-gradient(180deg, rgba(27,40,56,0.5), rgba(11,17,22,0.4)); border: 1px solid var(--border); color: var(--text); transition: border-color .12s, background .12s, transform .12s, box-shadow .12s; }
     ul#index-results a.row:hover { border-color: var(--accent); background: linear-gradient(180deg, rgba(102,192,244,0.08), rgba(11,17,22,0.5)); box-shadow: 0 0 18px -6px var(--accent-glow); transform: translateY(-1px); text-decoration: none; }
-    ul#index-results .appid { font-family: var(--mono); font-size: 0.78rem; color: var(--accent); min-width: 80px; flex-shrink: 0; }
-    ul#index-results .title { flex: 1; color: var(--text); }
-    ul#index-results .years { font-family: var(--mono); font-size: 0.72rem; color: var(--muted); flex-shrink: 0; }
+    ul#index-results .appid { font-family: var(--mono); font-size: 0.82rem; color: var(--accent); min-width: 100px; flex-shrink: 0; }
+    ul#index-results .title { flex: 1; color: var(--text); font-size: 0.95rem; }
+    ul#index-results .years { font-family: var(--mono); font-size: 0.74rem; color: var(--muted); flex-shrink: 0; letter-spacing: 0.04em; }
 
     /* detail view: master/detail split with years on the left, JSON on the right */
     .detail-view { display: none; }

--- a/scripts/pipeline/finalize.py
+++ b/scripts/pipeline/finalize.py
@@ -78,6 +78,11 @@ _SHARED_CSS = (
     "css/shared/topbar.css",
     "css/shared/site.css",
     "css/shared/cards.css",
+    # #457: filters.css owns .filter-panel + .filter-toggle-btn + .pg-filter
+    # + the mobile-modal chrome that topbar.js's observer keys on. Without
+    # this link the coverage page's filter modal rendered inline and every
+    # pill lost its site-consistent styling.
+    "css/shared/filters.css",
 )
 # Trailing scripts: topbar.js needs the ring buffer + analytics loaded first,
 # and the supabase client is a hard dep of the topbar user chip. Mirrors the

--- a/scripts/pipeline/finalize.py
+++ b/scripts/pipeline/finalize.py
@@ -1653,12 +1653,15 @@ tr:nth-child(odd) { background: rgba(0,0,0,0.1); }
 .stat-card .value { font-family: var(--mono); font-size: 1.7rem; font-weight: 600; color: var(--accent-hi); margin: 4px 0; text-shadow: 0 0 14px var(--accent-glow); }
 .stat-card .detail { font-size: 0.78rem; color: var(--muted); }
 .pct { color: var(--green-hi); }
-/* Filter chrome: shared .pg-filter pill styling comes from css/shared/filters.css,
-   so the coverage page picks up the same pill look the home + game pages use.
-   Only page-scoped rules here: the search input + the group container spacing. */
-.filter-groups { display: flex; flex-direction: column; gap: 10px; margin-bottom: 1em; }
-.filter-groups .pg-filter-group { padding: 4px 0; }
-#filter { padding: 8px 10px; width: 320px; background: rgba(11,17,22,0.6); color: var(--text); border: 1px solid var(--border2); font-family: inherit; font-size: 0.88rem; }
+/* Filter chrome: shared .filter-wrap + .filter-panel modal from
+   css/shared/filters.css so the coverage page opens the same dropdown /
+   mobile modal as the home browse page. Only page-scoped rules here: the
+   wrap positioning (so the panel anchors under the toggle), the search
+   input, and small overrides. */
+.filter-wrap { position: relative; display: inline-block; margin-bottom: 1em; }
+.filter-panel .filter-item { padding: 4px 0; }
+.filter-panel .pg-filter-group { padding: 4px 0; }
+#filter { width: 100%; box-sizing: border-box; padding: 8px 10px; background: rgba(11,17,22,0.6); color: var(--text); border: 1px solid var(--border2); font-family: inherit; font-size: 0.88rem; }
 #filter:focus { border-color: var(--accent); outline: none; box-shadow: 0 0 0 3px var(--accent-soft); }
 .pager { margin: 1em 0; display: flex; gap: 8px; align-items: center; }
 .pager button { padding: 6px 14px; background: rgba(11,17,22,0.6); color: var(--text); border: 1px solid var(--border2); cursor: pointer; font-family: inherit; font-size: 0.82rem; }
@@ -1704,24 +1707,41 @@ tr:nth-child(odd) { background: rgba(0,0,0,0.1); }
   <div class="detail">Total apps tracked in this report</div>
 </div>
 </div>
-<div class="filter-groups">
-<div><input id="filter" placeholder="Filter by App ID or title\u2026" oninput="onFilter()"></div>
-<div class="pg-filter-group" id="store-filter" aria-label="Filter by store">
-  <span class="pg-filter-group-label">Store</span>
-  <button class="pg-filter pg-filter--active" type="button" data-src="all">All</button>
-  <button class="pg-filter" type="button" data-src="store-steam">Steam ({store_counts["steam"]:,})</button>
-  <button class="pg-filter" type="button" data-src="store-gog">GOG ({store_counts["gog"]:,})</button>
-  <button class="pg-filter" type="button" data-src="store-epic">Epic ({store_counts["epic"]:,})</button>
-  <button class="pg-filter" type="button" data-src="store-pgwiki">PCGWiki ({store_counts["pgwiki"]:,})</button>
-</div>
-<div class="pg-filter-group" id="source-filter" aria-label="Filter by data source">
-  <span class="pg-filter-group-label">Data source</span>
-  <button class="pg-filter" type="button" data-src="official">Official dump only</button>
-  <button class="pg-filter" type="button" data-src="backfill">Live backfill only</button>
-  <button class="pg-filter" type="button" data-src="no-data">No data</button>
-  <button class="pg-filter" type="button" data-src="missing-title">Missing title</button>
-  <button class="pg-filter" type="button" data-src="bad-appid">Bad App ID</button>
-</div>
+<div class="filter-wrap" id="coverage-filter-wrap">
+  <button class="filter-toggle-btn" id="coverage-filter-toggle" type="button" aria-expanded="false">
+    <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M4.25 5.61C6.27 8.2 10 13 10 13v6c0 .55.45 1 1 1h2c.55 0 1-.45 1-1v-6s3.72-4.8 5.74-7.39C20.25 4.95 19.8 4 18.95 4H5.04C4.2 4 3.74 4.95 4.25 5.61z"/></svg>
+    Filters<span class="filter-badge" id="coverage-filter-badge" hidden></span>
+  </button>
+  <div class="filter-panel filter-panel--stack" id="coverage-filter-panel">
+    <div class="filter-panel-mobile-header">
+      <span class="filter-panel-mobile-title">Filters</span>
+      <button type="button" class="filter-panel-close" aria-label="Close filters">&times;</button>
+    </div>
+    <div class="filter-item"><input id="filter" placeholder="Filter by App ID or title\u2026" oninput="onFilter()"></div>
+    <div class="pg-filter-group" id="store-filter" aria-label="Filter by store">
+      <span class="pg-filter-group-label">Store</span>
+      <button class="pg-filter pg-filter--active" type="button" data-src="all">All</button>
+      <button class="pg-filter" type="button" data-src="store-steam">Steam ({store_counts["steam"]:,})</button>
+      <button class="pg-filter" type="button" data-src="store-gog">GOG ({store_counts["gog"]:,})</button>
+      <button class="pg-filter" type="button" data-src="store-epic">Epic ({store_counts["epic"]:,})</button>
+      <button class="pg-filter" type="button" data-src="store-pgwiki">PCGWiki ({store_counts["pgwiki"]:,})</button>
+    </div>
+    <div class="pg-filter-group" id="source-filter" aria-label="Filter by data source">
+      <span class="pg-filter-group-label">Data source</span>
+      <button class="pg-filter" type="button" data-src="official">Official dump only</button>
+      <button class="pg-filter" type="button" data-src="backfill">Live backfill only</button>
+      <button class="pg-filter" type="button" data-src="no-data">No data</button>
+      <button class="pg-filter" type="button" data-src="missing-title">Missing title</button>
+      <button class="pg-filter" type="button" data-src="bad-appid">Bad App ID</button>
+    </div>
+    <div class="filter-panel-footer filter-panel-footer--stack">
+      <button class="filter-collapse-btn" id="coverage-filter-collapse" type="button" aria-label="Collapse filters">
+        <span class="filter-collapse-caret" aria-hidden="true">&#x25B2;</span>
+        <span class="filter-collapse-text">Collapse</span>
+      </button>
+      <button class="filter-clear-btn" id="coverage-filter-clear" type="button">Clear filters</button>
+    </div>
+  </div>
 </div>
 <div class="pager">
 <button onclick="goPage(-1)">&larr; Prev</button>
@@ -1817,15 +1837,63 @@ function toggleSrc(s){{
   document.querySelectorAll(".pg-filter").forEach(b=>b.classList.toggle("pg-filter--active",activeSrc.has(b.dataset.src)));
   apply();
 }}
-// Delegated click wiring for the new .pg-filter pills. The toggle() call
-// above still owns the state math; the pills only need to route clicks
-// into it. Uses event delegation so both filter groups pick up their
-// clicks from one listener.
+// Delegated click wiring for the .pg-filter pills inside the modal. Both
+// groups (Store + Data source) route clicks through the same toggleSrc()
+// state machine. Scoped to #coverage-filter-panel so a stray .pg-filter
+// elsewhere on the site does not fire it.
 document.addEventListener("click",e=>{{
-  const btn=e.target.closest(".filter-groups .pg-filter");
+  const btn=e.target.closest("#coverage-filter-panel .pg-filter");
   if(!btn||!btn.dataset.src)return;
   toggleSrc(btn.dataset.src);
 }});
+
+// Filter modal chrome (#452). Matches the home browse pattern: toggle
+// button opens/closes the panel, outside click closes, X + Collapse
+// buttons close, badge reflects the active filter count. topbar.js's
+// shared observer takes care of portaling to <body> on mobile.
+(function wireCoverageFilterPanel(){{
+  const wrap=document.getElementById("coverage-filter-wrap");
+  const toggle=document.getElementById("coverage-filter-toggle");
+  const panel=document.getElementById("coverage-filter-panel");
+  const badge=document.getElementById("coverage-filter-badge");
+  if(!wrap||!toggle||!panel)return;
+  function setOpen(open){{
+    panel.classList.toggle("open",open);
+    toggle.setAttribute("aria-expanded",String(open));
+  }}
+  toggle.addEventListener("click",e=>{{
+    e.stopPropagation();
+    setOpen(!panel.classList.contains("open"));
+  }});
+  document.addEventListener("click",e=>{{
+    if(!panel.classList.contains("open"))return;
+    if(wrap.contains(e.target)||panel.contains(e.target))return;
+    setOpen(false);
+  }});
+  document.getElementById("coverage-filter-collapse")?.addEventListener("click",e=>{{
+    e.stopPropagation();setOpen(false);
+  }});
+  panel.querySelector(".filter-panel-close")?.addEventListener("click",e=>{{
+    e.stopPropagation();setOpen(false);
+  }});
+  document.getElementById("coverage-filter-clear")?.addEventListener("click",e=>{{
+    e.stopPropagation();
+    activeSrc=new Set(["all"]);
+    document.querySelectorAll("#coverage-filter-panel .pg-filter").forEach(b=>b.classList.toggle("pg-filter--active",b.dataset.src==="all"));
+    const inp=document.getElementById("filter");if(inp)inp.value="";
+    apply();
+  }});
+  window.updateFilterBadge=function(){{
+    if(!badge)return;
+    // Badge counts active non-"all" chips + a text-filter query if present.
+    const nonAll=[...activeSrc].filter(s=>s!=="all").length;
+    const q=(document.getElementById("filter")?.value||"").trim();
+    const count=nonAll+(q?1:0);
+    badge.textContent=String(count);
+    badge.hidden=count===0;
+    toggle.classList.toggle("has-filters",count>0);
+  }};
+}})();
 function onFilter(){{clearTimeout(filterTimer);filterTimer=setTimeout(()=>apply(),200)}}
 function apply(resetPage=true){{
   const q=document.getElementById("filter").value.toLowerCase();
@@ -1845,6 +1913,7 @@ function apply(resetPage=true){{
   if(sortCol>=0)doSortFiltered();
   if(resetPage) page=0;
   render();
+  if(typeof updateFilterBadge==="function")updateFilterBadge();
 }}
 function doSort(c){{
   if(sortCol===c)sortAsc*=-1;else{{sortCol=c;sortAsc=1}}

--- a/scripts/publish-cloudflare.sh
+++ b/scripts/publish-cloudflare.sh
@@ -42,6 +42,12 @@ DATA_BASE="${DATA_BASE:-https://data.proton-pulse.com}"
 # Top-level data files that ship WITH the shell on Pages (everything the site
 # fetches by a bare name, i.e. not under data/). Mirrors the gh-pages deploy's
 # optional-file list. data/ is deliberately excluded -- it goes to R2.
+#
+# coverage.html + data-index.html are pipeline-rendered top-level pages (linked
+# from the Browse nav dropdown). They are NOT in gh-pages-manifest.txt because
+# they do not exist in source -- finalize.py writes them straight into
+# OUTPUT_DIR. Ship them the same way as the JSON blobs so the nav items stop
+# falling back to the SPA marketing page on CF Pages (#447).
 SMALL_DATA=(
   search-index.json search-index-steam-extended.json most_played.json
   recent-reports.json stats.json coverage-summary.json data-versions.json
@@ -51,6 +57,7 @@ SMALL_DATA=(
   scoring-info.json form-schema.json app-id-redirects.json
   pcgamingwiki.json pcgwiki-catalog.json pcgw-id-map.json
   flightless-benchmarks.json flightless-review-queue.json
+  coverage.html data-index.html
 )
 
 log() { echo "[publish-cloudflare] $*"; }

--- a/stats.html
+++ b/stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=9e119a4e">
 <link rel="stylesheet" href="css/shared/topbar.css?v=e911094d">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
-<link rel="stylesheet" href="css/shared/filters.css?v=31464f82">
+<link rel="stylesheet" href="css/shared/filters.css?v=f7ac5796">
 <link rel="stylesheet" href="css/shared/cards.css?v=696d0204">
 <style>
 h1 {

--- a/stats.html
+++ b/stats.html
@@ -762,7 +762,7 @@ h2 {
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script type="module" src="js/lib/log-buffer.js?v=6d7ce577"></script>
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
-<script src="js/lib/topbar.js?v=8c197a9d"></script>
+<script src="js/lib/topbar.js?v=81be41f0"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/stats.html
+++ b/stats.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=9e119a4e">
 <link rel="stylesheet" href="css/shared/topbar.css?v=e911094d">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
-<link rel="stylesheet" href="css/shared/filters.css?v=2af967b6">
+<link rel="stylesheet" href="css/shared/filters.css?v=31464f82">
 <link rel="stylesheet" href="css/shared/cards.css?v=696d0204">
 <style>
 h1 {

--- a/status.html
+++ b/status.html
@@ -117,7 +117,7 @@
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script type="module" src="js/lib/log-buffer.js?v=6d7ce577"></script>
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
-<script src="js/lib/topbar.js?v=8c197a9d"></script>
+<script src="js/lib/topbar.js?v=81be41f0"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/status/main.js?v=98034590"></script>
 

--- a/submit.html
+++ b/submit.html
@@ -26,7 +26,7 @@
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script type="module" src="js/lib/log-buffer.js?v=6d7ce577"></script>
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
-<script src="js/lib/topbar.js?v=8c197a9d"></script>
+<script src="js/lib/topbar.js?v=81be41f0"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <!-- Markdown editor spike (?md=1). Loaded eagerly but only wired when the
      flag is on -- window.markdownit stays unused otherwise. -->

--- a/submit.html
+++ b/submit.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/lookup-inline.css?v=71ca0f75">
 <link rel="stylesheet" href="css/app/game-header.css?v=e93037b2">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
-<link rel="stylesheet" href="css/app/reports.css?v=efaf20fe">
+<link rel="stylesheet" href="css/app/reports.css?v=58f2ef97">
 <link rel="stylesheet" href="css/app/modals.css?v=5e3db937">
 <link rel="stylesheet" href="css/app/home.css?v=7110134a">
 </head>

--- a/system-edit.html
+++ b/system-edit.html
@@ -21,7 +21,7 @@
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script type="module" src="js/lib/log-buffer.js?v=6d7ce577"></script>
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
-<script src="js/lib/topbar.js?v=8c197a9d"></script>
+<script src="js/lib/topbar.js?v=81be41f0"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/terms.html
+++ b/terms.html
@@ -94,7 +94,7 @@
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script type="module" src="js/lib/log-buffer.js?v=6d7ce577"></script>
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
-<script src="js/lib/topbar.js?v=8c197a9d"></script>
+<script src="js/lib/topbar.js?v=81be41f0"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/tests/filterPanelRegressions.test.js
+++ b/tests/filterPanelRegressions.test.js
@@ -440,6 +440,66 @@ describe('game-page render() cleans up portalled panel before re-rendering (#358
   });
 });
 
+describe('game-page confidence range filter (#445)', () => {
+  const gamePageSrc = fs.readFileSync(
+    path.join(__dirname, '..', 'js', 'app', 'components', 'game-page.js'),
+    'utf8'
+  );
+
+  test('shared filters.css defines the .filter-range slider control', () => {
+    const flat = flatten(filtersCss);
+    expect(flat).toMatch(/\.filter-range\s*\{[^}]*flex-direction:\s*column/);
+    expect(flat).toMatch(/\.filter-range-input\s*\{[^}]*accent-color:\s*var\(--accent\)/);
+    expect(flat).toMatch(/\.filter-range-value\s*\{[^}]*font-variant-numeric:\s*tabular-nums/);
+  });
+
+  test('game-page renders paired min/max sliders with 0-100 range and default values', () => {
+    expect(gamePageSrc).toMatch(/id="fConfidenceMin"[^>]*type="range"[^>]*min="0"[^>]*max="100"/);
+    expect(gamePageSrc).toMatch(/id="fConfidenceMax"[^>]*type="range"[^>]*min="0"[^>]*max="100"/);
+    // Value labels are id'd so the input handler can update them without a
+    // full re-render.
+    expect(gamePageSrc).toContain('id="fConfidenceMinValue"');
+    expect(gamePageSrc).toContain('id="fConfidenceMaxValue"');
+  });
+
+  test('defaults are 0 (min) and 100 (max) so the filter is a no-op on load', () => {
+    expect(gamePageSrc).toMatch(/filterConfidenceMin\s*=\s*Number\.isFinite\(persistedFilters\.confidenceMin\)\s*\?\s*persistedFilters\.confidenceMin\s*:\s*0/);
+    expect(gamePageSrc).toMatch(/filterConfidenceMax\s*=\s*Number\.isFinite\(persistedFilters\.confidenceMax\)\s*\?\s*persistedFilters\.confidenceMax\s*:\s*100/);
+  });
+
+  test('filter step is a no-op until the range is narrowed (min>0 OR max<100)', () => {
+    // The filter must NOT drop rows when the sliders are at their defaults --
+    // otherwise every game-page load would filter out configs (no _kind='report')
+    // and every report with score=0 would disappear.
+    expect(gamePageSrc).toMatch(/if\s*\(filterConfidenceMin\s*>\s*0\s*\|\|\s*filterConfidenceMax\s*<\s*100\)/);
+  });
+
+  test('confidence range contributes to the active-filters badge count', () => {
+    // Two places count: initial render and refreshReports. Both must include
+    // the range check so the badge stays accurate as the user drags.
+    const badgeMatches = gamePageSrc.match(/confRangeActive|_confRangeActive/g) || [];
+    expect(badgeMatches.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('input handlers use the "input" event (not "change") for live drag updates', () => {
+    // "change" only fires on pointer release; users expect live feedback while
+    // dragging on both desktop and Steam Deck touch.
+    expect(gamePageSrc).toMatch(/'#fConfidenceMin'\)\?\.addEventListener\('input'/);
+    expect(gamePageSrc).toMatch(/'#fConfidenceMax'\)\?\.addEventListener\('input'/);
+  });
+
+  test('Clear filters resets both sliders and their value labels to defaults', () => {
+    // Clear must reset the JS state, the DOM slider values, and the visible
+    // value labels -- otherwise the UI shows stale numbers after clear.
+    expect(gamePageSrc).toMatch(/filterConfidenceMin\s*=\s*0;/);
+    expect(gamePageSrc).toMatch(/filterConfidenceMax\s*=\s*100;/);
+    expect(gamePageSrc).toMatch(/cmin\.value\s*=\s*'0'/);
+    expect(gamePageSrc).toMatch(/cmax\.value\s*=\s*'100'/);
+    expect(gamePageSrc).toMatch(/cminLbl\.textContent\s*=\s*'0%'/);
+    expect(gamePageSrc).toMatch(/cmaxLbl\.textContent\s*=\s*'100%'/);
+  });
+});
+
 describe('home (app.html browse) -- XL card size parity with index.html', () => {
   // Bug: XL only existed on index.html. Browse view should match.
   test('SIZES array includes xl alongside sm/md/lg', () => {

--- a/tests/filterPanelRegressions.test.js
+++ b/tests/filterPanelRegressions.test.js
@@ -474,6 +474,16 @@ describe('game-page confidence range filter (#445)', () => {
     expect(gamePageSrc).toMatch(/if\s*\(filterConfidenceMin\s*>\s*0\s*\|\|\s*filterConfidenceMax\s*<\s*100\)/);
   });
 
+  test('filter falls back to estimateScore when r.score is missing so it matches the card display (#461)', () => {
+    // report-card.js renders `r.score || estimateScore(r)`. Without the same
+    // fallback in the filter, mirrored ProtonDB reports (no persisted score)
+    // read as 0 and get dropped even when their displayed pill sat well inside
+    // the min/max range. Both the import and the fallback expression are
+    // asserted so a future refactor cannot silently regress either half.
+    expect(gamePageSrc).toContain("import { populateScoringTooltip, pulseTierFromReports, estimateScore }");
+    expect(gamePageSrc).toMatch(/Number\(r\.score\)\s*\|\|\s*estimateScore\(r\)/);
+  });
+
   test('confidence range contributes to the active-filters badge count', () => {
     // Two places count: initial render and refreshReports. Both must include
     // the range check so the badge stays accurate as the user drags.

--- a/tests/filterPanelRegressions.test.js
+++ b/tests/filterPanelRegressions.test.js
@@ -502,8 +502,15 @@ describe('game-page confidence range filter (#445)', () => {
 
 describe('home (app.html browse) -- XL card size parity with index.html', () => {
   // Bug: XL only existed on index.html. Browse view should match.
-  test('SIZES array includes xl alongside sm/md/lg', () => {
-    expect(homeSrc).toContain("const SIZES = ['sm', 'md', 'lg', 'xl']");
+  // #459 -- the SIZES array + apply pipeline live in the shared
+  // js/lib/card-size.js helper so home + index consume one implementation.
+  const cardSizeSrc = fs.readFileSync(
+    path.join(__dirname, '..', 'js', 'lib', 'card-size.js'),
+    'utf8'
+  );
+
+  test('shared helper exports the SIZES list with xl alongside sm/md/lg', () => {
+    expect(cardSizeSrc).toContain("export const CARD_SIZES = ['sm', 'md', 'lg', 'xl']");
   });
 
   test('XL button is rendered with the desktop-only modifier class', () => {

--- a/tests/filterSaveExplicit.test.js
+++ b/tests/filterSaveExplicit.test.js
@@ -73,7 +73,10 @@ describe('#415 slice 1: filter Save is explicit press-to-save', () => {
   test('Clear filters does NOT write to localStorage anymore', () => {
     const idx = src.indexOf("document.getElementById('gp-filter-clear')");
     expect(idx).toBeGreaterThan(0);
-    const slice = src.slice(idx, idx + 1600);
+    // Slice must span the whole handler body. Bumped from 1600 -> 2400 after
+    // #445 added confidence-range slider resets that pushed
+    // _updateSaveButtonState past the original window.
+    const slice = src.slice(idx, idx + 2400);
     expect(slice).not.toContain('localStorage.setItem');
     expect(slice).not.toContain('localStorage.removeItem');
     expect(slice).toContain('_updateSaveButtonState');

--- a/tests/filterSaveExplicit.test.js
+++ b/tests/filterSaveExplicit.test.js
@@ -141,11 +141,17 @@ describe('#415 slice 1: filter Save is explicit press-to-save', () => {
   });
 
   test('CSS ships dirty AND clean state variants for the save button', () => {
-    expect(reportsCss).toContain('.filter-save-btn.is-dirty');
-    expect(reportsCss).toContain('.filter-save-btn.is-clean');
+    // Save button styling moved to shared/filters.css in #458 so the
+    // coverage report inherits it without pulling app-page reports.css.
+    const filtersCss = fs.readFileSync(
+      path.join(__dirname, '..', 'css', 'shared', 'filters.css'),
+      'utf8'
+    );
+    expect(filtersCss).toContain('.filter-save-btn.is-dirty');
+    expect(filtersCss).toContain('.filter-save-btn.is-clean');
     // is-active alias retained so existing DOM inspectors + tests do not
     // suddenly see a missing selector.
-    expect(reportsCss).toContain('.filter-save-btn.is-active');
+    expect(filtersCss).toContain('.filter-save-btn.is-active');
   });
 
   test('button HTML no longer templates a persistFilters conditional class or aria-pressed', () => {

--- a/tests/filterSessionCache.test.js
+++ b/tests/filterSessionCache.test.js
@@ -96,15 +96,17 @@ describe('#415 slice 2b: filter panel drawer animation + accented dropdowns', ()
   test('filter-panel--stack keeps a single display value regardless of .open', () => {
     // Toggling display:block <-> flex on open/close reflows the content
     // instantly, which was the "portrait mode flash" bug during collapse.
-    // Desktop stays flex, mobile stays block (matches shared/filters.css
-    // modal !important). Neither depends on .open.
-    expect(reportsCss).toMatch(/\.filter-panel--stack\s*\{[^}]*display:\s*flex[^}]*flex-direction:\s*row/s);
-    expect(reportsCss).not.toContain('.filter-panel--stack:not(.open)');
-    expect(reportsCss).not.toMatch(/\.filter-panel--stack\.open\s*\{[^}]*display:\s*flex/s);
+    // Desktop stays flex, mobile stays block. Neither depends on .open.
+    // Rules moved from reports.css to shared/filters.css in #458 so the
+    // coverage report can inherit the same modal without pulling in the
+    // whole app-page stylesheet.
+    expect(filtersCss).toMatch(/\.filter-panel--stack\s*\{[^}]*display:\s*flex[^}]*flex-direction:\s*row/s);
+    expect(filtersCss).not.toContain('.filter-panel--stack:not(.open)');
+    expect(filtersCss).not.toMatch(/\.filter-panel--stack\.open\s*\{[^}]*display:\s*flex/s);
     // Mobile keeps block to match the shared modal's !important rule.
-    const mobileIdx = reportsCss.indexOf('@media (max-width: 720px)');
+    const mobileIdx = filtersCss.indexOf('@media (max-width: 720px)');
     expect(mobileIdx).toBeGreaterThan(0);
-    expect(reportsCss.slice(mobileIdx)).toMatch(/\.filter-panel--stack\s*\{[^}]*display:\s*block/s);
+    expect(filtersCss.slice(mobileIdx)).toMatch(/\.filter-panel--stack\s*\{[^}]*display:\s*block/s);
   });
 
   test('filter-item select uses an accent-tinted border so it stands out from the panel', () => {

--- a/tests/gridSize.test.js
+++ b/tests/gridSize.test.js
@@ -5,6 +5,10 @@ const read = (p) => fs.readFileSync(path.join(__dirname, '..', p), 'utf8');
 describe('configurable card size (S/M/L)', () => {
   const homeSrc = read('js/app/components/home.js');
   const cssSrc = read('css/app/home.css');
+  // #459 -- shared card-size helper. The SIZES / SIZE_KEY / DEFAULT_SIZE
+  // constants + savedSize / applyCardSize / initCardSizeToggle helpers live
+  // here so home + index consume one implementation instead of duplicating.
+  const cardSizeSrc = read('js/lib/card-size.js');
 
   test('renders an S/M/L size toggle', () => {
     expect(homeSrc).toContain('id="home-size-toggle"');
@@ -14,11 +18,14 @@ describe('configurable card size (S/M/L)', () => {
   });
 
   test('size is a saved user preference; default picks lg on desktop, md on mobile', () => {
-    expect(homeSrc).toContain("const SIZE_KEY = 'pp:grid-size'");
-    expect(homeSrc).toContain('localStorage.setItem(SIZE_KEY, size)');
-    expect(homeSrc).toContain("window.matchMedia('(min-width: 760px)').matches ? 'lg' : 'md'");
-    expect(homeSrc).toContain('SIZES.includes(s) ? s : _DEFAULT_SIZE');
-    expect(homeSrc).toContain('applyGridSize(_savedSize())');
+    // Constants + storage key live in the shared helper now.
+    expect(cardSizeSrc).toContain("export const CARD_SIZE_KEY = 'pp:grid-size'");
+    expect(cardSizeSrc).toContain("export const CARD_SIZES = ['sm', 'md', 'lg', 'xl']");
+    expect(cardSizeSrc).toContain("window.matchMedia('(min-width: 760px)').matches ? 'lg' : 'md'");
+    expect(cardSizeSrc).toContain('localStorage.setItem(CARD_SIZE_KEY');
+    // Home consumes the helper -- no local duplicate.
+    expect(homeSrc).toContain("import { initCardSizeToggle");
+    expect(homeSrc).toContain('initCardSizeToggle({');
   });
 
   test('list/grid layout is also a saved preference, restored on load', () => {
@@ -28,8 +35,11 @@ describe('configurable card size (S/M/L)', () => {
   });
 
   test('size class is applied to both card lists', () => {
-    expect(homeSrc).toContain("['cards-recent', 'cards-popular'].forEach");
-    expect(homeSrc).toContain('el2.classList.add(`cards--${size}`)');
+    // Home hands both card lists as containers into the shared apply pipeline;
+    // the helper does the classList swap once per container.
+    expect(homeSrc).toContain("document.getElementById('cards-recent')");
+    expect(homeSrc).toContain("document.getElementById('cards-popular')");
+    expect(cardSizeSrc).toContain('el.classList.add(`cards--${size}`)');
   });
 
   test('CSS defines the three card sizes', () => {
@@ -39,9 +49,13 @@ describe('configurable card size (S/M/L)', () => {
   });
 
   test('S/M/L/XL stay enabled in both layouts (tile mode uses size as column width)', () => {
+    // Home delegates the enable/disable to the shared setCardSizeButtonsEnabled
+    // so the same logic can be reused by index and any future consumer.
+    expect(homeSrc).toContain("import { initCardSizeToggle, setCardSizeButtonsEnabled }");
     expect(homeSrc).toContain('function _setSizeEnabled(enabled)');
-    expect(homeSrc).toContain('b.disabled = !enabled');
+    expect(homeSrc).toContain("setCardSizeButtonsEnabled(enabled, '.home-size-btn', 'home-size-toggle')");
     expect(homeSrc).toContain('_setSizeEnabled(true)');
+    expect(cardSizeSrc).toContain('b.disabled = !enabled');
     expect(cssSrc).toContain('.home-size-btn:disabled');
   });
 

--- a/tests/homepageCardUnified.test.js
+++ b/tests/homepageCardUnified.test.js
@@ -30,7 +30,13 @@ describe('homepage cards use the shared renderer + shared grid CSS (#125)', () =
   });
 
   test('homepage container toggles the shared grid classes, not pg-list--', () => {
-    expect(INDEX_JS).toMatch(/classList\.add\(`cards--\$\{size\}`\)/);
+    // The cards--<size> class swap moved into the shared card-size helper in
+    // #459, so INDEX_JS no longer contains the literal template string; the
+    // shared helper does. Assert both: helper owns the swap, and index.js
+    // consumes the helper.
+    const CARD_SIZE_JS = read('js/lib/card-size.js');
+    expect(CARD_SIZE_JS).toMatch(/classList\.add\(`cards--\$\{size\}`\)/);
+    expect(INDEX_JS).toMatch(/import \{ initCardSizeToggle/);
     expect(INDEX_JS).toMatch(/classList\.toggle\('home-cards-tile-mode'/);
     expect(INDEX_JS).not.toMatch(/pg-list--\$\{size\}/);
     expect(INDEX_JS).not.toMatch(/'pg-list--tile-mode'/);

--- a/tests/publishShellWorkflow.test.js
+++ b/tests/publishShellWorkflow.test.js
@@ -141,6 +141,24 @@ describe('publish job wires the deploy correctly', () => {
     expect(RAW).toMatch(/head -c 1 .*grep -qv '<'/);
   });
 
+  test('coverage.html + data-index.html are preserved with a SPA-fallback title check (#447)', () => {
+    // These two pages are pipeline-rendered HTML, linked from the Browse nav.
+    // The JSON preservation loop rejects them because they start with '<'.
+    // The dedicated HTML loop uses a <title> check to reject the marketing
+    // homepage fallback that CF Pages serves when the file is missing --
+    // otherwise a shell push after a missed pipeline deploy would clobber
+    // real content with SPA HTML and hide the breakage until someone clicked
+    // the nav item and got the wrong page.
+    expect(RAW).toContain('HTML_FILES=(coverage.html data-index.html)');
+    expect(RAW).toMatch(/grep -q '<title>Proton Pulse \| Smart Proton Launch Configurations/);
+    // And the SMALL_DATA list in publish-cloudflare.sh must ship them out.
+    const cfSh = fs.readFileSync(
+      path.join(__dirname, '..', 'scripts', 'publish-cloudflare.sh'),
+      'utf8'
+    );
+    expect(cfSh).toMatch(/coverage\.html\s+data-index\.html/);
+  });
+
   test('cert-status.json + cert-history.json are handled via publish-cloudflare.sh', () => {
     // Those two files live under a separate script (preserve-cert-monitor.sh)
     // which publish-cloudflare.sh invokes internally -- so this workflow

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -753,6 +753,55 @@ def test_generate_coverage_report_uses_shared_filter_pill_class(tmp_path):
     assert 'id="source-filter"' in html
 
 
+def test_generate_index_html_loads_data_config_and_uses_dataBase(tmp_path):
+    """data-index master/detail view must prefix data/ fetches with
+    config.dataBase (set to the R2 origin on CF Pages) -- otherwise
+    latest.json fetches hit the SPA fallback and JSON.parse breaks. #451."""
+    keys = {("730", "2024")}
+    generate_index_html(keys, tmp_path)
+    html = (tmp_path / "data-index.html").read_text()
+    # Config lookup + prefixing helpers both ship.
+    assert "fetch('data-config.json'" in html
+    assert 'function dataFileUrl' in html
+    # loadYear routes through dataFileUrl instead of hitting the same origin.
+    assert "dataFileUrl('data/' + appId + '/' + file)" in html
+    # The old direct fetch on 'data/' + appId + '/' + file is gone.
+    assert "fetch('data/' + appId + '/' + file)" not in html
+
+
+def test_generate_index_html_popular_titles_link_via_hash(tmp_path):
+    """Popular-titles list must route through the hash router (#/{id}) instead
+    of a raw data/{id}/latest.json download that 404s on CF Pages. #451."""
+    from scripts.pipeline.metadata import update_app_metadata as _update_meta
+    data_dir = tmp_path / "data"
+    (data_dir / "730").mkdir(parents=True)
+    (data_dir / "730" / "latest.json").write_text('[{"title":"Counter-Strike 2"}]')
+    keys = {("730", "2024")}
+    generate_index_html(keys, tmp_path)
+    html = (tmp_path / "data-index.html").read_text()
+    # Popular titles list an in-app hash link, not a raw JSON path.
+    assert '<a href="#/730">' in html
+    assert '<a href="data/730/latest.json">' not in html
+
+
+def test_generate_coverage_report_indexed_link_routes_via_data_index(tmp_path):
+    """Coverage 'Indexed' cells must link to data-index.html#/{id} instead of
+    a raw data/{id}/ path -- R2 does not auto-serve directory indexes, so a
+    bare data/{id}/ link 404s on CF Pages. #451."""
+    from scripts.pipeline.finalize import generate_coverage_report
+    (tmp_path / "data").mkdir()
+    generate_coverage_report(
+        index_keys=set(),
+        backfilled_keys=set(),
+        data_output_path=tmp_path / "data",
+        output_path=tmp_path,
+        steam_catalog={"730": "CS2"},
+    )
+    html = (tmp_path / "coverage.html").read_text()
+    assert 'data-index.html#/${id}' in html
+    assert '`<a href="data/${id}/">index</a>`' not in html
+
+
 def test_generate_coverage_report_store_column_and_labels(tmp_path):
     """Store column header renders + JS STORE_LABELS lookup ships so each row
     prints a readable store name (Steam / GOG / Epic / PCGamingWiki)."""

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -728,6 +728,43 @@ def test_generate_coverage_report_tags_each_row_with_a_store(tmp_path):
     assert 'bad-appid' not in gog_row
 
 
+def test_generate_coverage_report_uses_shared_filter_panel_modal(tmp_path):
+    """Coverage filter groups must live inside the shared .filter-panel modal
+    chrome (matching home browse) rather than rendering inline. #452.
+
+    Guards the modal wrap, toggle button + badge, mobile header + close X,
+    footer with Collapse + Clear, and that topbar.js's mobile-modal
+    observer (which keys on `.filter-panel.open`) will pick it up."""
+    from scripts.pipeline.finalize import generate_coverage_report
+    (tmp_path / "data").mkdir()
+    generate_coverage_report(
+        index_keys=set(),
+        backfilled_keys=set(),
+        data_output_path=tmp_path / "data",
+        output_path=tmp_path,
+        steam_catalog={"730": "CS2"},
+    )
+    html = (tmp_path / "coverage.html").read_text()
+    # Wrap + toggle + panel with the exact shared classes.
+    assert 'class="filter-wrap"' in html
+    assert 'id="coverage-filter-wrap"' in html
+    assert 'class="filter-toggle-btn"' in html
+    assert 'id="coverage-filter-toggle"' in html
+    assert 'aria-expanded="false"' in html
+    assert 'id="coverage-filter-badge"' in html
+    assert 'class="filter-panel filter-panel--stack"' in html
+    assert 'id="coverage-filter-panel"' in html
+    # Mobile modal chrome (header + close X + footer) mirrors home browse.
+    assert 'class="filter-panel-mobile-header"' in html
+    assert 'class="filter-panel-close"' in html
+    assert 'aria-label="Close filters"' in html
+    assert 'class="filter-panel-footer filter-panel-footer--stack"' in html
+    assert 'id="coverage-filter-collapse"' in html
+    assert 'id="coverage-filter-clear"' in html
+    # No orphan .filter-groups container from the pre-modal layout.
+    assert 'class="filter-groups"' not in html
+
+
 def test_generate_coverage_report_uses_shared_filter_pill_class(tmp_path):
     """Coverage page must use the shared .pg-filter class from css/shared/filters.css
     instead of the old bespoke .toggle chips, so the pill look matches the home +

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -532,7 +532,10 @@ def test_generate_coverage_report_uses_persisted_metadata_for_provenance(tmp_pat
     assert "Official ProtonDB Dump" in html
     assert "Live Backfill" in html
     assert '<div class="value">1</div>' in html
-    assert '"indexed-data",1,1,1,1,"official backfill protondb-signal steam-catalog",1' in html
+    # Schema updated in #450: store field added at index 1, flags gain a
+    # store-<name> prefix so the store filter chips can key on the same row
+    # payload the source filter uses.
+    assert '"steam","Counter-Strike 2","indexed-data",1,1,1,1,"store-steam official backfill protondb-signal steam-catalog",1' in html
 
 
 def test_generate_coverage_report_includes_no_data_filter_and_flag(tmp_path):
@@ -551,7 +554,8 @@ def test_generate_coverage_report_includes_no_data_filter_and_flag(tmp_path):
     html = (tmp_path / "coverage.html").read_text()
     assert 'data-src="no-data"' in html
     assert ">No data<" in html
-    assert '"steam-catalog",0,0,0,1,"steam-catalog no-data",0' in html
+    # Schema updated in #450: store field + store-<name> flag prefix.
+    assert '"steam","Steam-only Game","steam-catalog",0,0,0,1,"store-steam steam-catalog no-data",0' in html
 
 
 def test_generate_coverage_report_persists_filter_state_in_url(tmp_path):
@@ -667,3 +671,105 @@ def test_generate_coverage_report_bad_app_id_flag(tmp_path):
     )
     out = (tmp_path / "coverage.html").read_text()
     assert "bad-appid" in out
+
+
+# #450 -- coverage now spans all stores + uses shared filter pills
+
+def test_generate_coverage_report_includes_gog_epic_pcgwiki_rows(tmp_path):
+    """Non-Steam catalog entries must land in the coverage universe with their
+    catalog titles + store tag so the store filter chips can partition them."""
+    from scripts.pipeline.finalize import generate_coverage_report
+    (tmp_path / "data").mkdir()
+    generate_coverage_report(
+        index_keys=set(),
+        backfilled_keys=set(),
+        data_output_path=tmp_path / "data",
+        output_path=tmp_path,
+        steam_catalog={"730": "Counter-Strike 2"},
+        gog_catalog={"1207658691": "Witcher 3"},
+        epic_catalog={"fortnite": "Fortnite"},
+        pcgwiki_catalog={"pgwiki:half-life-2": "Half-Life 2"},
+    )
+    html = (tmp_path / "coverage.html").read_text()
+    # Each store's canonical id shape appears somewhere in the emitted DATA array.
+    assert '"gog:1207658691"' in html
+    assert '"epic:fortnite"' in html
+    assert '"pgwiki:half-life-2"' in html
+    # Catalog titles carry through so the store rows are readable, not opaque.
+    assert "Witcher 3" in html
+    assert "Fortnite" in html
+    assert "Half-Life 2" in html
+
+
+def test_generate_coverage_report_tags_each_row_with_a_store(tmp_path):
+    """Store field lives at row index 1 so filter chips can key on it without
+    a second lookup. Non-Steam ids must NOT get flagged as bad-appid anymore."""
+    from scripts.pipeline.finalize import generate_coverage_report
+    (tmp_path / "data").mkdir()
+    generate_coverage_report(
+        index_keys=set(),
+        backfilled_keys=set(),
+        data_output_path=tmp_path / "data",
+        output_path=tmp_path,
+        steam_catalog={"730": "CS2"},
+        gog_catalog={"1207658691": "Witcher 3"},
+    )
+    html = (tmp_path / "coverage.html").read_text()
+    # Row payload includes the store literal right after the id.
+    assert '["730","steam"' in html
+    assert '["gog:1207658691","gog"' in html
+    # Flag string carries the store-<name> prefix used by the store filter chip.
+    assert 'store-steam' in html
+    assert 'store-gog' in html
+    # gog:/epic:/pgwiki: are LEGIT ids -- they must not be flagged bad-appid.
+    row_start = html.index('["gog:1207658691","gog"')
+    row_end = html.index(']', row_start)
+    gog_row = html[row_start:row_end + 1]
+    assert 'bad-appid' not in gog_row
+
+
+def test_generate_coverage_report_uses_shared_filter_pill_class(tmp_path):
+    """Coverage page must use the shared .pg-filter class from css/shared/filters.css
+    instead of the old bespoke .toggle chips, so the pill look matches the home +
+    game page filters."""
+    from scripts.pipeline.finalize import generate_coverage_report
+    (tmp_path / "data").mkdir()
+    generate_coverage_report(
+        index_keys=set(),
+        backfilled_keys=set(),
+        data_output_path=tmp_path / "data",
+        output_path=tmp_path,
+        steam_catalog={"730": "CS2"},
+    )
+    html = (tmp_path / "coverage.html").read_text()
+    # New shared classes are present.
+    assert 'class="pg-filter pg-filter--active"' in html
+    assert 'class="pg-filter-group"' in html
+    # Old bespoke toggle class is gone from the filter row markup.
+    assert 'class="toggle active"' not in html
+    assert 'class="toggle"' not in html
+    # And the two dedicated filter groups (Store, Data source) both render.
+    assert 'id="store-filter"' in html
+    assert 'id="source-filter"' in html
+
+
+def test_generate_coverage_report_store_column_and_labels(tmp_path):
+    """Store column header renders + JS STORE_LABELS lookup ships so each row
+    prints a readable store name (Steam / GOG / Epic / PCGamingWiki)."""
+    from scripts.pipeline.finalize import generate_coverage_report
+    (tmp_path / "data").mkdir()
+    generate_coverage_report(
+        index_keys=set(),
+        backfilled_keys=set(),
+        data_output_path=tmp_path / "data",
+        output_path=tmp_path,
+        steam_catalog={"730": "CS2"},
+    )
+    html = (tmp_path / "coverage.html").read_text()
+    # Store column header in the sortable table.
+    assert '>Store</th>' in html
+    # Store label lookup embedded so the render function can convert
+    # short store tokens to human names.
+    assert 'STORE_LABELS' in html
+    for label in ('"Steam"', '"GOG"', '"Epic"', '"PCGamingWiki"'):
+        assert label in html

--- a/tests/test_pipeline_page_head.py
+++ b/tests/test_pipeline_page_head.py
@@ -1,0 +1,93 @@
+"""Regression guards for the shared head/scripts helpers used by the pipeline-
+generated top-level pages (coverage.html, data-index.html). #448.
+
+Motivating incident: both pages linked bare "site.css" + "topbar.js" at the
+repo root -- fine before the CSS/JS reorg, broken after. CF Pages returns the
+SPA fallback for any missing path, so the pages rendered unstyled with no
+topbar and read as "abysmal" design instead of a plain broken-link bug.
+These tests keep the head + tail wiring pinned to the post-reorg paths and
+make sure no future change can quietly reintroduce the bare references.
+"""
+
+from pathlib import Path
+
+from scripts.pipeline import finalize
+
+
+def test_head_links_the_shared_css_bundle():
+    head = "\n".join(finalize._pipeline_page_head("Test Page"))
+    # Match about.html's CSS cascade order exactly. If about.html adds one
+    # (e.g. a new shared/foo.css) the pipeline pages should stay in sync --
+    # this list is the mirror, so an intentional site-wide addition
+    # requires a same-diff update here.
+    assert 'href="css/shared/base.css"' in head
+    assert 'href="css/shared/topbar.css"' in head
+    assert 'href="css/shared/site.css"' in head
+    assert 'href="css/shared/cards.css"' in head
+
+
+def test_head_no_bare_root_paths():
+    head = "\n".join(finalize._pipeline_page_head("Test Page"))
+    assert 'href="site.css"' not in head
+    assert 'src="topbar.js"' not in head
+
+
+def test_head_sets_title_and_viewport_and_dark_scheme():
+    head = "\n".join(finalize._pipeline_page_head("Custom Title"))
+    assert "<title>Custom Title</title>" in head
+    assert 'name="viewport"' in head
+    assert 'content="dark"' in head
+
+
+def test_head_declares_content_security_policy():
+    # Same CSP as about.html so the pipeline pages inherit the site's
+    # security posture. The Supabase CDN + inline styles are both allowed.
+    head = "\n".join(finalize._pipeline_page_head("Test"))
+    assert 'http-equiv="Content-Security-Policy"' in head
+    assert "cdn.jsdelivr.net" in head
+    assert "'unsafe-inline'" in head
+
+
+def test_head_inlines_extra_style_when_provided():
+    head = "\n".join(finalize._pipeline_page_head("Test", extra_style="body{color:red}"))
+    assert "<style>body{color:red}</style>" in head
+
+
+def test_head_omits_style_tag_when_no_extra():
+    head = "\n".join(finalize._pipeline_page_head("Test"))
+    assert "<style>" not in head
+
+
+def test_scripts_load_topbar_and_deps_from_js_lib():
+    scripts = "\n".join(finalize._pipeline_page_scripts())
+    # topbar.js drives the injected banner + nav. Its deps must load first
+    # so the topbar can wire up the user chip and analytics without racing.
+    for src in (
+        "js/lib/supabase-client.js",
+        "js/lib/log-buffer.js",
+        "js/lib/analytics.js",
+        "js/lib/topbar.js",
+        "js/lib/toast.js",
+    ):
+        assert f'src="{src}"' in scripts, f"missing {src} in scripts tail"
+
+
+def test_scripts_no_bare_root_paths():
+    scripts = "\n".join(finalize._pipeline_page_scripts())
+    assert 'src="topbar.js"' not in scripts
+    assert 'src="supabase-client.js"' not in scripts
+
+
+def test_generator_functions_use_the_helpers():
+    """No bare 'site.css' or 'topbar.js' in the generator output paths.
+
+    Read the source of finalize.py and scan every HTML-generating function
+    for the old flat paths. Comments and the docstring in _SHARED_CSS may
+    mention "site.css" as history -- match only the actual output form.
+    """
+    src = Path(finalize.__file__).read_text()
+    assert 'href="site.css"' not in src, "generator still links to root site.css"
+    assert 'src="topbar.js"' not in src, "generator still scripts root topbar.js"
+    assert 'src="supabase-client.js"' not in src, (
+        "generator still scripts root supabase-client.js"
+    )

--- a/tests/test_pipeline_page_head.py
+++ b/tests/test_pipeline_page_head.py
@@ -24,6 +24,9 @@ def test_head_links_the_shared_css_bundle():
     assert 'href="css/shared/topbar.css"' in head
     assert 'href="css/shared/site.css"' in head
     assert 'href="css/shared/cards.css"' in head
+    # #457: filters.css owns .filter-panel + .pg-filter chrome; without it
+    # the coverage page's filter modal rendered inline and unstyled.
+    assert 'href="css/shared/filters.css"' in head
 
 
 def test_head_no_bare_root_paths():

--- a/tests/topbarMobileNav.test.js
+++ b/tests/topbarMobileNav.test.js
@@ -38,4 +38,15 @@ describe('mobile nav drawer accordion', () => {
     // collapseGroups runs inside the open branch of the toggle handler.
     expect(SRC).toMatch(/if \(open\) \{[\s\S]*collapseGroups\(\);/);
   });
+
+  test('opening a folded group auto-closes any other open group (#460)', () => {
+    // Accordion pattern: only one section expanded at a time. Without this
+    // opening Browse then tapping Resources leaves both expanded and pushes
+    // every item off the bottom of the viewport.
+    expect(SRC).toContain(".mnav-group.mnav-open");
+    // Guard the exact contract: on expand (i.e. when the clicked parent is
+    // NOT already expanded), iterate the open groups and reset them.
+    expect(SRC).toMatch(/if\s*\(!expanded\)\s*\{[\s\S]*mnav-open[\s\S]*openGroup\.classList\.remove\(['"]mnav-open['"]\)/);
+    expect(SRC).toMatch(/openBtn\.setAttribute\(['"]aria-expanded['"],\s*['"]false['"]\)/);
+  });
 });


### PR DESCRIPTION
Twelve one-decision-per-commit changes from the last session, ready to promote.

## What's landing

### User-visible

- **Confidence range filter on the per-game report list.** Two sliders (0-100, defaults 0/100) let readers narrow the report list to a confidence band. Follow-up fix wires the filter through the same estimateScore fallback the card display uses so mirrored ProtonDB rows without persisted scores stop disappearing at min > 0. (#445, #461)
- **Coverage report modernized.** Now spans all stores (Steam / GOG / Epic / PCGamingWiki) with per-store counts, adopts the shared .pg-filter pill markup, and wraps the filter groups in the same .filter-panel modal chrome as browse (toggle button + badge + mobile full-viewport modal + Collapse / Clear footer). (#450, #452)
- **Data index single-column row layout.** Easier to scan; master/detail split stays. (#449)
- **Mobile nav accordion.** Opening Browse then Resources auto-collapses the first, matching standard accordion UX. (#460)
- **Data index + Coverage nav items no longer 404-fall-back to the marketing homepage** on CF Pages; both HTML pages are shipped and preserved on every deploy, and the pages themselves link the shared CSS + topbar bundle so they render styled with the site chrome. (#447, #448)
- **Data index master/detail JSON fetch works on CF Pages.** Reads data-config.json to prefix data/ URLs with the R2 origin instead of hitting the same-origin SPA fallback. Coverage's 'Indexed' link routes through the master/detail view for the same reason. (#451)

### Internal

- **Shared card-size helper** (js/lib/card-size.js) so home + app browse consume one implementation of the S/M/L/XL toggle. Both pages call initCardSizeToggle with their own selector; no more diverging fixes. (#459)
- **Shared filter modal styles** relocated from css/app/reports.css to css/shared/filters.css so pipeline-generated pages (coverage, data-index) inherit them without pulling in the whole app-page stylesheet. Browse + game-page unaffected. (#458)
- **_pipeline_page_head / _pipeline_page_scripts helpers** in finalize.py so coverage.html + data-index.html link the same CSS + topbar + CSP as about.html. Regression test asserts no bare root paths regress. (#448, #457)

## Verification

Each change verified live on staging.proton-pulse.com after the corresponding pipeline / publish-shell deploy. Full test suite green: 2643 JS tests + Python coverage tests.

## Commit list

Twelve linear commits, one per logical decision. No merge-commit noise, no iteration chains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)