### PR TITLE
Promote staging: SGDB name-search covers (rate-limited, diagnosed, UA-fixed)

### DIFF
--- a/scripts/pipeline/finalize.py
+++ b/scripts/pipeline/finalize.py
@@ -1497,18 +1497,33 @@ def generate_sgdb_covers(
     asks SteamGridDB for a 460x215 widescreen grid using a title search so
     every game can render in the same widescreen slot on the game page.
 
-    Cached in sgdb-covers-cache.json under the pipeline output dir: entries
-    keep their probed_at date and only refresh after STALE_DAYS to protect
-    the SGDB free tier from unnecessary lookups. Fetch failures are recorded
-    as {"url": null, "probed_at": today} so a broken lookup is remembered
-    for STALE_DAYS instead of retried every run.
+    Rate-limited (#467): each _fetch_sgdb_by_name call sleeps
+    SGDB_REQUEST_DELAY (default 1.1s) between requests to stay under the
+    free-tier per-second cap; retries once on 429 with backoff. Probes are
+    bounded by SGDB_PROBE_CAP per run so a cold cache does not sit in the
+    API for hours -- successive runs pick up where the previous left off
+    via the cache. Prioritises entries that have real data on disk (a
+    data/{id}/ dir exists) so the games most likely to be viewed get
+    covers first.
 
-    Skipped entirely when SGDB_API_KEY is unset (identical to how the Steam
-    SGDB fallback in game_images.py behaves). #466.
+    Cached in sgdb-covers-cache.json under the pipeline output dir. Each
+    entry keeps its probed_at + last_error, so:
+      - Successful lookups skip re-probing until STALE_DAYS.
+      - Rate-limited misses (http_429_gave_up) are NOT cached long -- we
+        retry them next run so a transient rate hit isn't remembered as
+        a permanent miss.
+      - Genuine misses (no_matches) get the full STALE_DAYS TTL.
+
+    Skipped entirely when SGDB_API_KEY is unset. #466 / #467.
     """
-    import os as _os
     from datetime import date as _date, timedelta as _timedelta
-    from .game_images import _fetch_sgdb_by_name, SGDB_API_KEY, STALE_DAYS
+    from .common import app_id_to_dir
+    from .game_images import (
+        _fetch_sgdb_by_name,
+        SGDB_API_KEY,
+        SGDB_PROBE_CAP,
+        STALE_DAYS,
+    )
 
     if not SGDB_API_KEY:
         log("[sgdb-covers] SGDB_API_KEY unset -- skipping name-search fallback")
@@ -1535,39 +1550,79 @@ def generate_sgdb_covers(
         if title:
             targets[f"epic:{ns}"] = title
     for canonical_id, entry in (pcgwiki_catalog or {}).items():
-        # pcgwiki-catalog values are dicts; the GOG/Epic loaders return
-        # {id: title}. Handle both shapes.
         name = entry.get("name") if isinstance(entry, dict) else entry
         if name:
             targets[canonical_id] = name
 
-    log(f"[sgdb-covers] {len(targets):,} non-Steam candidates to consider")
+    # Prioritise entries with data on disk. A game visited by real users has
+    # a data/{id}/ dir; those are the covers that actually get rendered.
+    # #467: rank ranked-first so the SGDB_PROBE_CAP budget goes to the games
+    # that matter first.
+    def _has_data(canonical_id: str) -> bool:
+        return (data_output_path / app_id_to_dir(canonical_id)).is_dir()
+
+    hot = sorted(cid for cid in targets if _has_data(cid))
+    cold = sorted(cid for cid in targets if not _has_data(cid))
+    ordered = hot + cold
+
+    log(
+        f"[sgdb-covers] {len(targets):,} candidates ({len(hot):,} hot / "
+        f"{len(cold):,} cold), cap={SGDB_PROBE_CAP} probes/run"
+    )
 
     covers: dict[str, str] = {}
     probed = 0
     reused = 0
-    for canonical_id in sorted(targets.keys()):
+    rate_limited = 0
+    # First-N error samples so the log surfaces the actual failure mode
+    # instead of the earlier silent "0 hits" mystery.
+    err_samples: list[str] = []
+    for canonical_id in ordered:
         name = targets[canonical_id]
         cached = cache.get(canonical_id)
-        if cached and cached.get("probed_at", "") >= stale_before:
+        # Only skip if the cached entry is fresh AND wasn't a transient
+        # rate-limit failure -- we want to retry those next run.
+        if cached and cached.get("probed_at", "") >= stale_before \
+                and cached.get("last_error") != "http_429_gave_up":
             reused += 1
             if cached.get("url"):
                 covers[canonical_id] = cached["url"]
             continue
-        url = _fetch_sgdb_by_name(name)
-        cache[canonical_id] = {"url": url, "probed_at": today, "name": name}
+        if probed >= SGDB_PROBE_CAP:
+            # Preserve existing cached URL (if any) but don't refresh.
+            if cached and cached.get("url"):
+                covers[canonical_id] = cached["url"]
+            continue
+        url, err = _fetch_sgdb_by_name(name)
+        cache[canonical_id] = {
+            "url": url,
+            "probed_at": today,
+            "name": name,
+            "last_error": err,
+        }
         if url:
             covers[canonical_id] = url
+        else:
+            if err == "http_429_gave_up":
+                rate_limited += 1
+            if len(err_samples) < 5 and err:
+                err_samples.append(f"{canonical_id}={err}")
         probed += 1
-        if probed % 100 == 0:
-            log(f"[sgdb-covers] progress {probed}/{len(targets)} probed ({reused} reused from cache)")
+        if probed % 50 == 0:
+            log(
+                f"[sgdb-covers] progress {probed}/{SGDB_PROBE_CAP} probed "
+                f"({reused} reused, {rate_limited} rate-limited)"
+            )
 
     cache_path.write_text(json.dumps(cache, separators=(",", ":")) + "\n", encoding="utf-8")
     out_file = output_path / "sgdb-covers.json"
     out_file.write_text(json.dumps(covers, separators=(",", ":")) + "\n", encoding="utf-8")
+    if err_samples:
+        log(f"[sgdb-covers] error samples: {', '.join(err_samples)}")
     log(
         f"[sgdb-covers] wrote {len(covers):,} widescreen covers to {out_file} "
-        f"(probed {probed}, reused {reused}, cache size {len(cache):,})"
+        f"(probed {probed}, reused {reused}, rate-limited {rate_limited}, "
+        f"cache size {len(cache):,})"
     )
 
 

--- a/scripts/pipeline/game_images.py
+++ b/scripts/pipeline/game_images.py
@@ -26,6 +26,7 @@ game-images-skip.json entries are migrated into the unified cache automatically.
 import json
 import os
 import time
+import urllib.error
 import urllib.request
 from datetime import date, timedelta
 from pathlib import Path
@@ -62,6 +63,16 @@ STALE_DAYS = 30           # re-probe hot games whose cache entry is older than t
 # id during a run, Steam's storefront is wobbling and we must not flag anything
 # as delisted. Half-Life 2 (220) has been continuously listed since 2004.
 CANARY_APPID = "220"
+# #467: SGDB is a free-tier public API; we must not burst. 1.1s between calls
+# stays under any reasonable per-second cap and leaves headroom for jitter.
+# Retry once on 429 with backoff so a stray rate-limit doesn't get remembered
+# as a permanent None in the cache. SGDB_PROBE_CAP bounds how many entries
+# we newly probe per run so the cold-cache case doesn't sit in the SGDB API
+# for hours -- successive runs chip through the backlog via the cache.
+SGDB_REQUEST_DELAY = float(os.environ.get("SGDB_REQUEST_DELAY", "1.1"))
+SGDB_PROBE_CAP     = int(os.environ.get("SGDB_PROBE_CAP", "500"))
+SGDB_MAX_RETRIES   = 2  # extra tries after the first 429
+SGDB_BACKOFF_BASE  = 2.0  # seconds, doubled per retry
 
 
 def _standard_header_url(app_id: str) -> str:
@@ -155,61 +166,88 @@ def _fetch_sgdb_header(app_id: str, timeout: int = 8) -> str | None:
     return grids[0].get("url")
 
 
-def _fetch_sgdb_by_name(name: str, timeout: int = 8) -> str | None:
-    """Ask SteamGridDB for a header-shaped grid using a title-search fallback.
+def _sgdb_request(url: str, timeout: int = 8) -> tuple[dict | None, str | None]:
+    """One SGDB GET with 429 retry + exponential backoff.
 
-    Used by generate_sgdb_covers for non-Steam games (pgwiki:pw_*, gog:*,
-    epic:*) that have no Steam appId. Uses the autocomplete search endpoint
-    to find the best matching SGDB game id, then reuses SGDB_GRIDS_URL to
-    pull a 460x215 static grid -- same widescreen shape as the Steam
-    header slot on the game page so the frontend can drop it in without a
-    layout change.
+    Returns (body, error_reason). On success: (parsed JSON dict, None).
+    On failure: (None, "http_401" / "http_429" / "http_500" / "timeout" /
+    "network:<detail>"). Callers use the reason string in log lines so
+    the pipeline surfaces the real failure mode instead of a silent None
+    -- #466 shipped generate_sgdb_covers with a bare except that hid
+    every 429 and made SGDB look like it was returning zero matches.
 
-    Returns the URL or None on any failure (empty API key, empty name,
-    no matches, no grids). Silent on error so the outer generator can
-    fall through to whatever the store catalog provided.
+    Sleeps SGDB_REQUEST_DELAY BEFORE the first call so the caller does
+    not have to remember. Retries on 429 with SGDB_BACKOFF_BASE * 2**i
+    backoff, up to SGDB_MAX_RETRIES extra attempts, then gives up.
     """
-    if not SGDB_API_KEY or not name or not name.strip():
-        return None
-    from urllib.parse import quote
+    if not SGDB_API_KEY:
+        return None, "no_api_key"
     hdrs = {"Authorization": f"Bearer {SGDB_API_KEY}"}
-    # Step 1: name search -> take the top match (SGDB ranks by relevance).
-    try:
-        req = urllib.request.Request(
-            SGDB_SEARCH_URL.format(name=quote(name.strip(), safe="")),
-            headers=hdrs,
-        )
-        # URL from hardcoded SGDB_SEARCH_URL constant + URL-encoded name
-        with urllib.request.urlopen(req, timeout=timeout) as r:  # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
-            body = json.loads(r.read())
-    except Exception:
-        return None
+    for attempt in range(SGDB_MAX_RETRIES + 1):
+        time.sleep(SGDB_REQUEST_DELAY)
+        req = urllib.request.Request(url, headers=hdrs)
+        try:
+            # URL comes from a hardcoded SGDB_* format string with URL-quoted args.
+            with urllib.request.urlopen(req, timeout=timeout) as r:  # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
+                return json.loads(r.read()), None
+        except urllib.error.HTTPError as e:
+            if e.code == 429 and attempt < SGDB_MAX_RETRIES:
+                backoff = SGDB_BACKOFF_BASE * (2 ** attempt)
+                log(f"[sgdb] 429 rate-limited, retry {attempt + 1}/{SGDB_MAX_RETRIES} in {backoff:.1f}s")
+                time.sleep(backoff)
+                continue
+            # Final attempt was a 429 -- surface a distinct reason so the
+            # cache knows this is a transient rate-limit (should retry
+            # next run) rather than a real no-hit.
+            if e.code == 429:
+                return None, "http_429_gave_up"
+            return None, f"http_{e.code}"
+        except urllib.error.URLError as e:
+            return None, f"network:{e.reason}"
+        except Exception as e:
+            return None, f"other:{type(e).__name__}"
+    return None, "http_429_gave_up"
+
+
+def _fetch_sgdb_by_name(name: str, timeout: int = 8) -> tuple[str | None, str | None]:
+    """SGDB title search -> best-match game id -> 460x215 grid URL.
+
+    Returns (url, error_reason). See _sgdb_request for the reason strings.
+    Empty API key / empty name short-circuits with a specific reason so
+    the caller can distinguish "we didn't try" from "we tried and got no
+    hit" in logs and cache entries. #467.
+    """
+    if not SGDB_API_KEY:
+        return None, "no_api_key"
+    if not name or not name.strip():
+        return None, "empty_name"
+    from urllib.parse import quote
+    search_url = SGDB_SEARCH_URL.format(name=quote(name.strip(), safe=""))
+    body, err = _sgdb_request(search_url, timeout=timeout)
+    if err:
+        return None, err
     if not body.get("success"):
-        return None
+        return None, "search_success_false"
     matches = body.get("data") or []
     if not matches:
-        return None
+        return None, "no_matches"
     game_id = matches[0].get("id")
     if not game_id:
-        return None
-    # Step 2: pull 460x215 static grids for that game id (same call the
-    # Steam-appId path uses).
-    try:
-        req = urllib.request.Request(SGDB_GRIDS_URL.format(game_id=game_id), headers=hdrs)
-        # URL from hardcoded SGDB_GRIDS_URL constant + validated game_id
-        with urllib.request.urlopen(req, timeout=timeout) as r:  # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
-            body = json.loads(r.read())
-    except Exception:
-        return None
+        return None, "no_game_id"
+    grids_url = SGDB_GRIDS_URL.format(game_id=game_id)
+    body, err = _sgdb_request(grids_url, timeout=timeout)
+    if err:
+        return None, err
     if not body.get("success"):
-        return None
+        return None, "grids_success_false"
     grids = body.get("data") or []
     if not grids:
-        return None
+        return None, "no_grids"
     for g in grids:
         if "png" in (g.get("mime") or "") and g.get("url"):
-            return g["url"]
-    return grids[0].get("url")
+            return g["url"], None
+    first = grids[0].get("url")
+    return (first, None) if first else (None, "no_url_in_grids")
 
 
 def _url_is_ok(url: str, timeout: int = 8) -> bool:

--- a/scripts/pipeline/game_images.py
+++ b/scripts/pipeline/game_images.py
@@ -70,7 +70,11 @@ CANARY_APPID = "220"
 # we newly probe per run so the cold-cache case doesn't sit in the SGDB API
 # for hours -- successive runs chip through the backlog via the cache.
 SGDB_REQUEST_DELAY = float(os.environ.get("SGDB_REQUEST_DELAY", "1.1"))
-SGDB_PROBE_CAP     = int(os.environ.get("SGDB_PROBE_CAP", "500"))
+# Lowered 500 -> 100 so worst-case (2 sleeps per successful lookup) tops out
+# at ~4 min for the SGDB step, well under any implicit runner budget.
+# Successive pipeline runs chip through the backlog via the cache; 100 hot
+# games per run is still ~30k covers over ~5 months of daily runs.
+SGDB_PROBE_CAP     = int(os.environ.get("SGDB_PROBE_CAP", "100"))
 SGDB_MAX_RETRIES   = 2  # extra tries after the first 429
 SGDB_BACKOFF_BASE  = 2.0  # seconds, doubled per retry
 

--- a/scripts/pipeline/game_images.py
+++ b/scripts/pipeline/game_images.py
@@ -136,7 +136,12 @@ def _fetch_sgdb_header(app_id: str, timeout: int = 8) -> str | None:
     """
     if not SGDB_API_KEY:
         return None
-    hdrs = {"Authorization": f"Bearer {SGDB_API_KEY}"}
+    # #467 follow-up: real User-Agent so Cloudflare doesn't 403 us as a bot.
+    hdrs = {
+        "Authorization": f"Bearer {SGDB_API_KEY}",
+        "User-Agent": "proton-pulse-web pipeline (+https://github.com/mdeguzis/proton-pulse-web)",
+        "Accept": "application/json",
+    }
     # Step 1: Steam appId -> SGDB game id.
     try:
         req = urllib.request.Request(SGDB_STEAM_LOOKUP.format(appid=app_id), headers=hdrs)
@@ -186,7 +191,15 @@ def _sgdb_request(url: str, timeout: int = 8) -> tuple[dict | None, str | None]:
     """
     if not SGDB_API_KEY:
         return None, "no_api_key"
-    hdrs = {"Authorization": f"Bearer {SGDB_API_KEY}"}
+    # #467 follow-up: SGDB sits behind Cloudflare which returns 403 for the
+    # default Python urllib User-Agent (bot heuristic). Set a real UA so
+    # search + grids endpoints reach the app server. Verified by curl
+    # returning 401 (auth-shape) with a real UA vs 403 (blocked) without.
+    hdrs = {
+        "Authorization": f"Bearer {SGDB_API_KEY}",
+        "User-Agent": "proton-pulse-web pipeline (+https://github.com/mdeguzis/proton-pulse-web)",
+        "Accept": "application/json",
+    }
     for attempt in range(SGDB_MAX_RETRIES + 1):
         time.sleep(SGDB_REQUEST_DELAY)
         req = urllib.request.Request(url, headers=hdrs)

--- a/tests/test_sgdb_covers.py
+++ b/tests/test_sgdb_covers.py
@@ -1,15 +1,28 @@
-"""generate_sgdb_covers: name-search fallback for non-Steam widescreen covers (#466).
+"""generate_sgdb_covers: rate-limited name-search fallback for non-Steam
+widescreen covers (#466, hardened in #467).
 
 The pipeline asks SteamGridDB for a 460x215 grid using each non-Steam
 game's title so pgwiki:pw_*, gog:*, and epic:* rows can render the same
-widescreen slot as a Steam-header game. Cached in sgdb-covers-cache.json
-so a probed entry only re-hits SGDB after STALE_DAYS.
+widescreen slot as a Steam-header game. Cached in sgdb-covers-cache.json;
+rate-limited to SGDB_REQUEST_DELAY per call; bounded per run by
+SGDB_PROBE_CAP so a cold cache never sits in the API for hours.
 """
 
 import json
 from unittest.mock import patch
 
 from scripts.pipeline import finalize as _finalize
+
+
+def _fake_ok(name, timeout=8):
+    """Return the (url, err) shape _fetch_sgdb_by_name uses."""
+    return (f"https://sgdb.example/{name.replace(' ', '_')}.png", None) if name else (None, "empty_name")
+
+
+def _fake_none(reason):
+    def _inner(name, timeout=8):
+        return (None, reason)
+    return _inner
 
 
 def test_generate_sgdb_covers_writes_empty_when_api_key_missing(tmp_path, monkeypatch):
@@ -22,22 +35,18 @@ def test_generate_sgdb_covers_writes_empty_when_api_key_missing(tmp_path, monkey
         tmp_path / "data",
         gog_catalog={"1207658691": "Witcher 3"},
     )
-    # Skip path writes nothing.
     assert not (tmp_path / "sgdb-covers.json").exists()
     assert not (tmp_path / "sgdb-covers-cache.json").exists()
 
 
 def test_generate_sgdb_covers_probes_every_catalog_and_writes_map(tmp_path, monkeypatch):
-    """Cold cache: every non-Steam id gets probed once, hits go into
-    sgdb-covers.json, cache records probed_at + name for staleness gating."""
+    """Cold cache: every non-Steam id gets probed once (up to the cap), hits
+    go into sgdb-covers.json, cache records probed_at + name + last_error."""
     monkeypatch.setattr("scripts.pipeline.game_images.SGDB_API_KEY", "test-key")
+    monkeypatch.setattr("scripts.pipeline.game_images.SGDB_PROBE_CAP", 500)
     (tmp_path / "data").mkdir()
 
-    def _fake(name, timeout=8):
-        # Non-empty title -> deterministic URL; empty -> None (matches real).
-        return f"https://sgdb.example/{name.replace(' ', '_')}.png" if name else None
-
-    with patch("scripts.pipeline.game_images._fetch_sgdb_by_name", side_effect=_fake):
+    with patch("scripts.pipeline.game_images._fetch_sgdb_by_name", side_effect=_fake_ok):
         _finalize.generate_sgdb_covers(
             tmp_path,
             tmp_path / "data",
@@ -53,65 +62,198 @@ def test_generate_sgdb_covers_probes_every_catalog_and_writes_map(tmp_path, monk
 
     cache = json.loads((tmp_path / "sgdb-covers-cache.json").read_text())
     for cid in ("gog:1207658691", "epic:fortnite", "pgwiki:pw_rl"):
-        assert cid in cache
         assert cache[cid]["url"] is not None
-        assert cache[cid]["probed_at"]  # ISO date string, format checked below
-        assert len(cache[cid]["probed_at"]) == 10  # YYYY-MM-DD
+        assert len(cache[cid]["probed_at"]) == 10
+        # #467: last_error is stored (None on success) so a future run can
+        # differentiate transient rate-limit failures from real misses.
+        assert cache[cid]["last_error"] is None
 
 
 def test_generate_sgdb_covers_reuses_recent_cache_without_probing(tmp_path, monkeypatch):
-    """A fresh cache entry must skip the SGDB call so the free-tier budget
-    is spent only on entries that actually need a refresh."""
+    """A fresh non-rate-limited cache entry must skip the SGDB call so the
+    free-tier budget is spent only on entries that actually need a refresh."""
     from datetime import date
     monkeypatch.setattr("scripts.pipeline.game_images.SGDB_API_KEY", "test-key")
     (tmp_path / "data").mkdir()
     today = date.today().isoformat()
-    # Pre-seed the cache with a fresh entry.
     (tmp_path / "sgdb-covers-cache.json").write_text(json.dumps({
-        "gog:1": {"url": "https://sgdb.example/cached.png", "probed_at": today, "name": "Cached Game"},
+        "gog:1": {"url": "https://sgdb.example/cached.png", "probed_at": today, "name": "Cached Game", "last_error": None},
     }))
     calls = []
 
     def _fake(name, timeout=8):
         calls.append(name)
-        return None
+        return (None, "no_matches")
 
     with patch("scripts.pipeline.game_images._fetch_sgdb_by_name", side_effect=_fake):
         _finalize.generate_sgdb_covers(tmp_path, tmp_path / "data", gog_catalog={"1": "Cached Game"})
 
-    assert calls == []  # cache hit, no fetch
+    assert calls == []
     covers = json.loads((tmp_path / "sgdb-covers.json").read_text())
     assert covers["gog:1"] == "https://sgdb.example/cached.png"
 
 
 def test_generate_sgdb_covers_remembers_negative_lookups(tmp_path, monkeypatch):
-    """A None response caches the failure so we don't retry every run --
-    saves the free-tier budget from repeated dead lookups."""
+    """A no_matches response caches the failure with a real reason so future
+    runs skip it for STALE_DAYS -- saves the free-tier budget."""
     from datetime import date
     monkeypatch.setattr("scripts.pipeline.game_images.SGDB_API_KEY", "test-key")
     (tmp_path / "data").mkdir()
-    with patch("scripts.pipeline.game_images._fetch_sgdb_by_name", return_value=None):
+    with patch("scripts.pipeline.game_images._fetch_sgdb_by_name",
+               side_effect=_fake_none("no_matches")):
         _finalize.generate_sgdb_covers(tmp_path, tmp_path / "data", gog_catalog={"1": "Obscure"})
 
     covers = json.loads((tmp_path / "sgdb-covers.json").read_text())
-    assert "gog:1" not in covers  # No hit means nothing shipped to the frontend
+    assert "gog:1" not in covers
     cache = json.loads((tmp_path / "sgdb-covers-cache.json").read_text())
-    assert cache["gog:1"]["url"] is None  # But cache remembers the miss
+    assert cache["gog:1"]["url"] is None
+    assert cache["gog:1"]["last_error"] == "no_matches"
     assert cache["gog:1"]["probed_at"] == date.today().isoformat()
 
 
+def test_generate_sgdb_covers_retries_rate_limited_cache_entries(tmp_path, monkeypatch):
+    """#467: a transient http_429_gave_up in the cache MUST be retried on the
+    next run, not treated as a persistent no-hit. Otherwise a burst of 429s
+    would poison the cache and the entry would never get a real cover."""
+    from datetime import date
+    monkeypatch.setattr("scripts.pipeline.game_images.SGDB_API_KEY", "test-key")
+    monkeypatch.setattr("scripts.pipeline.game_images.SGDB_PROBE_CAP", 500)
+    (tmp_path / "data").mkdir()
+    today = date.today().isoformat()
+    (tmp_path / "sgdb-covers-cache.json").write_text(json.dumps({
+        "gog:1": {"url": None, "probed_at": today, "name": "Rate Limited Game", "last_error": "http_429_gave_up"},
+    }))
+    with patch("scripts.pipeline.game_images._fetch_sgdb_by_name", side_effect=_fake_ok):
+        _finalize.generate_sgdb_covers(tmp_path, tmp_path / "data", gog_catalog={"1": "Rate Limited Game"})
+
+    covers = json.loads((tmp_path / "sgdb-covers.json").read_text())
+    assert covers["gog:1"] == "https://sgdb.example/Rate_Limited_Game.png"
+    cache = json.loads((tmp_path / "sgdb-covers-cache.json").read_text())
+    assert cache["gog:1"]["last_error"] is None
+
+
+def test_generate_sgdb_covers_respects_probe_cap(tmp_path, monkeypatch):
+    """#467: with SGDB_PROBE_CAP=2, only 2 catalog entries get freshly probed
+    per run even if 5 are eligible. Successive runs chip through the rest
+    via the cache."""
+    monkeypatch.setattr("scripts.pipeline.game_images.SGDB_API_KEY", "test-key")
+    monkeypatch.setattr("scripts.pipeline.game_images.SGDB_PROBE_CAP", 2)
+    (tmp_path / "data").mkdir()
+    with patch("scripts.pipeline.game_images._fetch_sgdb_by_name", side_effect=_fake_ok) as m:
+        _finalize.generate_sgdb_covers(
+            tmp_path, tmp_path / "data",
+            gog_catalog={"1": "A", "2": "B", "3": "C", "4": "D", "5": "E"},
+        )
+    assert m.call_count == 2
+
+
+def test_generate_sgdb_covers_prioritises_games_with_data_on_disk(tmp_path, monkeypatch):
+    """#467: an entry whose data/{id}/ dir already exists is a game users
+    view, so it should get probed before a cold catalog stub."""
+    monkeypatch.setattr("scripts.pipeline.game_images.SGDB_API_KEY", "test-key")
+    monkeypatch.setattr("scripts.pipeline.game_images.SGDB_PROBE_CAP", 1)
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    # Only the hot id has a data dir. app_id_to_dir maps gog:hot -> gog_hot.
+    (data_dir / "gog_hot").mkdir(parents=True)
+    with patch("scripts.pipeline.game_images._fetch_sgdb_by_name", side_effect=_fake_ok) as m:
+        _finalize.generate_sgdb_covers(
+            tmp_path, data_dir,
+            gog_catalog={"hot": "Hot Game", "cold": "Cold Stub"},
+        )
+    assert m.call_count == 1
+    # The hot game (with data on disk) was the one probed, not the cold stub.
+    m.assert_called_once_with("Hot Game")
+
+
 def test_fetch_sgdb_by_name_early_returns_when_key_missing(monkeypatch):
-    """Sanity: the helper itself short-circuits on empty API key, matching
-    _fetch_sgdb_header's contract for the Steam-appId lookup path."""
+    """Sanity: the helper itself short-circuits on empty API key."""
     from scripts.pipeline.game_images import _fetch_sgdb_by_name
     monkeypatch.setattr("scripts.pipeline.game_images.SGDB_API_KEY", "")
-    assert _fetch_sgdb_by_name("Rocket League") is None
+    url, err = _fetch_sgdb_by_name("Rocket League")
+    assert url is None
+    assert err == "no_api_key"
 
 
 def test_fetch_sgdb_by_name_early_returns_when_name_blank(monkeypatch):
-    """Empty / whitespace-only titles never get sent to the API. Otherwise
-    we'd waste a call on the autocomplete endpoint with a nonsense query."""
+    """Empty / whitespace-only titles never get sent to the API."""
     from scripts.pipeline.game_images import _fetch_sgdb_by_name
     monkeypatch.setattr("scripts.pipeline.game_images.SGDB_API_KEY", "test-key")
-    assert _fetch_sgdb_by_name("") is None
-    assert _fetch_sgdb_by_name("   ") is None
+    for blank in ("", "   ", "\t\n"):
+        url, err = _fetch_sgdb_by_name(blank)
+        assert url is None
+        assert err == "empty_name"
+
+
+def test_sgdb_request_retries_once_on_429(monkeypatch):
+    """#467: a single 429 must retry with backoff, not fail immediately.
+    Prevents a transient rate-limit from being remembered as a permanent
+    no-hit."""
+    from scripts.pipeline import game_images as _gi
+    monkeypatch.setattr("scripts.pipeline.game_images.SGDB_API_KEY", "test-key")
+    monkeypatch.setattr("scripts.pipeline.game_images.SGDB_REQUEST_DELAY", 0)
+    monkeypatch.setattr("scripts.pipeline.game_images.SGDB_BACKOFF_BASE", 0)
+    monkeypatch.setattr("scripts.pipeline.game_images.SGDB_MAX_RETRIES", 2)
+
+    call_count = [0]
+
+    class _FakeOk:
+        def read(self):
+            return b'{"success": true, "data": {"id": 42}}'
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def _fake_urlopen(req, timeout=8):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            import urllib.error
+            raise urllib.error.HTTPError(req.full_url, 429, "Too Many Requests", {}, None)
+        return _FakeOk()
+
+    monkeypatch.setattr(_gi.urllib.request, "urlopen", _fake_urlopen)
+    body, err = _gi._sgdb_request("https://sgdb.example/test")
+    assert call_count[0] == 2  # first 429, then success on retry
+    assert err is None
+    assert body["data"]["id"] == 42
+
+
+def test_sgdb_request_gives_up_after_max_retries(monkeypatch):
+    """After SGDB_MAX_RETRIES consecutive 429s we surface http_429_gave_up
+    so the caller (and cache) can distinguish a rate-limit run from a
+    genuine no-hit."""
+    from scripts.pipeline import game_images as _gi
+    monkeypatch.setattr("scripts.pipeline.game_images.SGDB_API_KEY", "test-key")
+    monkeypatch.setattr("scripts.pipeline.game_images.SGDB_REQUEST_DELAY", 0)
+    monkeypatch.setattr("scripts.pipeline.game_images.SGDB_BACKOFF_BASE", 0)
+    monkeypatch.setattr("scripts.pipeline.game_images.SGDB_MAX_RETRIES", 2)
+
+    def _fake_urlopen(req, timeout=8):
+        import urllib.error
+        raise urllib.error.HTTPError(req.full_url, 429, "Too Many Requests", {}, None)
+
+    monkeypatch.setattr(_gi.urllib.request, "urlopen", _fake_urlopen)
+    body, err = _gi._sgdb_request("https://sgdb.example/test")
+    assert body is None
+    assert err == "http_429_gave_up"
+
+
+def test_sgdb_request_surfaces_401_immediately(monkeypatch):
+    """A 401 (auth failure) is NOT retried -- it's a config issue that will
+    not clear on backoff. Caller uses the http_401 reason to log the real
+    problem instead of pretending we got no matches."""
+    from scripts.pipeline import game_images as _gi
+    monkeypatch.setattr("scripts.pipeline.game_images.SGDB_API_KEY", "test-key")
+    monkeypatch.setattr("scripts.pipeline.game_images.SGDB_REQUEST_DELAY", 0)
+
+    def _fake_urlopen(req, timeout=8):
+        import urllib.error
+        raise urllib.error.HTTPError(req.full_url, 401, "Unauthorized", {}, None)
+
+    monkeypatch.setattr(_gi.urllib.request, "urlopen", _fake_urlopen)
+    body, err = _gi._sgdb_request("https://sgdb.example/test")
+    assert body is None
+    assert err == "http_401"


### PR DESCRIPTION
Three commits landing the SteamGridDB name-search cover feature end-to-end.

## What's landing

- **#467** — SGDB name-search rate limiting + real diagnostics + probe cap. Reworks the #466 initial implementation to sleep SGDB_REQUEST_DELAY (default 1.1s) between calls, retry on 429 with backoff, cap probes per run (SGDB_PROBE_CAP), and surface real error reasons (http_401 / http_429_gave_up / no_matches / etc) instead of silently returning None. Cache now records last_error so transient 429s get retried while genuine no-matches are remembered.
- **Lower probe cap** — SGDB_PROBE_CAP default dropped 500 -> 100 (~4 min max for the SGDB step) after two consecutive staging runs got runner-reclaimed at exactly 15 min. Successive pipeline runs chip through the backlog via the cache.
- **User-Agent header** — SGDB sits behind Cloudflare, which 403s the default Python urllib UA as a suspected bot. Adding a real UA (`proton-pulse-web pipeline (+https://github.com/mdeguzis/proton-pulse-web)`) + `Accept: application/json` header restored real responses. Applied to both the existing Steam-appId path (silently 0-hits for a while, same cause) and the new name-search path.

## Verified live on staging

Latest pipeline run (31137095925):
- `sgdb-covers.json` has 15 real widescreen covers (all epic entries this batch — hot-first prioritisation)
- Log samples show clean HTTP behaviour: `no_grids` and `no_matches` reasons instead of the earlier universal `http_403`
- Cache size 100, next run picks up the next 100 hot candidates

Test suite: 2652 JS passing, 12 dedicated Python tests for SGDB (retry/backoff/cache-fresh-vs-rate-limited/probe-cap/priority).

🤖 Generated with [Claude Code](https://claude.com/claude-code)