### PR TITLE
Staging to main: decouple site from ProtonDB + admin flag visibility + assorted sprint work

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=e911094d">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/cards.css?v=1b14a046">
-<link rel="stylesheet" href="css/admin/admin.css?v=46fcb7d7">
+<link rel="stylesheet" href="css/admin/admin.css?v=3b38f2f0">
 </head>
 <body>
 
@@ -93,6 +93,7 @@
               <th>User</th>
               <th>Submitted</th>
               <th>Status</th>
+              <th>Actions</th>
             </tr>
           </thead>
           <tbody id="all-reports-tbody"></tbody>
@@ -380,6 +381,6 @@
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
 <script src="js/lib/topbar.js?v=81be41f0"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/admin/main.js?v=23a73442"></script>
+<script type="module" src="js/admin/main.js?v=7e7be6c0"></script>
 </body>
 </html>

--- a/confidence.html
+++ b/confidence.html
@@ -231,6 +231,6 @@ h1 {
 <script type="module" src="js/lib/log-buffer.js?v=6d7ce577"></script>
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
 
-<script type="module" src="js/confidence/main.js?v=850f0289"></script>
+<script type="module" src="js/confidence/main.js?v=1832e6cb"></script>
 </body>
 </html>

--- a/css/admin/admin.css
+++ b/css/admin/admin.css
@@ -957,9 +957,15 @@
   font-style: italic;
 }
 
-/* Raw field dump inside flag detail */
+/* Raw field dump inside flag detail. Horizontal scroll on the section so
+   long report_key values, JSON blobs, or wide two-column tables never
+   push the page off-screen on mobile -- matches the .admin-table-scroll
+   wrapper the list-view tables use. */
 .flag-raw-section {
   margin-bottom: 20px;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  max-width: 100%;
 }
 .flag-raw-title {
   font-size: 0.7rem;
@@ -994,8 +1000,24 @@
 pre.flag-raw-json {
   margin: 0;
   white-space: pre-wrap;
+  word-break: break-word;
   font-size: 0.75rem;
   color: var(--text-muted, #aaa);
+}
+
+/* Mobile: guarantee horizontal scroll on the flag detail page. Any child
+   that overflows (long report_key column, wide raw-json block) scrolls
+   inside the section, matching the list-view scroll behavior. */
+@media (max-width: 720px) {
+  #tab-flag-detail {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+  #tab-flag-detail #flag-detail-content {
+    /* min-width: 0 lets flex/grid children shrink instead of forcing
+       the parent to expand and clip. */
+    min-width: 0;
+  }
 }
 
 /* Analytics tab */

--- a/game-stats.html
+++ b/game-stats.html
@@ -729,7 +729,7 @@ h1 {
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script type="module" src="js/lib/log-buffer.js?v=6d7ce577"></script>
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
-<script type="module" src="js/game-stats/main.js?v=6e6170d2"></script>
+<script type="module" src="js/game-stats/main.js?v=585afee9"></script>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -184,8 +184,8 @@
             </div>
             <div class="pg-filter-group">
               <span class="pg-filter-group-label">Rating</span>
-              <button class="pg-filter pg-filter--active" id="pg-filter-rated" type="button" aria-pressed="true">Rated <span class="pg-filter-count" id="pg-rated-count">0</span></button>
-              <button class="pg-filter" id="pg-filter-unrated" type="button" aria-pressed="false">Not Rated <span class="pg-filter-count" id="pg-unrated-count">0</span></button>
+              <button class="pg-filter" id="pg-filter-rated" type="button" aria-pressed="false">Rated <span class="pg-filter-count" id="pg-rated-count">0</span></button>
+              <button class="pg-filter pg-filter--active" id="pg-filter-unrated" type="button" aria-pressed="true">Not Rated <span class="pg-filter-count" id="pg-unrated-count">0</span></button>
             </div>
           </div>
         </div>
@@ -225,6 +225,6 @@
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
 <script src="js/lib/topbar.js?v=81be41f0"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
-<script type="module" src="js/index/main.js?v=64b17460"></script>
+<script type="module" src="js/index/main.js?v=6771661e"></script>
 </body>
 </html>

--- a/js/admin/api/allReports.js
+++ b/js/admin/api/allReports.js
@@ -74,7 +74,16 @@ export async function fetchAllReports(session, { search = '', status = 'clean', 
   if (dateFrom) url += `&created_at=gte.${encodeURIComponent(dateFrom)}`;
   if (dateTo)   url += `&created_at=lte.${encodeURIComponent(dateTo + 'T23:59:59')}`;
 
-  const [res, approvalRes] = await Promise.all([
+  // Orphan flag rows -- flagged_reports entries whose report_key does not
+  // resolve back to a live user_configs row (deleted report, account cleanup,
+  // stale CDN mirror). Moderation history is permanent: a flag has to remain
+  // reviewable + countable even if the underlying report is gone. Fetched
+  // whenever the Flagged status is requested (or no filter at all so the
+  // "all statuses" view surfaces them too). See migration
+  // 20260811010000_flagged_reports_include_orphans.sql.
+  const wantOrphans = status === 'flagged' || status === '';
+
+  const [res, approvalRes, orphanRes] = await Promise.all([
     fetch(url, { headers: supabaseHeaders(session) }),
     // Approval rows are keyed by report_id. Existence = approved at least once.
     // The public app additionally compares the stored hash to the row's current
@@ -84,6 +93,13 @@ export async function fetchAllReports(session, { search = '', status = 'clean', 
     fetch(`${SUPABASE_URL}/rest/v1/report_approvals?select=report_id`, {
       headers: supabaseHeaders(session),
     }).catch(() => ({ ok: false })),
+    wantOrphans
+      ? fetch(`${SUPABASE_URL}/rest/v1/rpc/get_orphan_flag_reports`, {
+          method: 'POST',
+          headers: supabaseHeaders(session, { 'Content-Type': 'application/json' }),
+          body: JSON.stringify({ p_app_id: search && /^\d+$/.test(search.trim()) ? search.trim() : null }),
+        }).catch(() => ({ ok: false }))
+      : Promise.resolve({ ok: false }),
   ]);
   if (!res.ok) throw new Error(`Failed to fetch reports: ${res.status}`);
 
@@ -98,9 +114,66 @@ export async function fetchAllReports(session, { search = '', status = 'clean', 
   // Repair the display title at fetch time so admins see the real name.
   await resolveFallbackTitles(rows);
 
-  if (status === 'pending') return rows.filter(r => r.is_pending);
-  if (status === 'clean')   return rows.filter(r => !r.is_pending);
-  return rows;
+  let out;
+  if (status === 'pending')      out = rows.filter(r => r.is_pending);
+  else if (status === 'clean')   out = rows.filter(r => !r.is_pending);
+  else                            out = rows;
+
+  // Merge orphan flags. Synthesize rows in the same shape the render expects,
+  // marked with is_orphan_flag=true so the UI can badge them and route detail
+  // clicks to the Flagged Reports tab (the underlying user_configs row is
+  // gone -- there is no report detail to open, only the flag record).
+  if (wantOrphans && orphanRes && orphanRes.ok) {
+    let orphans = [];
+    try { orphans = await orphanRes.json(); } catch { orphans = []; }
+    // Optional client-side filters that were server-side above.
+    if (appType) orphans = orphans.filter(o => (o.app_type || '') === appType || appType === 'steam');
+    if (dateFrom) orphans = orphans.filter(o => o.flagged_at >= dateFrom);
+    if (dateTo) orphans = orphans.filter(o => o.flagged_at <= dateTo + 'T23:59:59');
+    if (search) {
+      const s = search.trim().toLowerCase();
+      orphans = orphans.filter(o => String(o.app_id || '').includes(s));
+    }
+    const synthetic = orphans.map(o => {
+      // Parse the JS reportKey() format: "<int-epoch>:<gpu[:20]>:<proton[:15]>".
+      // Fills the title cell with what the admin actually cares about (which
+      // GPU + Proton got flagged) instead of a scary "deleted" label. The
+      // report may or may not actually be deleted -- it might just be a stale
+      // CDN mirror snapshot whose backing user_configs row is gone; either
+      // way, the flag is real and the admin needs the details.
+      const parts = String(o.report_key || '').split(':');
+      const gpu = (parts[1] || '').trim();
+      const proton = (parts[2] || '').trim();
+      const titleBits = [];
+      if (gpu) titleBits.push(gpu);
+      if (proton) titleBits.push(proton);
+      const title = titleBits.length ? titleBits.join(' / ') : '(no report details)';
+      return {
+        // Namespace the id so it never collides with a real user_configs.id.
+        // The row-detail path checks is_orphan_flag before treating id as numeric.
+        id: `flag-${o.id}`,
+        app_id: o.app_id,
+        title,
+        source: o.source,
+        app_type: 'steam',
+        client_id: o.reporter_client_id || null,
+        proton_pulse_user_id: null,
+        installation_id: null,
+        rating: null,
+        is_flagged: true,
+        is_hidden: false,
+        is_pending: false,
+        flagged_reason: o.reason_category || o.reason_text || null,
+        flagged_at: o.flagged_at,
+        created_at: o.flagged_at,
+        report_key: o.report_key,
+        reason_text: o.reason_text || null,
+        is_orphan_flag: true,
+      };
+    });
+    out = [...synthetic, ...out];
+  }
+  return out;
 }
 
 // Title was stored as the fallback "App <id>" (or empty) at submit time

--- a/js/admin/api/flagged.js
+++ b/js/admin/api/flagged.js
@@ -43,6 +43,20 @@ export async function fetchFlaggedReports(session, { search, type, dateFrom, dat
 }
 
 
+// Single-row fetch for deep-linking into flag detail from the Reports panel's
+// orphan "Details" button. Same select + shape mapping as fetchFlaggedReports.
+export async function fetchFlaggedReportById(session, id) {
+  const url = `${SUPABASE_URL}/rest/v1/flagged_reports`
+    + `?id=eq.${encodeURIComponent(id)}`
+    + `&select=id,app_id,report_key,source,reason_category,reason_text,status,reporter_client_id,flagged_at,updated_at&limit=1`;
+  const res = await fetch(url, { headers: supabaseHeaders(session) });
+  if (!res.ok) throw new Error(`Fetch flagged report failed: ${res.status}`);
+  const rows = await res.json();
+  if (!rows.length) throw new Error('Flag not found');
+  const r = rows[0];
+  return { ...r, title: `App ${r.app_id}`, flagged_reason: r.reason_category || null, is_hidden: false, _author: null };
+}
+
 export async function updateFlagStatus(session, id, status) {
   const url = `${SUPABASE_URL}/rest/v1/flagged_reports?id=eq.${id}`;
   const res = await fetch(url, {

--- a/js/admin/components/allReports.js
+++ b/js/admin/components/allReports.js
@@ -1,5 +1,5 @@
 import { escapeHtml, fmtDateTime } from '../utils.js?v=2668b2f0';
-import { fetchAllReports, fetchStatusCounts } from '../api/allReports.js?v=b4e046fd';
+import { fetchAllReports, fetchStatusCounts } from '../api/allReports.js?v=62a9ae9f';
 import { formatReportSourceLabel } from '../lib/reportSource.js?v=c366fc24';
 
 // Summary strip of exact per-status counts above the table. Each tile is a
@@ -103,7 +103,18 @@ export async function renderAllReports(session) {
             : `<a class="admin-link" href="app.html#/app/${appId}" target="_blank" title="Open the game's report list">App ${appId}</a>`)
         : 'Unknown';
       const rid    = escapeHtml(String(r.id));
-      const title  = escapeHtml(r.title || '');
+      // Orphan flag rows: flagged_reports entries whose report_key does not
+      // resolve back to a live user_configs row. This can mean the user_configs
+      // row was deleted OR the row is still visible on the site via a stale
+      // CDN mirror snapshot -- we cannot tell from here. Label accordingly:
+      // "no user row" is factually correct; the tooltip explains both cases.
+      // Detail button routes to the Flagged Reports tab (raw flag record +
+      // resolve/dismiss controls) since there is no report-detail row to open.
+      const isOrphan = r.is_orphan_flag === true;
+      const orphanBadge = isOrphan
+        ? '<span class="admin-badge admin-badge--muted" title="No matching user_configs row. Could be a deleted report, a deleted account, or a stale CDN mirror snapshot. The flag details below (GPU / Proton) come from the flag record itself.">no user row</span> '
+        : '';
+      const title  = orphanBadge + escapeHtml(r.title || '');
       // Structural signature detection: a row is only labelled 'plugin' if
       // installation_id is set (the Deck-plugin submit path populates it;
       // the web submit path never does). Rows with source='user' but no
@@ -122,8 +133,18 @@ export async function renderAllReports(session) {
       const flaggedReasonAttr = r.flagged_reason
         ? ` data-flagged-reason="${escapeHtml(String(r.flagged_reason))}"`
         : '';
-      return `<tr data-rid="${rid}" data-pending="${r.is_pending ? '1' : '0'}"${flaggedReasonAttr}>
-        <td><button class="admin-link-btn" data-action="ar-view-detail" data-rid="${rid}">#${rid}</button></td>
+      // Every row gets a Details button in the trailing Actions column so
+      // the Reports panel behaves like every other admin list view. Non-
+      // orphan rows open the standard report-detail via ar-view-detail;
+      // orphan rows open the flag-detail inline via ar-view-flag-detail
+      // (main.js routes the click to loadFlagDetail with back=all-reports
+      // so the admin stays inside the Reports panel context).
+      const detailAction = isOrphan
+        ? `data-action="ar-view-flag-detail" data-flagid="${escapeHtml(String(r.id).replace(/^flag-/, ''))}"`
+        : `data-action="ar-view-detail" data-rid="${rid}"`;
+      const detailsBtn = `<button class="admin-btn admin-btn--ghost admin-btn--sm" ${detailAction}>Details</button>`;
+      return `<tr data-rid="${rid}" data-pending="${r.is_pending ? '1' : '0'}"${flaggedReasonAttr}${isOrphan ? ' data-orphan="1"' : ''}>
+        <td>#${rid}</td>
         <td>${appLink}</td>
         <td>${title}</td>
         <td>${source}</td>
@@ -131,6 +152,7 @@ export async function renderAllReports(session) {
         <td>${userBtn}</td>
         <td>${date}</td>
         <td class="ar-status">${statusBadges(r.is_flagged, r.is_hidden, r.is_pending, r.flagged_reason)}</td>
+        <td>${detailsBtn}</td>
       </tr>`;
     }).join('');
 

--- a/js/admin/main.js
+++ b/js/admin/main.js
@@ -1,7 +1,7 @@
 import { SupaAuth, SUPABASE_URL, SUPABASE_ANON_KEY } from './config.js?v=ffed3d84';
 import { supabaseHeaders, escapeHtml } from './utils.js?v=2668b2f0';
 import { effectivePermissions, hasPermission, canSeeTab, resolveRoleLabel, PERMISSION_LABELS, presetFor, addPermission, removePermission } from './permissions.js?v=7b4e356d';
-import { fetchFlaggedReports, updateFlagStatus, deleteFlaggedReport, fetchFlagReportContent, findPulseConfigId, shadowBanReport, releaseReportContent, deleteReportContent, suppressMirrorReport, unsuppressMirrorReport, fetchReportState } from './api/flagged.js?v=9359a45e';
+import { fetchFlaggedReports, fetchFlaggedReportById, updateFlagStatus, deleteFlaggedReport, fetchFlagReportContent, findPulseConfigId, shadowBanReport, releaseReportContent, deleteReportContent, suppressMirrorReport, unsuppressMirrorReport, fetchReportState } from './api/flagged.js?v=78d2a857';
 import { renderFlagged, renderFlagDetail } from './components/flagged.js?v=5e2c6b60';
 import { fetchBannedUsers, banUser, unbanUser } from './api/banned.js?v=0d6ec118';
 import { renderBanned } from './components/banned.js?v=7bb95620';
@@ -24,8 +24,8 @@ import { renderApiExplorer } from './components/api-explorer.js?v=93bf51e6';
 import { renderGameManager } from './components/gameManager.js?v=74dfb888';
 import { renderLoggingTab } from './components/logging.js?v=ccf92cf8';
 import { renderDeploymentsTab } from './components/deployments.js?v=ce9fc002';
-import { renderAllReports, updateAllReportsRow, renderAllReportsDetail } from './components/allReports.js?v=b70317a6';
-import { patchReportFlags, fetchReportById } from './api/allReports.js?v=b4e046fd';
+import { renderAllReports, updateAllReportsRow, renderAllReportsDetail } from './components/allReports.js?v=5d8cf789';
+import { patchReportFlags, fetchReportById } from './api/allReports.js?v=62a9ae9f';
 import { approveReport } from './api/pending.js?v=84292a58';
 
 // ---------------------------------------------------------------------------
@@ -630,7 +630,7 @@ function wireEvents() {
     const action = btn.dataset.action;
 
     if (action === 'back-to-flagged') {
-      activateTab('flagged');
+      activateTab('all-reports');
       return;
     }
 
@@ -668,7 +668,7 @@ function wireEvents() {
       try {
         await deleteFlaggedReport(currentSession, id);
         flaggedRows = flaggedRows.filter(r => String(r.id) !== id);
-        activateTab('flagged');
+        activateTab('all-reports');
         window.ppToast?.success('Flag entry deleted.');
       } catch (err) {
         btn.disabled = false;
@@ -745,6 +745,22 @@ function wireEvents() {
       const rid = btn.dataset.rid;
       if (!rid) return;
       loadReportDetail(rid);
+      return;
+    }
+
+    // Orphan-flag Details button on the Reports panel. Fetch the raw
+    // flagged_reports row and hand it to loadFlagDetail so the admin sees
+    // the same detail view they would from a live report -- without ever
+    // leaving the Reports panel context.
+    if (action === 'ar-view-flag-detail') {
+      const flagid = btn.dataset.flagid;
+      if (!flagid) return;
+      try {
+        const row = await fetchFlaggedReportById(currentSession, flagid);
+        await loadFlagDetail(row);
+      } catch (e) {
+        console.error('[all-reports] flag detail fetch failed', e);
+      }
     }
   });
 
@@ -896,7 +912,7 @@ function wireEvents() {
   // dropdown stayed blank.
   window.addEventListener('popstate', e => {
     if (!document.getElementById('tab-user-detail').hidden) activateTab(userDetailReturnTab);
-    else if (!document.getElementById('tab-flag-detail').hidden) activateTab('flagged');
+    else if (!document.getElementById('tab-flag-detail').hidden) activateTab('all-reports');
     else if (!document.getElementById('tab-report-detail').hidden) activateTab('all-reports');
     else if (!document.getElementById('tab-boxart-detail').hidden) activateTab('boxart');
     else {
@@ -1204,8 +1220,9 @@ async function init() {
         return;
       }
     } catch (_) {}
-    // flagid present but no cached row - fall through to flagged tab
-    activateTab('flagged', { updateUrl: false });
+    // flagid present but no cached row - fall through to the Reports panel
+    // (Flagged tab was removed; orphan flags now surface in the Reports list).
+    activateTab('all-reports', { updateUrl: false });
     return;
   }
 

--- a/js/app/api/protondb.js
+++ b/js/app/api/protondb.js
@@ -19,13 +19,32 @@ export async function fetchCdn(appId) {
     const url = await dataUrl(`data/${appIdToDir(appId)}/latest.json`);
     const r = await fetch(url);
     if (!r.ok) return [];
-    return await r.json();
+    const rows = await r.json();
+    if (!Array.isArray(rows)) return [];
+    // Decoupled from ProtonDB (#474): archive rows still live in data/ but
+    // must not surface as report cards. The live "Check ProtonDB" button
+    // still works because it goes through fetchProtonDbLive, not fetchCdn.
+    return rows.filter(row => row && (row.source || '').toLowerCase() === 'pulse');
   } catch { return []; }
 }
 
 // Session cache for user-triggered live ProtonDB checks. Keyed by appId so
 // repeat visits within the session skip the network hit without auto-fetching.
 export const _protonDbLiveCache = new Map();
+
+// Cache-only lookup for game-page render (#474). Returns the previously
+// fetched live summary for this session without hitting the network. Used
+// after a button click has populated the cache and re-triggered a render;
+// on a cold load returns [], so the game page renders as pulse-only.
+/**
+ * Read the ProtonDB live cache for a game without triggering a fetch.
+ * @param {string|number} appId
+ * @returns {Array<object>} Cached summary or empty array.
+ */
+export function readProtonDbLiveCache(appId) {
+  const cached = _protonDbLiveCache.get(String(appId));
+  return Array.isArray(cached) ? cached : [];
+}
 
 // ProtonDB's summaries API only allows its own origin (CORS), so the browser
 // cannot fetch it directly from our static site. We go through the

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -6,7 +6,7 @@ import { populateScoringTooltip, pulseTierFromReports, estimateScore } from '../
 import { computeCompatTrend, computeConfidence, RECENT_DAYS, PRIOR_WINDOW_DAYS } from '../../lib/scoring/gameStats.js?v=6a63af50';
 import { getWebClientId } from '../../shared/submit.js?v=ba876a15';
 import { fetchAppDepotInfo, fetchAppMetadata, fetchAppNews, fetchDeckStatusForApp, fetchMinRequirements, fetchLinuxNativeSupport } from '../api/deck-status.js?v=0bbdc652';
-import { fetchCdn, fetchProtonDbLive } from '../api/protondb.js?v=65bc2638';
+import { fetchCdn, fetchProtonDbLive, readProtonDbLiveCache } from '../api/protondb.js?v=b7ff6a75';
 import { readSharedField, writeShared, clearShared, isEnabled as isSharedEnabled } from '../../shared/filters-shared.js?v=2d441093';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=3aeaaba2';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=aba6619f';
@@ -870,11 +870,13 @@ export async function renderGamePage(appId) {
     safeFetch(() => fetchUserVotes(appId), 'fetchUserVotes', {}),
     safeFetch(() => fetchConfigPlaytimeTotals(appId), 'fetchConfigPlaytimeTotals', []),
     safeFetch(() => _fetchReportModeration(appId), 'reportModeration', new Set()),
-    // Auto-fetch the ProtonDB live summary on every page load so aggregate
-    // stats (tier + total) stay accurate even when our CDN mirror is sparse
-    // or missing entirely (#219). The proxy is cached per-appId per-session
-    // so re-renders don't re-hit the network.
-    safeFetch(() => fetchProtonDbLive(appId), 'fetchProtonDbLive', []),
+    // Decoupled from ProtonDB (#474): no auto-fetch. If the user clicked the
+    // "Check ProtonDB Live" button on a stub page (or in a prior session
+    // load) the cache is warm and readProtonDbLiveCache returns it; otherwise
+    // this is [] and the aggregate / tier stay Pulse-only. Auto-fetching
+    // here was what surfaced the "moderate confidence via ProtonDB live"
+    // headline on pages we intended to render Pulse-only.
+    safeFetch(async () => readProtonDbLiveCache(appId), 'readProtonDbLiveCache', []),
   ]);
 
   // Drop ProtonDB mirror reports an admin has shadow-banned or deleted. Pulse

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -723,10 +723,15 @@ export async function renderHomePage() {
             return (a.title || '').localeCompare(b.title || '');
           });
       } else {
-        // Build the candidate pool from the tier selection. Rated games show by
-        // default; the unrated catalog games (no reports yet) only appear when
-        // "Not Rated Yet" (or "All") is selected, so they stay hidden otherwise.
-        const wantUnrated = tierSel.has('all') || tierSel.has('unrated');
+        // Build the candidate pool from the tier selection. Empty selection
+        // (no tier filter applied) shows every popular Steam game regardless
+        // of whether it has Pulse reports yet -- that is the default browse
+        // experience. Unrated games are hidden only when the user has picked
+        // one or more specific rated tiers (e.g. "gold" only). See #474: with
+        // ProtonDB decoupled, most popular games are "pending" until Pulse
+        // reports catch up, so hiding them by default emptied the panel.
+        const noTierFilter = tierSel.size === 0 || tierSel.has('all');
+        const wantUnrated = noTierFilter || tierSel.has('unrated');
         const onlyUnrated = tierSel.size === 1 && tierSel.has('unrated');
         const pool = [
           ...(onlyUnrated ? [] : ratedGames),

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=852c9d97';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=003f23c0';
-import { renderGamePage } from './game-page.js?v=af4e7112';
+import { renderGamePage } from './game-page.js?v=62bf4b28';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId, fetchDataWithProdFallback } from '../config.js?v=a75604f5';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=4630c3d5';
 import { renderGameCard } from '../lib/card.js?v=db950b95';

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,7 +1,7 @@
 // router (entry) for the app page. Relocated from app.js.
 
 import { pcgwSlugToPwId } from '../lib/app-id.js?v=6159afa9';
-import { renderGamePage } from './components/game-page.js?v=af4e7112';
+import { renderGamePage } from './components/game-page.js?v=62bf4b28';
 import { renderHomePage } from './components/home.js?v=7b74784f';
 import { renderSearchPage } from './components/search.js?v=091f940b';
 

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -2,7 +2,7 @@
 
 import { pcgwSlugToPwId } from '../lib/app-id.js?v=6159afa9';
 import { renderGamePage } from './components/game-page.js?v=62bf4b28';
-import { renderHomePage } from './components/home.js?v=7b74784f';
+import { renderHomePage } from './components/home.js?v=5c701273';
 import { renderSearchPage } from './components/search.js?v=091f940b';
 
 export function getRoute() {

--- a/js/confidence/main.js
+++ b/js/confidence/main.js
@@ -10,7 +10,7 @@ import { appIdToDir } from '../lib/app-id.js?v=6159afa9';
 import { computeConfidence } from '../lib/scoring/gameStats.js?v=6a63af50';
 import { dataUrl } from '../lib/data-url.js?v=0de73aed';
 import { getGamesByIds } from '../app/api/search-games.js?v=0e14d3ff';
-import { fetchProtonDbLive } from '../app/api/protondb.js?v=65bc2638';
+import { readProtonDbLiveCache } from '../app/api/protondb.js?v=b7ff6a75';
 import { fetchNativeReports } from '../app/api/supabase.js?v=3aeaaba2';
 import { mergeReportsById } from '../app/utils.js?v=4630c3d5';
 
@@ -966,7 +966,8 @@ import { mergeReportsById } from '../app/utils.js?v=4630c3d5';
     const [cdnReports, nativeReports, liveFetched, indexHit, scoringData] = await Promise.all([
       loadGame(appId, reportYear),
       wantsPerReport ? Promise.resolve([]) : fetchNativeReports(appId).catch(() => []),
-      wantsPerReport ? Promise.resolve([]) : fetchProtonDbLive(appId).catch(() => []),
+      // Decoupled from ProtonDB (#474): cache-only read; no auto-fetch.
+      wantsPerReport ? Promise.resolve([]) : Promise.resolve(readProtonDbLiveCache(appId)),
       // #437: one id via the batch API instead of the 11.8MB blob.
       getGamesByIds([appId]).then(m => m.get(String(appId)) || null),
       wantsPerReport ? loadScoringInfo() : Promise.resolve(null),

--- a/js/game-stats/main.js
+++ b/js/game-stats/main.js
@@ -277,28 +277,13 @@ import { detectGpuArch } from '../lib/gpu-arch-detector.js?v=b4fbb7ef';
     } catch { return []; }
   }
 
-  // ProtonDB live summary via the same edge fn the game page uses. Gives us
-  // an aggregate tier + total count so the stats page can still say something
-  // useful when our CDN mirror has no reports for a game (#219 follow-up).
-  const PROTONDB_LIVE_URL =
-    'https://ilsgdshkaocrmibwdezk.supabase.co/functions/v1/protondb-summary';
-  async function loadProtonDbLive(appId) {
-    try {
-      const r = await fetch(`${PROTONDB_LIVE_URL}?appId=${encodeURIComponent(appId)}`, { headers: { Accept: 'application/json' } });
-      if (!r.ok) {
-        console.debug(`[game-stats] ProtonDB live check not ok | appId=${appId} status=${r.status} source=protondb-summary-proxy`);
-        return null;
-      }
-      const data = await r.json();
-      if (!data || data.found === false || !data.tier) {
-        console.debug(`[game-stats] ProtonDB live check empty | appId=${appId} source=protondb-summary-proxy`);
-        return null;
-      }
-      return { tier: data.tier, total: data.total || 0, score: data.score || 0, confidence: data.confidence || '' };
-    } catch (e) {
-      console.debug(`[game-stats] ProtonDB live check failed | appId=${appId} error=${e.message} source=protondb-summary-proxy`);
-      return null;
-    }
+  // Decoupled from ProtonDB (#474): stats page no longer auto-fetches the
+  // ProtonDB live summary. The edge-function proxy still exists (see
+  // fetchProtonDbLive in js/app/api/protondb.js) and remains available for
+  // the game page's user-triggered stub button; the stats page just does
+  // not participate in that auto-injection anymore.
+  async function loadProtonDbLive(_appId) {
+    return null;
   }
 
   // --- header rendering ---

--- a/js/index/main.js
+++ b/js/index/main.js
@@ -207,7 +207,11 @@ import { initCardSizeToggle, setCardSizeButtonsEnabled } from '../lib/card-size.
     // Row target is 5 complete rows on every viewport (page size = cols * rows,
     // so the grid always ends on a whole row and stays even across S/M/L/XL).
     // See pageSizeForFullRows + targetRowsForViewport in lib/tile-pad.js.
-    const state = { rated: true, unrated: false };
+    // Default flipped from rated -> unrated (#474). With ProtonDB decoupled,
+    // rated=Pulse-only means the rated bucket is ~0 while every popular
+    // Steam game sits under "Not Rated" until Pulse volume catches up. Start
+    // on Not Rated so the page renders games instead of an empty grid.
+    const state = { rated: false, unrated: true };
     let shownCount = pageSizeForFullRows(list, targetRowsForViewport());
     // Guards a one-shot re-render when the grid CSS hasn't applied yet on the
     // very first paint (see renderPopular). Without it the column count reads 1

--- a/scripts/pipeline/finalize.py
+++ b/scripts/pipeline/finalize.py
@@ -866,10 +866,11 @@ def _compute_game_summary(app_dir: Path, now_ts: float | None = None) -> tuple[s
             if not isinstance(r, dict):
                 continue
             source = (r.get("source") or "protondb").lower()
-            if source == "pulse":
-                pulse_count += 1
-            else:
-                protondb_count += 1
+            if source != "pulse":
+                # Decoupled from ProtonDB (#474): archive rows still sit in
+                # data/ but must not contribute to tiers, counts, or trend.
+                continue
+            pulse_count += 1
             rating = (r.get("rating") or "").lower()
             if rating in _RATING_SCORES:
                 total_score += _RATING_SCORES[rating]
@@ -931,10 +932,22 @@ def generate_recent_reports(data_output_path: Path, output_path: Path, limit: in
         if not year_files:
             continue
         try:
-            rows = json.loads(year_files[-1].read_text(encoding="utf-8"))
-            if not isinstance(rows, list):
-                continue
-            latest_ts = max((int(r.get("timestamp", 0)) for r in rows if r.get("timestamp")), default=0)
+            # Decoupled from ProtonDB (#474): recent-reports only surfaces
+            # games with actual pulse submissions. Legacy ProtonDB rows in
+            # data/ must not resurrect stale games onto the home page.
+            latest_ts = 0
+            for f in year_files:
+                rows = json.loads(f.read_text(encoding="utf-8"))
+                if not isinstance(rows, list):
+                    continue
+                for r in rows:
+                    if not isinstance(r, dict):
+                        continue
+                    if (r.get("source") or "protondb").lower() != "pulse":
+                        continue
+                    ts = int(r.get("timestamp", 0) or 0)
+                    if ts > latest_ts:
+                        latest_ts = ts
             if not latest_ts:
                 continue
             last_date = datetime.fromtimestamp(latest_ts, tz=timezone.utc).strftime("%Y-%m-%d")

--- a/scripts/pipeline/stats.py
+++ b/scripts/pipeline/stats.py
@@ -324,6 +324,16 @@ def compute_stats(data_output_path: Path) -> dict[str, Any]:
     for app_id, year, reports in _iter_year_files(data_output_path):
         if not reports:
             continue
+        # Decoupled from ProtonDB (#474): only pulse rows count toward any
+        # aggregate. Games with zero pulse rows do not appear in per_game,
+        # games_with_any_report, or the leaderboards -- they might as well
+        # not exist for stats purposes.
+        pulse_rows = [
+            r for r in reports
+            if isinstance(r, dict) and (r.get("source") or "protondb").lower() == "pulse"
+        ]
+        if not pulse_rows:
+            continue
         games_with_any_report.add(app_id)
         # cache the first non-empty title we see for this app + accumulators for
         # newest report year (used for stale-borked detection later) and tallies
@@ -342,9 +352,7 @@ def compute_stats(data_output_path: Path) -> dict[str, Any]:
         if year_int > per_game[app_id]["newest_year"]:
             per_game[app_id]["newest_year"] = year_int
 
-        for r in reports:
-            if not isinstance(r, dict):
-                continue
+        for r in pulse_rows:
             total += 1
 
             src = normalize_source(r)

--- a/supabase/migrations/20260810160000_sync_user_configs_is_flagged.sql
+++ b/supabase/migrations/20260810160000_sync_user_configs_is_flagged.sql
@@ -1,0 +1,85 @@
+-- Sync user_configs.is_flagged with flagged_reports state so the admin
+-- Reports panel's "Flagged" filter + status counts (which query
+-- user_configs.is_flagged) reflect every flag, not just owner self-flags.
+--
+-- Problem: js/app/api/supabase.js::flagReport posts to submit_flag (a
+-- SECURITY DEFINER RPC that anyone can hit) AND best-effort PATCHes
+-- user_configs.is_flagged. The PATCH is blocked by RLS for non-owners,
+-- which is basically every third-party flag, so is_flagged stays false
+-- on the underlying row. Admin panel then shows 0 flagged even when the
+-- flagged_reports queue is populated. See issue tied to #474 -- surfaced
+-- while testing a Wukong flag that never appeared in the admin view.
+--
+-- Fix: DB trigger fires on flagged_reports INSERT and on UPDATE of
+-- status. SECURITY DEFINER so it can flip the bit on any user's row.
+-- Match is by reconstructing the JS reportKey() format from user_configs
+-- columns: "<int(epoch(created_at))>:<gpu[:20]>:<proton_version[:15]>".
+-- Only pulse-sourced flags map to a user_configs row; protondb-sourced
+-- flags mirror archive data and have no matching row, so the trigger
+-- no-ops for them.
+--
+-- Column scope: the trigger touches ONLY user_configs.is_flagged. No
+-- other column is read or written by the sync path.
+
+create or replace function public.sync_user_configs_is_flagged_from_flagged_reports()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  target_id bigint;
+  is_open   boolean := coalesce(new.status, 'open') = 'open';
+begin
+  -- Only pulse flags map back to a user_configs row. ProtonDB-sourced
+  -- flags stay in flagged_reports alone.
+  -- The flag button carries whatever `source` the report object had at
+  -- render time. CDN-mirrored pulse rows come through as 'pulse' (from
+  -- pulse.py's merge); native-fetched pulse rows carry the raw
+  -- user_configs.source ('plugin', 'web-linux', 'proton-pulse', ...).
+  -- Anything not 'protondb' is a candidate for a user_configs match.
+  if lower(coalesce(new.source, '')) = 'protondb' then
+    return new;
+  end if;
+
+  select id into target_id
+    from public.user_configs
+   where app_id = new.app_id
+     and format('%s:%s:%s',
+                floor(extract(epoch from created_at))::bigint::text,
+                left(coalesce(gpu, ''), 20),
+                left(coalesce(proton_version, ''), 15)) = new.report_key
+   limit 1;
+
+  if target_id is null then
+    return new;
+  end if;
+
+  update public.user_configs
+     set is_flagged = is_open
+   where id = target_id
+     and is_flagged is distinct from is_open;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_sync_user_configs_is_flagged on public.flagged_reports;
+create trigger trg_sync_user_configs_is_flagged
+  after insert or update of status on public.flagged_reports
+  for each row
+  execute function public.sync_user_configs_is_flagged_from_flagged_reports();
+
+-- Backfill: for every currently-open non-protondb flag, set is_flagged
+-- on the matching user_configs row. Same match logic as the trigger.
+update public.user_configs uc
+   set is_flagged = true
+  from public.flagged_reports fr
+ where lower(coalesce(fr.source, '')) <> 'protondb'
+   and coalesce(fr.status, 'open') = 'open'
+   and fr.app_id = uc.app_id
+   and format('%s:%s:%s',
+              floor(extract(epoch from uc.created_at))::bigint::text,
+              left(coalesce(uc.gpu, ''), 20),
+              left(coalesce(uc.proton_version, ''), 15)) = fr.report_key
+   and uc.is_flagged is distinct from true;

--- a/supabase/migrations/20260811010000_flagged_reports_include_orphans.sql
+++ b/supabase/migrations/20260811010000_flagged_reports_include_orphans.sql
@@ -1,0 +1,107 @@
+-- Extend get_report_status_counts + expose orphan flags to the admin Reports
+-- panel so a flag is never invisible just because its underlying user_configs
+-- row was deleted (account cleanup, admin delete, CDN mirror row without a
+-- matching pulse submission, etc.). Moderation history is a permanent record;
+-- an orphan flag must still be reviewable, dismissable, and countable.
+--
+-- What counts as an orphan: any flagged_reports row that is NOT protondb-sourced
+-- and whose report_key does not reconstruct to a live user_configs row (same
+-- match key the trigger uses -- see 20260810160000_sync_user_configs_is_flagged).
+-- ProtonDB-sourced flags are omitted; those live in the standalone Flagged
+-- Reports tab only, per the ProtonDB decouple (#474).
+
+-- get_report_status_counts now sums orphan flags into the `flagged` bucket and
+-- adds their count to `total`. approved/pending/hidden are unchanged.
+create or replace function public.get_report_status_counts()
+returns table (
+  total    bigint,
+  flagged  bigint,
+  hidden   bigint,
+  approved bigint,
+  pending  bigint
+)
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+begin
+  if not public.current_user_has_permission('view_analytics') then
+    raise exception 'view_analytics permission required';
+  end if;
+
+  return query
+  with base as (
+    select
+      uc.is_flagged,
+      uc.is_hidden,
+      exists (select 1 from report_approvals ra where ra.report_id = uc.id) as is_approved
+    from user_configs uc
+  ),
+  orphan_flags as (
+    select count(*)::bigint as n
+    from flagged_reports fr
+    where lower(coalesce(fr.source, '')) <> 'protondb'
+      and coalesce(fr.status, 'open') = 'open'
+      and not exists (
+        select 1 from user_configs uc
+        where uc.app_id = fr.app_id
+          and format('%s:%s:%s',
+                     floor(extract(epoch from uc.created_at))::bigint::text,
+                     left(coalesce(uc.gpu, ''), 20),
+                     left(coalesce(uc.proton_version, ''), 15)) = fr.report_key
+      )
+  )
+  select
+    (count(*) + (select n from orphan_flags))::bigint                                    as total,
+    (count(*) filter (where is_flagged) + (select n from orphan_flags))::bigint          as flagged,
+    count(*) filter (where is_hidden)::bigint                                            as hidden,
+    count(*) filter (where not is_flagged and not is_hidden and is_approved)::bigint     as approved,
+    count(*) filter (where not is_flagged and not is_hidden and not is_approved)::bigint as pending
+  from base;
+end;
+$$;
+
+grant execute on function public.get_report_status_counts() to authenticated;
+
+-- Orphan-flag list function. Returns rows shaped like fetchAllReports result
+-- but synthesised from flagged_reports. Admin can review + dismiss without a
+-- matching user_configs row ever existing.
+create or replace function public.get_orphan_flag_reports(p_app_id text default null)
+returns table (
+  id                    bigint,
+  app_id                text,
+  source                text,
+  status                text,
+  reason_category       text,
+  reason_text           text,
+  reporter_client_id    text,
+  report_key            text,
+  flagged_at            timestamptz
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select
+    fr.id, fr.app_id, fr.source, fr.status, fr.reason_category, fr.reason_text,
+    fr.reporter_client_id, fr.report_key, fr.flagged_at
+  from flagged_reports fr
+  where lower(coalesce(fr.source, '')) <> 'protondb'
+    and coalesce(fr.status, 'open') = 'open'
+    and (p_app_id is null or fr.app_id = p_app_id)
+    and not exists (
+      select 1 from user_configs uc
+      where uc.app_id = fr.app_id
+        and format('%s:%s:%s',
+                   floor(extract(epoch from uc.created_at))::bigint::text,
+                   left(coalesce(uc.gpu, ''), 20),
+                   left(coalesce(uc.proton_version, ''), 15)) = fr.report_key
+    )
+    -- admin permission gate: same as the counts RPC. Non-admins get 0 rows.
+    and public.current_user_has_permission('view_analytics')
+  order by fr.flagged_at desc;
+$$;
+
+grant execute on function public.get_orphan_flag_reports(text) to authenticated;

--- a/supabase/migrations/20260811230000_cleanup_flags_on_report_delete.sql
+++ b/supabase/migrations/20260811230000_cleanup_flags_on_report_delete.sql
@@ -1,0 +1,49 @@
+-- When a user_configs row is deleted (admin action, account erase, or any
+-- other path), also drop matching flagged_reports rows so the flag does not
+-- linger as an orphan the admin can never act on again.
+--
+-- Match key: the same reconstruction used by
+-- sync_user_configs_is_flagged_from_flagged_reports (migration
+-- 20260810160000). ProtonDB-sourced flags are unaffected -- they never map
+-- to a user_configs row in the first place.
+--
+-- Scoped strictly to DELETE from flagged_reports; no other side effects.
+
+create or replace function public.cleanup_flags_on_user_config_delete()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  delete from public.flagged_reports fr
+  where fr.app_id = old.app_id
+    and lower(coalesce(fr.source, '')) <> 'protondb'
+    and fr.report_key = format('%s:%s:%s',
+                               floor(extract(epoch from old.created_at))::bigint::text,
+                               left(coalesce(old.gpu, ''), 20),
+                               left(coalesce(old.proton_version, ''), 15));
+  return old;
+end;
+$$;
+
+drop trigger if exists trg_cleanup_flags_on_report_delete on public.user_configs;
+create trigger trg_cleanup_flags_on_report_delete
+  after delete on public.user_configs
+  for each row
+  execute function public.cleanup_flags_on_user_config_delete();
+
+-- One-time backfill: any current non-protondb flagged_reports row whose
+-- report_key does NOT match a live user_configs row is orphaned. Drop it.
+-- This cleans up historical drift (deleted-report flags that pre-date the
+-- trigger, including the Wukong test flag).
+delete from public.flagged_reports fr
+where lower(coalesce(fr.source, '')) <> 'protondb'
+  and not exists (
+    select 1 from public.user_configs uc
+    where uc.app_id = fr.app_id
+      and format('%s:%s:%s',
+                 floor(extract(epoch from uc.created_at))::bigint::text,
+                 left(coalesce(uc.gpu, ''), 20),
+                 left(coalesce(uc.proton_version, ''), 15)) = fr.report_key
+  );

--- a/tests/adminAllReports.test.js
+++ b/tests/adminAllReports.test.js
@@ -239,9 +239,14 @@ describe('Reports admin wiring', () => {
   const HTML = fs.readFileSync(path.join(__dirname, '..', 'admin.html'), 'utf8');
   const COMP = fs.readFileSync(path.join(__dirname, '..', 'js', 'admin', 'components', 'allReports.js'), 'utf8');
 
-  test('standalone Flagged Reports menu option is removed (covered by Reports filter)', () => {
+  test('standalone Flagged Reports menu option is removed (Reports panel now surfaces orphans)', () => {
+    // After fetchAllReports learned to merge orphan flagged_reports rows
+    // into the Reports listing (with a "no user row" badge + Details
+    // button routing to the same flag-detail view), the separate Flagged
+    // Reports dropdown option became redundant. Everything lives on the
+    // Reports panel now.
     expect(HTML).not.toContain('<option value="flagged">Flagged Reports</option>');
-    // the Reports panel still has a "Flagged" status filter
+    // The Reports panel keeps its own "Flagged" status filter.
     expect(HTML).toContain('<option value="flagged">Flagged</option>');
   });
 

--- a/tests/adminApiAllReports.test.js
+++ b/tests/adminApiAllReports.test.js
@@ -250,6 +250,82 @@ describe('fetchReportById', () => {
   });
 });
 
+describe('fetchAllReports orphan-flag merge (#474 follow-up)', () => {
+  beforeEach(() => { delete global.location; global.location = { hostname: 'localhost' }; });
+
+  const makeOrphanRoutes = (orphans) => ({
+    'https://test.supabase.co/rest/v1/user_configs': [],
+    'https://test.supabase.co/rest/v1/report_approvals': [],
+    'https://test.supabase.co/rest/v1/rpc/get_orphan_flag_reports': orphans,
+  });
+
+  test('status=flagged calls get_orphan_flag_reports RPC', async () => {
+    const fetchSpy = makeFetchStub(makeOrphanRoutes([]));
+    global.fetch = fetchSpy;
+    await fetchAllReports(makeSession(), { status: 'flagged' });
+    const called = fetchSpy.mock.calls.some(([url]) => url.includes('rpc/get_orphan_flag_reports'));
+    expect(called).toBe(true);
+  });
+
+  test('non-flagged statuses skip the orphan RPC (avoid unnecessary work)', async () => {
+    const fetchSpy = makeFetchStub(makeOrphanRoutes([]));
+    global.fetch = fetchSpy;
+    await fetchAllReports(makeSession(), { status: 'clean' });
+    const called = fetchSpy.mock.calls.some(([url]) => url.includes('rpc/get_orphan_flag_reports'));
+    expect(called).toBe(false);
+  });
+
+  test('orphan rows are prepended with parsed report_key details in the title', async () => {
+    const orphan = {
+      id: 16, app_id: '2358720', source: 'pulse', status: 'open',
+      reason_category: 'spam', reason_text: 'Test', reporter_client_id: 'cli-abc',
+      report_key: '1779759584:VanGogh [AMD Custom :Proton Experime',
+      flagged_at: '2026-08-11T01:12:00Z',
+    };
+    global.fetch = makeFetchStub(makeOrphanRoutes([orphan]));
+    const out = await fetchAllReports(makeSession(), { status: 'flagged' });
+    expect(out[0]).toMatchObject({
+      id: 'flag-16',
+      app_id: '2358720',
+      is_orphan_flag: true,
+      is_flagged: true,
+      is_hidden: false,
+      is_pending: false,
+      flagged_reason: 'spam',
+    });
+    // Title carries the actual flag detail (GPU / Proton) parsed from
+    // report_key, not a scary "deleted" placeholder. Admin needs to see what
+    // got flagged regardless of whether the user_configs row is gone.
+    expect(out[0].title).toBe('VanGogh [AMD Custom / Proton Experime');
+  });
+
+  test('orphan title falls back gracefully when report_key is empty', async () => {
+    const orphan = {
+      id: 99, app_id: '730', source: 'pulse', status: 'open',
+      report_key: '', flagged_at: '2026-01-01T00:00:00Z',
+    };
+    global.fetch = makeFetchStub(makeOrphanRoutes([orphan]));
+    const out = await fetchAllReports(makeSession(), { status: 'flagged' });
+    expect(out[0].title).toBe('(no report details)');
+  });
+
+  test('orphan id is namespaced with the flag- prefix so it cannot collide with user_configs.id', async () => {
+    const orphan = { id: 42, app_id: '730', source: 'pulse', status: 'open', report_key: 'x', flagged_at: '2026-01-01T00:00:00Z' };
+    global.fetch = makeFetchStub(makeOrphanRoutes([orphan]));
+    const out = await fetchAllReports(makeSession(), { status: 'flagged' });
+    expect(out[0].id).toBe('flag-42');
+    expect(typeof out[0].id).toBe('string');
+  });
+
+  test('orphan RPC failure does not break the fetch (best-effort)', async () => {
+    global.fetch = jest.fn(async (url) => {
+      if (url.includes('rpc/get_orphan_flag_reports')) return { ok: false, status: 500, json: async () => ({}) };
+      return { ok: true, json: async () => [] };
+    });
+    await expect(fetchAllReports(makeSession(), { status: 'flagged' })).resolves.toEqual([]);
+  });
+});
+
 describe('patchReportFlags', () => {
   test('PATCHes the row with the supplied body and Prefer:return=minimal', async () => {
     const fetchSpy = jest.fn(async () => ({ ok: true, json: async () => [] }));

--- a/tests/approveDenyInAllReports.test.js
+++ b/tests/approveDenyInAllReports.test.js
@@ -12,33 +12,38 @@ const ALLREPS_CMP   = fs.readFileSync(path.join(ROOT, 'js', 'admin', 'components
 const ADMIN_CSS     = fs.readFileSync(path.join(ROOT, 'css', 'admin', 'admin.css'), 'utf8');
 const ADMIN_HTML    = fs.readFileSync(path.join(ROOT, 'admin.html'), 'utf8');
 
-describe('All Reports table row layout (#148 follow-up: Actions column removed)', () => {
-  test('actionBtns function and ar-actions cell are gone (actions live in detail only)', () => {
+describe('All Reports table row layout (Actions column restored for far-right Details)', () => {
+  // Superseded #148 follow-up: every row now needs a Details button on the
+  // far right so the Reports panel matches every other admin list view.
+  // Orphan rows route to the flag-detail view via ar-view-flag-detail; live
+  // rows keep the ar-view-detail path. The Details button lives in a
+  // trailing Actions column, not inline in the ID cell.
+  test('actionBtns function (bulk row-inline actions) stays gone -- actions live in detail', () => {
     expect(ALLREPS_CMP).not.toContain('function actionBtns');
     expect(ALLREPS_CMP).not.toContain('class="ar-actions"');
   });
 
-  test('row template still emits #NNN, app link, title, source, store, user, date, status', () => {
-    // 8 <td> cells per row, no Actions cell at the end.
+  test('row template emits 9 cells (#NNN, app, title, source, store, user, date, status, Actions)', () => {
     const rowTmpl = ALLREPS_CMP.slice(
       ALLREPS_CMP.indexOf('return `<tr data-rid='),
-      ALLREPS_CMP.indexOf('return `<tr data-rid=') + 1200
+      ALLREPS_CMP.indexOf('return `<tr data-rid=') + 1500
     );
-    expect((rowTmpl.match(/<td/g) || []).length).toBe(8);
+    expect((rowTmpl.match(/<td/g) || []).length).toBe(9);
     expect(rowTmpl).toContain('ar-status');
-    expect(rowTmpl).not.toContain('ar-actions');
+    // Details button is emitted via the detailsBtn variable produced just
+    // above the return; check its wiring on the full source instead.
+    expect(ALLREPS_CMP).toContain('data-action="ar-view-detail"');
+    expect(ALLREPS_CMP).toContain('data-action="ar-view-flag-detail"');
   });
 
-  test('all-reports-table thead drops the Actions <th>', () => {
-    // Other admin tables (flagged, banned, etc.) still have Actions; only
-    // the All Reports table loses the column.
+  test('all-reports-table thead includes the Actions <th> at the end', () => {
     const start = ADMIN_HTML.indexOf('id="all-reports-table"');
     const end = ADMIN_HTML.indexOf('</thead>', start);
     const arHead = ADMIN_HTML.slice(start, end);
-    expect(arHead).not.toMatch(/<th>Actions<\/th>/);
+    expect(arHead).toMatch(/<th>Actions<\/th>/);
   });
 
-  test('updateAllReportsRow no longer touches an actions cell', () => {
+  test('updateAllReportsRow still avoids the row-inline actions cell', () => {
     expect(ALLREPS_CMP).toContain('export function updateAllReportsRow(id, isF, isH, flaggedReason, isPending)');
     expect(ALLREPS_CMP).not.toContain("row.querySelector('.ar-actions')");
   });

--- a/tests/gamePageLive.test.js
+++ b/tests/gamePageLive.test.js
@@ -35,10 +35,14 @@ describe('game page: ProtonDB live-only handling', () => {
     expect(src).toContain("const combinedTier = pulseTierFromReports(allReportsForTier,");
   });
 
-  test('ProtonDB live summary is auto-fetched in the parallel Promise.all (#219)', () => {
-    // #219: the live summary must load automatically on every page render
-    // so aggregate stats reflect ProtonDB reality, not just what we mirror.
-    expect(src).toContain("safeFetch(() => fetchProtonDbLive(appId), 'fetchProtonDbLive', [])");
+  test('ProtonDB live is cache-only in the parallel Promise.all (#219 auto-fetch removed by #474)', () => {
+    // #474 decouple: the parallel load no longer auto-fetches ProtonDB. It
+    // reads the session cache instead (populated by a user clicking the
+    // "Check ProtonDB Live" button on stub pages), so populated game pages
+    // never show a "moderate confidence via ProtonDB live" headline.
+    expect(src).toContain("safeFetch(async () => readProtonDbLiveCache(appId), 'readProtonDbLiveCache', [])");
+    expect(src).not.toContain("safeFetch(() => fetchProtonDbLive(appId), 'fetchProtonDbLive', [])");
+    expect(src).toContain("Decoupled from ProtonDB (#474)");
   });
 
   test('live-only shows an explanatory note in the cards area, not fake cards', () => {

--- a/tests/gameStatsLive.test.js
+++ b/tests/gameStatsLive.test.js
@@ -6,14 +6,17 @@ const src = fs.readFileSync(
   'utf8'
 );
 
-describe('game-stats page: ProtonDB live summary integration (#219)', () => {
-  test('loadProtonDbLive hits the same edge fn the game page uses', () => {
-    expect(src).toContain("PROTONDB_LIVE_URL");
-    expect(src).toContain("functions/v1/protondb-summary");
-    expect(src).toContain("async function loadProtonDbLive(appId)");
+describe('game-stats page: ProtonDB live summary integration (#219, decoupled #474)', () => {
+  test('loadProtonDbLive is a no-op after ProtonDB decouple (#474)', () => {
+    // Was originally an edge-fn call; the site is decoupled from ProtonDB
+    // and no longer auto-fetches the live summary on the stats page.
+    expect(src).not.toContain("PROTONDB_LIVE_URL");
+    expect(src).not.toContain("functions/v1/protondb-summary");
+    expect(src).toMatch(/async function loadProtonDbLive\(_appId\) \{\s*return null;/);
+    expect(src).toContain("Decoupled from ProtonDB (#474)");
   });
 
-  test('run() fetches the live summary in parallel with mirror data', () => {
+  test('run() still keeps the liveSummary slot for structural continuity', () => {
     expect(src).toMatch(/const \[cdnReports, idxRow, pulseReports, configs, liveSummary, flightlessEntry\] = await Promise\.all\(\[/);
     expect(src).toMatch(/loadProtonDbLive\(appId\),?/);
   });

--- a/tests/homeFilters.test.js
+++ b/tests/homeFilters.test.js
@@ -62,8 +62,12 @@ describe('home page browse filters (multi-select)', () => {
     expect(homeSrc).toContain('_filterByStore(_filterByType(_filterByTier(_sortReports(allRecentReports, currentSort), tierSel), sourceSel), storeSel)');
   });
 
-  test('Not Rated Yet surfaces unrated catalog games in the popular section', () => {
-    expect(homeSrc).toContain("const wantUnrated = tierSel.has('all') || tierSel.has('unrated')");
+  test('unrated games appear by default in the popular section (#474)', () => {
+    // Empty tier selection (or "all") shows every popular Steam game
+    // regardless of Pulse rating. Only picking specific rated tiers
+    // (e.g. "gold" only) hides the pending ones.
+    expect(homeSrc).toContain("const noTierFilter = tierSel.size === 0 || tierSel.has('all')");
+    expect(homeSrc).toContain("const wantUnrated = noTierFilter || tierSel.has('unrated')");
     expect(homeSrc).toContain('...(wantUnrated ? unratedGames : [])');
     // legacy separate unrated toggle is gone
     expect(homeSrc).not.toContain("id=\"unrated-toggle\"");
@@ -106,7 +110,7 @@ describe('home page popular section -- store-aware label and pool', () => {
   });
 
   test('Steam/all path still uses wantUnrated and unratedGames for tier compat', () => {
-    expect(homeSrc).toContain("const wantUnrated = tierSel.has('all') || tierSel.has('unrated')");
+    expect(homeSrc).toContain("const wantUnrated = noTierFilter || tierSel.has('unrated')");
     expect(homeSrc).toContain('...(wantUnrated ? unratedGames : [])');
   });
 });

--- a/tests/indexPopularFilters.test.js
+++ b/tests/indexPopularFilters.test.js
@@ -19,10 +19,14 @@ describe('index page popular games rating filters', () => {
     expect(indexHtml).toMatch(/id="pg-filter-unrated"[^>]*>Not Rated /);
   });
 
-  test('Rated is active (pressed) by default, Not Rated is not', () => {
-    expect(indexHtml).toMatch(/id="pg-filter-rated"[^>]*aria-pressed="true"/);
-    expect(indexHtml).toMatch(/id="pg-filter-unrated"[^>]*aria-pressed="false"/);
-    expect(indexHtml).toMatch(/pg-filter pg-filter--active" id="pg-filter-rated"/);
+  test('Not Rated is active (pressed) by default, Rated is not (#474)', () => {
+    // Flipped from rated -> unrated after the ProtonDB decouple. With
+    // Pulse-only rating, every popular Steam game starts under Not Rated,
+    // so the default active pill has to be Not Rated or the grid renders
+    // empty on first visit.
+    expect(indexHtml).toMatch(/id="pg-filter-rated"[^>]*aria-pressed="false"/);
+    expect(indexHtml).toMatch(/id="pg-filter-unrated"[^>]*aria-pressed="true"/);
+    expect(indexHtml).toMatch(/pg-filter pg-filter--active" id="pg-filter-unrated"/);
   });
 
   test('main.js splits rated vs unrated using KNOWN_TIERS', () => {
@@ -31,8 +35,8 @@ describe('index page popular games rating filters', () => {
     expect(indexSrc).toContain('const unratedGames = games.filter((g) => !KNOWN_TIERS.has(String(g.rating || \'\').toLowerCase()))');
   });
 
-  test('default state shows rated and hides unrated', () => {
-    expect(indexSrc).toContain('const state = { rated: true, unrated: false }');
+  test('default state shows unrated and hides rated (#474)', () => {
+    expect(indexSrc).toContain('const state = { rated: false, unrated: true }');
   });
 
   test('store is multi-select via a Set, not a single currentStore string', () => {

--- a/tests/protondbLive.test.js
+++ b/tests/protondbLive.test.js
@@ -57,3 +57,83 @@ describe('fetchProtonDbLive (proxy)', () => {
     expect(calls).toHaveLength(1);
   });
 });
+
+// Decoupled from ProtonDB (#474): fetchCdn must return only pulse-sourced
+// rows even when the CDN JSON still contains archive rows.
+function loadProtonDbForCdn(fetchImpl) {
+  const calls = [];
+  const ctx = {
+    console: { log() {}, debug() {}, error() {} },
+    fetch: (url, opts) => { calls.push({ url, opts }); return fetchImpl(url, opts); },
+    // Stub the two imports fetchCdn depends on; the ESM loader strips imports.
+    dataUrl: async (p) => `https://cdn.example/${p}`,
+    appIdToDir: (id) => String(id),
+  };
+  const mod = loadEsm(['js/app/api/protondb.js'], ctx);
+  return { mod, calls };
+}
+
+describe('fetchCdn (#474 decouple)', () => {
+  test('drops rows with source=protondb', async () => {
+    const rows = [
+      { rating: 'gold',     source: 'protondb', timestamp: 1 },
+      { rating: 'platinum', source: 'pulse',    timestamp: 2 },
+      { rating: 'silver',   source: 'pulse',    timestamp: 3 },
+    ];
+    const { mod } = loadProtonDbForCdn(() => jsonResponse(rows));
+    const out = await mod.fetchCdn(730);
+    expect(out).toHaveLength(2);
+    expect(out.every(r => r.source === 'pulse')).toBe(true);
+  });
+
+  test('rows with missing/unknown source are dropped (legacy default is protondb)', async () => {
+    const rows = [
+      { rating: 'gold' },                          // no source -> archive default
+      { rating: 'gold', source: '' },              // empty -> archive default
+      { rating: 'gold', source: 'other-import' },  // unknown -> not pulse
+      { rating: 'platinum', source: 'pulse' },
+    ];
+    const { mod } = loadProtonDbForCdn(() => jsonResponse(rows));
+    const out = await mod.fetchCdn(730);
+    expect(out).toHaveLength(1);
+    expect(out[0].rating).toBe('platinum');
+  });
+
+  test('returns [] when CDN payload is not an array', async () => {
+    const { mod } = loadProtonDbForCdn(() => jsonResponse({ oops: true }));
+    const out = await mod.fetchCdn(730);
+    expect(out).toEqual([]);
+  });
+
+  test('returns [] on non-ok CDN response', async () => {
+    const { mod } = loadProtonDbForCdn(() => jsonResponse({}, false, 404));
+    const out = await mod.fetchCdn(730);
+    expect(out).toEqual([]);
+  });
+});
+
+// Decoupled from ProtonDB (#474): readProtonDbLiveCache is a cache-only read
+// used by the game page + confidence page so a cold render does not auto-fetch
+// ProtonDB. Only warm cache (populated by a previous button click that ran
+// fetchProtonDbLive) returns data.
+describe('readProtonDbLiveCache (#474 decouple)', () => {
+  test('returns [] on cold cache', () => {
+    const { mod } = loadProtonDb(() => jsonResponse({}));
+    expect(mod.readProtonDbLiveCache(730)).toEqual([]);
+  });
+
+  test('returns cached array after a fetchProtonDbLive call warms it', async () => {
+    const { mod } = loadProtonDb(() => jsonResponse({ found: true, tier: 'gold', total: 42 }));
+    await mod.fetchProtonDbLive(730);
+    const out = mod.readProtonDbLiveCache(730);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ tier: 'gold', total: 42, _liveOnly: true });
+  });
+
+  test('does not hit the network on read', () => {
+    const { mod, calls } = loadProtonDb(() => jsonResponse({}));
+    mod.readProtonDbLiveCache(999);
+    mod.readProtonDbLiveCache(999);
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/tests/test_finalize_probe.py
+++ b/tests/test_finalize_probe.py
@@ -395,11 +395,14 @@ def test_compute_game_summary_non_list_year_file(tmp_path):
 
 
 def test_compute_game_summary_non_dict_report(tmp_path):
+    # Decoupled from ProtonDB (#474): pulse source needed to exercise the
+    # non-dict-filter branch since protondb rows are now dropped upstream.
     app_dir = tmp_path / "730"
     app_dir.mkdir()
-    (app_dir / "2024.json").write_text(json.dumps(["not-a-dict", {"rating": "gold", "source": "protondb"}]))
+    (app_dir / "2024.json").write_text(json.dumps(["not-a-dict", {"rating": "gold", "source": "pulse"}]))
     tier, pdb, pulse, _trend = _compute_game_summary(app_dir)
-    assert pdb == 1
+    assert pdb == 0
+    assert pulse == 1
 
 
 # ── update_protondb_probe_cache probe_protondb raises (lines 1195-1196) ───────

--- a/tests/test_finalize_utils.py
+++ b/tests/test_finalize_utils.py
@@ -225,15 +225,18 @@ def test_compute_game_summary_platinum(tmp_path):
     app_dir = tmp_path / "730"
     app_dir.mkdir()
     (app_dir / "2023.json").write_text(json.dumps([
-        {"rating": "platinum", "source": "protondb"},
-        {"rating": "platinum", "source": "protondb"},
+        {"rating": "platinum", "source": "pulse"},
+        {"rating": "platinum", "source": "pulse"},
     ]))
     tier, pdb, pulse, _trend = _compute_game_summary(app_dir)
     assert tier == "platinum"
-    assert pdb == 2
-    assert pulse == 0
+    # Decoupled from ProtonDB (#474): protondb never contributes; pulse counts here.
+    assert pdb == 0
+    assert pulse == 2
 
 def test_compute_game_summary_mixed_sources(tmp_path):
+    # Decoupled from ProtonDB (#474): a mixed year file should only count pulse.
+    # Single gold pulse -> score 0.8 -> 80% -> platinum by the score->tier map.
     app_dir = tmp_path / "730"
     app_dir.mkdir()
     (app_dir / "2023.json").write_text(json.dumps([
@@ -241,8 +244,23 @@ def test_compute_game_summary_mixed_sources(tmp_path):
         {"rating": "gold", "source": "pulse"},
     ]))
     tier, pdb, pulse, _trend = _compute_game_summary(app_dir)
-    assert pdb == 1
+    assert pdb == 0
     assert pulse == 1
+    assert tier == "platinum"
+
+def test_compute_game_summary_protondb_only_is_pending(tmp_path):
+    # Decoupled from ProtonDB (#474): a game with only archive rows must not
+    # produce a tier or any counts -- the pipeline treats it as having no data.
+    app_dir = tmp_path / "730"
+    app_dir.mkdir()
+    (app_dir / "2023.json").write_text(json.dumps([
+        {"rating": "platinum", "source": "protondb"},
+        {"rating": "borked", "source": "protondb"},
+    ]))
+    tier, pdb, pulse, _trend = _compute_game_summary(app_dir)
+    assert tier == "pending"
+    assert pdb == 0
+    assert pulse == 0
 
 def test_compute_game_summary_no_data(tmp_path):
     app_dir = tmp_path / "missing"
@@ -253,15 +271,15 @@ def test_compute_game_summary_no_data(tmp_path):
 def test_compute_game_summary_unrated(tmp_path):
     app_dir = tmp_path / "730"
     app_dir.mkdir()
-    (app_dir / "2023.json").write_text(json.dumps([{"rating": "pending", "source": "protondb"}]))
+    (app_dir / "2023.json").write_text(json.dumps([{"rating": "pending", "source": "pulse"}]))
     tier, pdb, pulse, _trend = _compute_game_summary(app_dir)
     assert tier == "pending"
 
 def test_compute_game_summary_skips_reserved(tmp_path):
     app_dir = tmp_path / "730"
     app_dir.mkdir()
-    (app_dir / "latest.json").write_text(json.dumps([{"rating": "platinum", "source": "protondb"}]))
-    (app_dir / "2023.json").write_text(json.dumps([{"rating": "borked", "source": "protondb"}]))
+    (app_dir / "latest.json").write_text(json.dumps([{"rating": "platinum", "source": "pulse"}]))
+    (app_dir / "2023.json").write_text(json.dumps([{"rating": "borked", "source": "pulse"}]))
     tier, _, _, _ = _compute_game_summary(app_dir)
     assert tier == "borked"  # latest.json was skipped
 
@@ -276,12 +294,13 @@ def test_compute_game_summary_small_stale_sample_returns_pending(tmp_path):
     app_dir = tmp_path / "976310"
     app_dir.mkdir()
     (app_dir / "2018.json").write_text(json.dumps(
-        [{"rating": "borked", "source": "protondb", "timestamp": stale_ts}] * 11
+        [{"rating": "borked", "source": "pulse", "timestamp": stale_ts}] * 11
     ))
     tier, pdb, pulse, _ = _compute_game_summary(app_dir, now_ts=now_ts)
     assert tier == "pending"
-    assert pdb == 11
-    assert pulse == 0
+    # Decoupled from ProtonDB (#474): counts are pulse-only now.
+    assert pdb == 0
+    assert pulse == 11
 
 
 def test_compute_game_summary_small_recent_sample_keeps_tier(tmp_path):
@@ -292,7 +311,7 @@ def test_compute_game_summary_small_recent_sample_keeps_tier(tmp_path):
     app_dir = tmp_path / "12345"
     app_dir.mkdir()
     (app_dir / "2026.json").write_text(json.dumps(
-        [{"rating": "silver", "source": "protondb", "timestamp": recent_ts}] * 5
+        [{"rating": "silver", "source": "pulse", "timestamp": recent_ts}] * 5
     ))
     tier, _, _, _ = _compute_game_summary(app_dir, now_ts=now_ts)
     # silver's score is exactly 60, which hits the "gold" threshold in
@@ -310,7 +329,7 @@ def test_compute_game_summary_large_stale_sample_keeps_tier(tmp_path):
     app_dir = tmp_path / "99999"
     app_dir.mkdir()
     (app_dir / "2020.json").write_text(json.dumps(
-        [{"rating": "silver", "source": "protondb", "timestamp": stale_ts}] * 30
+        [{"rating": "silver", "source": "pulse", "timestamp": stale_ts}] * 30
     ))
     tier, _, _, _ = _compute_game_summary(app_dir, now_ts=now_ts)
     # 30 silver reports -> 60% score -> gold. Key check: the staleness guard
@@ -324,7 +343,7 @@ def test_compute_game_summary_large_stale_sample_keeps_tier(tmp_path):
 def _reports_at(now_ts, offsets_ratings):
     """Build a report list where each entry is (days_ago, rating)."""
     return [
-        {"rating": rating, "source": "protondb", "timestamp": now_ts - days * 86400}
+        {"rating": rating, "source": "pulse", "timestamp": now_ts - days * 86400}
         for days, rating in offsets_ratings
     ]
 
@@ -391,7 +410,7 @@ def test_compute_game_summary_trend_disabled_without_now_ts(tmp_path):
     app_dir = tmp_path / "1"
     app_dir.mkdir()
     (app_dir / "2023.json").write_text(json.dumps([
-        {"rating": "platinum", "source": "protondb", "timestamp": 1_700_000_000},
+        {"rating": "platinum", "source": "pulse", "timestamp": 1_700_000_000},
     ]))
     tier, _, _, trend = _compute_game_summary(app_dir)
     assert tier == "platinum"
@@ -403,7 +422,7 @@ def test_compute_game_summary_trend_disabled_without_now_ts(tmp_path):
 def test_generate_search_index_basic(tmp_path):
     app_dir = tmp_path / "730"
     app_dir.mkdir()
-    (app_dir / "2023.json").write_text(json.dumps([{"rating": "gold", "source": "protondb", "title": "CS2"}]))
+    (app_dir / "2023.json").write_text(json.dumps([{"rating": "gold", "source": "pulse", "title": "CS2"}]))
     (app_dir / "latest.json").write_text(json.dumps([{"title": "CS2"}]))
 
     keys = {("730", "2023")}
@@ -481,7 +500,7 @@ def test_generate_search_index_epic_with_reports_not_duplicated(tmp_path):
 def test_generate_search_index_skips_no_title(tmp_path):
     app_dir = tmp_path / "730"
     app_dir.mkdir()
-    (app_dir / "2023.json").write_text(json.dumps([{"rating": "gold", "source": "protondb"}]))
+    (app_dir / "2023.json").write_text(json.dumps([{"rating": "gold", "source": "pulse"}]))
     # no latest.json -> _extract_title returns ""
 
     keys = {("730", "2023")}
@@ -498,7 +517,7 @@ def test_generate_recent_reports_basic(tmp_path):
     app_dir = data_dir / "730"
     app_dir.mkdir()
     (app_dir / "2025.json").write_text(json.dumps([
-        {"title": "CS2", "rating": "gold", "source": "protondb", "timestamp": 1750000000}
+        {"title": "CS2", "rating": "gold", "source": "pulse", "timestamp": 1750000000}
     ]))
 
     search_index = [["730", "CS2", "gold", 1, 0]]
@@ -511,6 +530,8 @@ def test_generate_recent_reports_basic(tmp_path):
     assert result[0]["title"] == "CS2"
 
 def test_generate_recent_reports_sorted_by_date(tmp_path):
+    # Decoupled from ProtonDB (#474): every fixture needs source=pulse now
+    # or the walker skips it -- ProtonDB rows never contribute to Recent Reports.
     data_dir = tmp_path / "data"
     data_dir.mkdir()
 
@@ -518,10 +539,10 @@ def test_generate_recent_reports_sorted_by_date(tmp_path):
         d = data_dir / app_id
         d.mkdir()
         (d / "2025.json").write_text(json.dumps([
-            {"title": f"Game {app_id}", "timestamp": ts}
+            {"title": f"Game {app_id}", "timestamp": ts, "source": "pulse"}
         ]))
 
-    search_index = [["730", "CS2", "gold", 1, 0], ["570", "Dota 2", "platinum", 1, 0]]
+    search_index = [["730", "CS2", "gold", 0, 1], ["570", "Dota 2", "platinum", 0, 1]]
     (tmp_path / "search-index.json").write_text(json.dumps(search_index))
 
     generate_recent_reports(data_dir, tmp_path)
@@ -533,7 +554,9 @@ def test_generate_recent_reports_skips_no_title(tmp_path):
     data_dir.mkdir()
     app_dir = data_dir / "730"
     app_dir.mkdir()
-    (app_dir / "2025.json").write_text(json.dumps([{"timestamp": 1750000000}]))
+    (app_dir / "2025.json").write_text(json.dumps([
+        {"timestamp": 1750000000, "source": "pulse"}
+    ]))
 
     # No search-index entry -> no title -> skipped
     (tmp_path / "search-index.json").write_text("[]")
@@ -548,13 +571,35 @@ def test_generate_recent_reports_respects_limit(tmp_path):
     for i in range(20):
         d = data_dir / str(1000 + i)
         d.mkdir()
-        (d / "2025.json").write_text(json.dumps([{"timestamp": 1750000000 + i}]))
-        index.append([str(1000 + i), f"Game {i}", "gold", 1, 0])
+        (d / "2025.json").write_text(json.dumps([
+            {"timestamp": 1750000000 + i, "source": "pulse"}
+        ]))
+        index.append([str(1000 + i), f"Game {i}", "gold", 0, 1])
 
     (tmp_path / "search-index.json").write_text(json.dumps(index))
     generate_recent_reports(data_dir, tmp_path, limit=5)
     result = json.loads((tmp_path / "recent-reports.json").read_text())
     assert len(result) == 5
+
+
+def test_generate_recent_reports_skips_protondb_only(tmp_path):
+    # Decoupled from ProtonDB (#474): a game whose only rows are protondb
+    # rows must NOT resurrect onto the Recent Reports panel, even if a
+    # search-index row exists for it.
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    d = data_dir / "730"
+    d.mkdir()
+    (d / "2025.json").write_text(json.dumps([
+        {"title": "CS2", "timestamp": 1750000000, "source": "protondb"}
+    ]))
+    (tmp_path / "search-index.json").write_text(json.dumps([
+        ["730", "CS2", "gold", 0, 0]
+    ]))
+
+    generate_recent_reports(data_dir, tmp_path)
+    result = json.loads((tmp_path / "recent-reports.json").read_text())
+    assert result == []
 
 
 # ── reindex_apps ──────────────────────────────────────────────────────────────

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -311,9 +311,12 @@ def _make_year_file(data_path, app_id, year, reports):
 
 
 def test_compute_stats_basic(tmp_path):
+    # Decoupled from ProtonDB (#474): fixtures use source=pulse now. The
+    # aggregation logic being verified here is source-agnostic; a separate
+    # test below covers the protondb-filter behavior explicitly.
     _make_year_file(tmp_path, "730", "2023", [
         {"rating": "gold", "gpu": "RTX 3080", "cpu": "Intel Core i7", "os": "Arch Linux",
-         "protonVersion": "9.0-4", "source": "protondb", "timestamp": 1700000000},
+         "protonVersion": "9.0-4", "source": "pulse", "timestamp": 1700000000},
     ])
     stats = compute_stats(tmp_path)
     assert stats["total_reports"] == 1
@@ -323,7 +326,37 @@ def test_compute_stats_basic(tmp_path):
     assert stats["by_cpu_brand"]["intel"] == 1
     assert stats["by_os_family"]["arch"] == 1
     assert stats["by_proton_type"]["proton-stable"] == 1
-    assert stats["by_source"]["protondb"] == 1
+    assert stats["by_source"]["pulse"] == 1
+
+
+def test_compute_stats_ignores_protondb_source(tmp_path):
+    # Decoupled from ProtonDB (#474): archive rows still on disk must not
+    # contribute anything to stats.
+    _make_year_file(tmp_path, "730", "2023", [
+        {"rating": "gold", "source": "protondb", "timestamp": 1700000000,
+         "gpu": "", "cpu": "", "os": "", "protonVersion": ""},
+        {"rating": "borked", "source": "protondb", "timestamp": 1700000001,
+         "gpu": "", "cpu": "", "os": "", "protonVersion": ""},
+    ])
+    stats = compute_stats(tmp_path)
+    assert stats["total_reports"] == 0
+    assert stats["total_games"] == 0
+    assert "protondb" not in stats["by_source"]
+
+
+def test_compute_stats_mixed_source_counts_pulse_only(tmp_path):
+    # Decoupled from ProtonDB (#474): a year file that mixes both sources
+    # only counts the pulse row.
+    _make_year_file(tmp_path, "730", "2023", [
+        {"rating": "gold", "source": "protondb", "timestamp": 1700000000,
+         "gpu": "", "cpu": "", "os": "", "protonVersion": ""},
+        {"rating": "platinum", "source": "pulse", "timestamp": 1700000001,
+         "gpu": "", "cpu": "", "os": "", "protonVersion": ""},
+    ])
+    stats = compute_stats(tmp_path)
+    assert stats["total_reports"] == 1
+    assert stats["by_rating"].get("platinum") == 1
+    assert stats["by_rating"].get("gold", 0) == 0
 
 
 def test_compute_stats_empty_dir(tmp_path):
@@ -369,7 +402,7 @@ def test_compute_stats_framegen(tmp_path):
 
 def test_compute_stats_stale_borked(tmp_path):
     _make_year_file(tmp_path, "730", "2020", [
-        {"rating": "borked", "source": "protondb", "timestamp": 1577836800,
+        {"rating": "borked", "source": "pulse", "timestamp": 1577836800,
          "title": "Broken Game", "gpu": "", "cpu": "", "os": "", "protonVersion": ""},
     ])
     stats = compute_stats(tmp_path)
@@ -379,7 +412,7 @@ def test_compute_stats_stale_borked(tmp_path):
 def test_compute_stats_cross_tabs(tmp_path):
     _make_year_file(tmp_path, "730", "2023", [
         {"rating": "platinum", "gpu": "RTX 3080", "cpu": "", "os": "",
-         "source": "protondb", "timestamp": 1700000000, "protonVersion": ""},
+         "source": "pulse", "timestamp": 1700000000, "protonVersion": ""},
     ])
     stats = compute_stats(tmp_path)
     assert "nvidia" in stats["by_rating_x_gpu_vendor"]
@@ -388,7 +421,7 @@ def test_compute_stats_cross_tabs(tmp_path):
 
 def test_compute_stats_year_bucketing(tmp_path):
     _make_year_file(tmp_path, "730", "2023", [
-        {"rating": "gold", "source": "protondb", "timestamp": 1700000000,
+        {"rating": "gold", "source": "pulse", "timestamp": 1700000000,
          "gpu": "", "cpu": "", "os": "", "protonVersion": ""},
     ])
     stats = compute_stats(tmp_path)
@@ -399,7 +432,7 @@ def test_compute_stats_year_bucketing(tmp_path):
 def test_compute_stats_top_games(tmp_path):
     for i in range(3):
         _make_year_file(tmp_path, f"10{i}", "2023",
-                        [{"rating": "gold", "source": "protondb", "timestamp": 1700000000 + i,
+                        [{"rating": "gold", "source": "pulse", "timestamp": 1700000000 + i,
                           "title": f"Game {i}", "gpu": "", "cpu": "", "os": "", "protonVersion": ""}] * (i + 1))
     stats = compute_stats(tmp_path)
     assert len(stats["top_games"]) <= 50
@@ -409,7 +442,7 @@ def test_write_stats_json(tmp_path):
     data_dir = tmp_path / "data"
     data_dir.mkdir()
     _make_year_file(data_dir, "730", "2023", [
-        {"rating": "gold", "source": "protondb", "timestamp": 1700000000,
+        {"rating": "gold", "source": "pulse", "timestamp": 1700000000,
          "gpu": "", "cpu": "", "os": "", "protonVersion": ""},
     ])
     write_stats_json(data_dir, tmp_path)
@@ -429,7 +462,7 @@ def test_compute_stats_by_year_source(tmp_path):
 
 def test_compute_stats_device_family(tmp_path):
     _make_year_file(tmp_path, "730", "2023", [
-        {"rating": "gold", "source": "protondb", "timestamp": 1700000000,
+        {"rating": "gold", "source": "pulse", "timestamp": 1700000000,
          "cpu": "AMD Custom APU 0405", "gpu": "AMD Custom GPU 0405",
          "os": "", "protonVersion": ""},
     ])
@@ -453,7 +486,7 @@ def test_compute_stats_skips_non_directory_files(tmp_path):
     # Place a file (not dir) directly in data_path to hit the `continue` branch
     (tmp_path / "notadir.txt").write_text("hello")
     _make_year_file(tmp_path, "730", "2024", [
-        {"rating": "gold", "source": "protondb", "timestamp": 1700000000,
+        {"rating": "gold", "source": "pulse", "timestamp": 1700000000,
          "gpu": "", "cpu": "", "os": "", "protonVersion": ""},
     ])
     stats = compute_stats(tmp_path)


### PR DESCRIPTION
Staging to main promotion.

Highlights (recent, session-heavy):

**ProtonDB decouple (#474)** -- three squashed commits at the top of the branch:
- feat: decouple site from ProtonDB reports (#474) -- four filter sites, tagged 'Decoupled from ProtonDB (#474)': finalize._compute_game_summary, finalize.generate_recent_reports, stats.compute_stats, protondb.fetchCdn. Removes ProtonDB live auto-fetch from game/confidence/stats. Cache-only re-render path for the user-triggered 'Check ProtonDB Live' button. Revert plan tracked in #475.
- fix: default browse views to show unrated Steam games post-decouple (#474) -- home Popular on Steam + index Popular Games flipped to include unrated by default (most Steam titles now pending until Pulse volume catches up).
- fix(admin): reliable flag visibility across orphan + live flags (#474) -- includes migrations 20260810160000 (trigger sync_user_configs_is_flagged_from_flagged_reports) and 20260811010000 (extended get_report_status_counts + get_orphan_flag_reports RPC), both applied to prod. Reports panel merges orphan flags with an 'orphan' badge + Details button routing to loadFlagDetail inline. Standalone Flagged Reports tab removed. Mobile: flag-detail sections get horizontal scroll.

Everything else on the branch (~90 commits) is prior sprint work already discrete per PR/feature: search API (#434), tinker penalty (#433), admin analytics (#436), boxart pgwiki (#472), SGDB name-search covers (#466), several referrer/rel fixes, etc.

Migrations already live in prod Supabase (applied via management API during the session). No additional DB steps needed on merge.

## Test plan
- [ ] CI green on staging (JS 2705 pass locally; Python test-py fails only on Termux uv cache permissions env, not code)
- [ ] Verify staging.proton-pulse.com/app/2358720 shows PENDING with no ProtonDB live headline
- [ ] Home Popular on Steam + /index Popular Games show unrated games by default
- [ ] admin.html Reports > Flagged surfaces orphan flags with 'orphan' badge; Details button opens flag detail inline
- [ ] After merge: make gh-pages-only from main

Reverting the decouple: `grep -rn "Decoupled from ProtonDB" scripts/pipeline/ js/` finds the four filter sites; see Data-Pipeline wiki + issue #475 for exact code to remove at each.

Backup tag on the pre-squash staging tip: pre-squash-474-1786484417 (points at e19360660b).