### PR TITLE
Staging to main: Deck verdict data fixes, VR polish, deploy-pipeline repairs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@ Thanks for the PR! A few quick reminders:
 
 ## Verified on staging?
 
-- [ ] Ran `make gh-staging` and checked https://mdeguzis.github.io/proton-pulse-web-staging/
+- [ ] Ran `make cf-staging` and checked https://staging.proton-pulse.com/
 - [ ] Version + short SHA on the about page match what I expected
 - [ ] Screenshot / short GIF attached (for UI changes)
 

--- a/.github/workflows/deck-backfill.yml
+++ b/.github/workflows/deck-backfill.yml
@@ -1,0 +1,124 @@
+name: Deck Verdict Backfill
+
+# Ad-hoc full fill of Valve's Deck / Machine / SteamOS verdicts.
+#
+# The pipeline's in-run budget only fetches a few hundred new verdicts so
+# finalize stays predictable, which leaves the long tail of the ~32k Steam
+# catalog uncovered for months. This drains it in one sitting.
+#
+# Rate: measured 80 consecutive requests at 0.15s spacing with zero failures
+# (~3.1 req/s). This is store.steampowered.com/saleaction/
+# ajaxgetdeckappcompatibilityreport -- a lightweight store widget, NOT the
+# appdetails API that soft-throttles at 200 requests / 5 minutes. Do not copy
+# the 2.0s spacing the appdetails enrichers use; it is the wrong endpoint's
+# limit and would turn a 3-hour job into 18.
+#
+# Writes NOTHING to the site. The only output is the verdict cache; the next
+# finalize publishes deck-status.json from it. Safe to run at any time -- it
+# cannot race a deploy or half-publish data.
+
+on:
+  workflow_dispatch:
+    inputs:
+      budget:
+        description: "Max NEW verdicts to fetch. 0 = no cap (full fill, ~3h for the whole catalog)."
+        default: "0"
+        required: false
+        type: string
+      delay:
+        description: "Seconds between requests. 0.35 is the default and leaves headroom under the measured ~3 req/s ceiling."
+        default: "0.35"
+        required: false
+        type: string
+
+concurrency:
+  group: deck-backfill
+  cancel-in-progress: false
+
+jobs:
+  backfill:
+    runs-on: ubuntu-24.04
+    # A no-cap fill over ~32k rows at 0.35s is roughly 3 hours. The ceiling is
+    # generous so a slow upstream does not truncate the run; the cache is saved
+    # on always() regardless.
+    timeout-minutes: 350
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Restore pipeline cache
+        uses: actions/cache/restore@v6
+        with:
+          path: .cache
+          # Same key prefix as update-data.yml so this reads the verdict cache
+          # the pipeline wrote and the pipeline reads what this fills in. A
+          # mismatched prefix means both start cold and re-fetch each other's
+          # work.
+          key: pipeline-cache-${{ runner.os }}-update-data.yml-${{ github.ref_name }}-${{ github.run_id }}-${{ github.run_attempt }}-deckbackfill
+          restore-keys: |
+            pipeline-cache-${{ runner.os }}-update-data.yml-${{ github.ref_name }}-
+
+      # deck-status scopes itself from search-index.json. A fresh checkout has
+      # no pipeline output, so pull the published index rather than rebuilding
+      # it -- this job only needs the id list, not the data behind it.
+      - name: Fetch published search index
+        env:
+          DATA_BASE: ${{ github.ref_name == 'main' && 'https://www.proton-pulse.com' || 'https://staging.proton-pulse.com' }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/protondb-output
+          for f in search-index.json most_played.json recent-reports.json; do
+            # most_played / recent-reports are priority hints only; a miss is
+            # not fatal, deck-status treats them as absent.
+            curl -fsSL "$DATA_BASE/$f" -o "/tmp/protondb-output/$f" \
+              && echo "got $f" || echo "skip $f (optional)"
+          done
+          test -s /tmp/protondb-output/search-index.json
+
+      - name: Backfill Deck verdicts
+        env:
+          BUDGET: ${{ inputs.budget }}
+          DELAY: ${{ inputs.delay }}
+        run: |
+          set -euo pipefail
+          uv run python scripts/split_reports.py deck-status \
+            /tmp/protondb-output \
+            --budget "$BUDGET" \
+            --delay "$DELAY"
+
+      - name: Save pipeline cache
+        # always(): a run that times out mid-fill still fetched thousands of
+        # real verdicts. Dropping the cache would make the next run redo them.
+        if: always()
+        uses: actions/cache/save@v6
+        with:
+          path: .cache
+          key: pipeline-cache-${{ runner.os }}-update-data.yml-${{ github.ref_name }}-${{ github.run_id }}-${{ github.run_attempt }}-deckbackfill
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "### Deck verdict backfill"
+            echo
+            if [ -s /tmp/protondb-output/deck-status.json ]; then
+              python3 - <<'PY'
+          import json, collections
+          with open("/tmp/protondb-output/deck-status.json") as fh:
+              d = json.load(fh)
+          counts = collections.Counter(v.get("status") for v in d.values())
+          print(f"- verdicts in map: **{len(d):,}**")
+          for k, n in sorted(counts.items()):
+              print(f"  - {k}: {n:,}")
+          print()
+          print("The next finalize run publishes this map. Re-run if it timed out; "
+                "cached verdicts are skipped so it resumes where it stopped.")
+          PY
+            else
+              echo "No deck-status.json produced -- the run failed before writing one. Check the step log."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-shell.yml
+++ b/.github/workflows/publish-shell.yml
@@ -112,6 +112,14 @@ jobs:
             app-id-redirects.json pcgamingwiki.json pcgwiki-catalog.json
             pcgw-id-map.json flightless-benchmarks.json flightless-review-queue.json
             sgdb-covers.json
+            # This list is a FOURTH place a pipeline data file must be
+            # registered (after gh-pages-manifest.txt, the update-data.yml
+            # copy loops, and publish-cloudflare.sh SMALL_DATA). Miss it and
+            # the file survives a pipeline run but is dropped by the next
+            # shell deploy, so the site works until someone pushes a CSS
+            # tweak. vr-index.json + vrdb.json (#246) and anti-cheat.json
+            # were all lost this way.
+            vr-index.json vrdb.json anti-cheat.json
           )
           for f in "${FILES[@]}"; do
             if curl -sfL --max-time 30 "$LIVE_BASE/$f" -o "/tmp/shell-out/$f" \

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -520,6 +520,21 @@ jobs:
         run: |
           bash scripts/publish-cloudflare.sh /tmp/protondb-output "$GITHUB_WORKSPACE"
 
+      # The backup step at the end of this job runs `bash <script>` from the
+      # workspace, but the gh-pages orphan deploy below does `git rm -rf .`
+      # first, which deletes every tracked file including that script. Every
+      # scheduled run from 2026-08-19 onward failed here with
+      # "scripts/backup-to-release.sh: No such file or directory", so the
+      # nightly data backup silently stopped for five days.
+      #
+      # Same hazard the preserve-* scripts already work around, but staged in
+      # its own step rather than inside the orphan step: the backup runs on
+      # both deploy targets, and on deploy_target=cloudflare the orphan step
+      # is skipped entirely, so a cp living inside it would never happen.
+      - name: Stage the backup script out of the workspace
+        if: inputs.staging_with_pipeline != true && inputs.staging_with_finalize != true
+        run: cp scripts/backup-to-release.sh /tmp/backup-to-release.sh
+
       - name: Deploy to gh-pages (orphan, no history)
         if: inputs.staging_with_pipeline != true && inputs.staging_with_finalize != true && inputs.deploy_target != 'cloudflare'
         run: |
@@ -693,7 +708,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          bash scripts/backup-to-release.sh /tmp/protondb-output
+          bash /tmp/backup-to-release.sh /tmp/protondb-output
 
   # ── Pages-only redeploy: refresh app/index shell files on gh-pages ─────────
   pages-only:

--- a/Makefile
+++ b/Makefile
@@ -224,17 +224,13 @@ gh-run: gh-check check-staging-sync
 draft-release:
 	@bash scripts/draft-release.sh
 
-gh-pages-only: gh-check check-staging-sync
-	gh workflow run $(GITHUB_WORKFLOW) --field pages_only=true
-	@bash scripts/draft-release.sh
-	@echo "Triggered $(GITHUB_WORKFLOW) with pages_only=true"
-	@echo "NOTE: this promotes shell files to the OLD gh-pages branch (rollback path only per #362). For prod CF Pages (www.proton-pulse.com) use \`make cf-prod\` -- but ideally you do not need to, since publish-shell.yml auto-deploys on every push to main."
-
-gh-staging: gh-check
-	@bash scripts/wait-for-remote.sh
-	gh workflow run $(GITHUB_WORKFLOW) --ref staging --field staging_only=true
-	@echo "Triggered $(GITHUB_WORKFLOW) with staging_only=true -- preview at https://mdeguzis.github.io/proton-pulse-web-staging/"
-	@echo "NOTE: this deploys to the OLD gh-pages staging repo (kept as rollback per #362). For the live CF Pages staging site (staging.proton-pulse.com) use \`make cf-staging\`."
+# The gh-pages deploy targets (gh-pages-only, gh-staging) were removed: they
+# pushed to the old gh-pages branch + staging repo, which #362 replaced with
+# Cloudflare Pages. They stayed around as a rollback path long enough to be a
+# footgun -- `make gh-staging` looks like the obvious way to preview staging
+# and silently deploys somewhere nobody looks. Use cf-staging / cf-prod below.
+# The gh-* PIPELINE targets (gh-run, gh-staging-finalize, ...) are unrelated
+# and still current; they dispatch update-data.yml, they do not touch gh-pages.
 
 # ── Cloudflare Pages shell deploys (#362 follow-up) ────────────────────
 #

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Contributions welcome. Quick version:
 2. Fork the repo or grab a `feature/<short-name>` branch off `staging`.
 3. Run `make pre-push` before every commit that touches JS or CSS.
 4. Open the PR against **`staging`**, not `main`. `main` is production only.
-5. Run `make gh-staging` to preview at https://mdeguzis.github.io/proton-pulse-web-staging/ and confirm the About page shows your version + short SHA.
+5. Run `make cf-staging` to preview at https://staging.proton-pulse.com/ and confirm the About page shows your version + short SHA.
 
 The full flow (feature branches, pre-push gate, staging review, promote to prod) lives in the wiki:
 

--- a/about.html
+++ b/about.html
@@ -16,7 +16,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=9e119a4e">
 <link rel="stylesheet" href="css/shared/topbar.css?v=1b5edcc1">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
-<link rel="stylesheet" href="css/shared/cards.css?v=3d5cd654">
+<link rel="stylesheet" href="css/shared/cards.css?v=5b30165c">
 <link rel="stylesheet" href="css/index/index.css?v=54fb9989">
 </head>
 <body>
@@ -263,7 +263,7 @@
       </div>
       <div class="il-col">
         <div class="il-subhead">In your account</div>
-        <div class="il-row"><span class="il-chip il-chip--steam"><svg viewBox="0 0 24 24" width="26" height="26" aria-hidden="true"><g fill="#fff"><rect x="3.4" y="3.4" width="7" height="7" rx="1.5"/><rect x="13.6" y="3.4" width="7" height="7" rx="1.5"/><rect x="3.4" y="13.6" width="7" height="7" rx="1.5"/><rect x="13.6" y="13.6" width="7" height="7" rx="1.5"/></g></svg></span><div class="il-text"><b>In your library</b><span>You own this game on Steam. Shown on the store pill.</span></div></div>
+        <div class="il-row"><span class="il-chip il-chip--steam"><svg viewBox="0 0 24 24" width="26" height="26" aria-hidden="true"><g fill="#fff"><rect x="3.5" y="4.8" width="17" height="3.6" rx="1.8"/><rect x="3.5" y="10.2" width="17" height="3.6" rx="1.8"/><rect x="3.5" y="15.6" width="17" height="3.6" rx="1.8"/></g></svg></span><div class="il-text"><b>In your library</b><span>You own this game on Steam. Shown on the store pill.</span></div></div>
         <div class="il-row"><span class="il-chip il-chip--steam"><svg viewBox="0 0 24 24" width="26" height="26" aria-hidden="true"><g fill="#fff" stroke="#000" stroke-width="1" stroke-linejoin="round"><path d="M4.6 8.2h14.8v3.4H4.6z"/><path d="M5.6 11.6h12.8v7a1.4 1.4 0 0 1-1.4 1.4H7a1.4 1.4 0 0 1-1.4-1.4z"/><path d="M12 8.2C10.6 8.2 8 7.9 7.5 6.3 7.1 5.1 8.4 4.3 9.5 5 10.6 5.7 11.5 6.8 12 8.2z"/><path d="M12 8.2C13.4 8.2 16 7.9 16.5 6.3 16.9 5.1 15.6 4.3 14.5 5 13.4 5.7 12.5 6.8 12 8.2z"/></g><path d="M12 8.4v11.8" stroke="#000" stroke-width="1"/></svg></span><div class="il-text"><b>On your wishlist</b><span>This game is on your Steam wishlist. Shown on the store pill.</span></div></div>
         <div class="il-subhead il-subhead--spaced">Store</div>
         <div class="il-row"><span class="il-storeicon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><defs><linearGradient id="st" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#1a9fff"/><stop offset="1" stop-color="#1668cf"/></linearGradient></defs><rect x="0.6" y="0.6" width="22.8" height="22.8" rx="5" fill="url(#st)"/><g fill="#fff" transform="translate(3.8 3.8) scale(0.685)"><path d="M11.979 0C5.678 0 .511 4.86.022 11.037l6.432 2.658c.545-.371 1.203-.59 1.912-.59.063 0 .125.004.188.006l2.861-4.142V8.91c0-2.495 2.028-4.524 4.524-4.524 2.494 0 4.524 2.031 4.524 4.527s-2.03 4.525-4.524 4.525h-.105l-4.076 2.911c0 .052.004.105.004.159 0 1.875-1.515 3.396-3.39 3.396-1.635 0-3.016-1.173-3.331-2.727L.436 15.27C1.862 20.307 6.486 24 11.979 24c6.627 0 11.999-5.373 11.999-12S18.605 0 11.979 0zM7.54 18.21l-1.473-.61c.262.543.714.999 1.314 1.25 1.297.539 2.793-.076 3.332-1.375.263-.63.264-1.319.005-1.949s-.75-1.121-1.377-1.383c-.624-.26-1.29-.249-1.878-.03l1.523.63c.956.4 1.409 1.5 1.009 2.455-.397.957-1.497 1.41-2.454 1.012H7.54zm11.415-9.303c0-1.662-1.353-3.015-3.015-3.015-1.665 0-3.015 1.353-3.015 3.015 0 1.665 1.35 3.015 3.015 3.015 1.663 0 3.015-1.35 3.015-3.015zm-5.273-.005c0-1.252 1.013-2.266 2.265-2.266 1.249 0 2.266 1.014 2.266 2.266 0 1.251-1.017 2.265-2.266 2.265-1.253 0-2.265-1.014-2.265-2.265z"/></g></svg></span><div class="il-text"><b>Steam</b><span>The game is on Steam.</span></div></div>
@@ -440,7 +440,7 @@
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script type="module" src="js/lib/log-buffer.js?v=6d7ce577"></script>
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
-<script src="js/lib/topbar.js?v=7917046a"></script>
+<script src="js/lib/topbar.js?v=08584723"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/about/version.js?v=dd0d91d0"></script>
 <script src="js/about/jump-nav.js?v=ebc19086"></script>

--- a/admin.html
+++ b/admin.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=9e119a4e">
 <link rel="stylesheet" href="css/shared/topbar.css?v=1b5edcc1">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
-<link rel="stylesheet" href="css/shared/cards.css?v=3d5cd654">
+<link rel="stylesheet" href="css/shared/cards.css?v=5b30165c">
 <link rel="stylesheet" href="css/admin/admin.css?v=3b38f2f0">
 </head>
 <body>
@@ -379,7 +379,7 @@
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script type="module" src="js/lib/log-buffer.js?v=6d7ce577"></script>
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
-<script src="js/lib/topbar.js?v=7917046a"></script>
+<script src="js/lib/topbar.js?v=08584723"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/admin/main.js?v=7e7be6c0"></script>
 </body>

--- a/app.html
+++ b/app.html
@@ -17,8 +17,8 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=1b5edcc1">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/filters.css?v=f7ac5796">
-<link rel="stylesheet" href="css/shared/cards.css?v=3d5cd654">
-<link rel="stylesheet" href="css/app/game-header.css?v=510455ae">
+<link rel="stylesheet" href="css/shared/cards.css?v=5b30165c">
+<link rel="stylesheet" href="css/app/game-header.css?v=f144a9b7">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=58f2ef97">
 <link rel="stylesheet" href="css/app/modals.css?v=1d1a3a89">
@@ -58,7 +58,7 @@
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script type="module" src="js/lib/log-buffer.js?v=6d7ce577"></script>
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
-<script src="js/lib/topbar.js?v=7917046a"></script>
+<script src="js/lib/topbar.js?v=08584723"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script src="js/lib/gh-gist.js?v=346e3ea7"></script>
 <!-- #153: markdown-it renders the Notes field on report cards. renderNotes

--- a/auth.html
+++ b/auth.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=9e119a4e">
 <link rel="stylesheet" href="css/shared/topbar.css?v=1b5edcc1">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
-<link rel="stylesheet" href="css/shared/cards.css?v=3d5cd654">
+<link rel="stylesheet" href="css/shared/cards.css?v=5b30165c">
 <link rel="stylesheet" href="css/shared/lookup-inline.css?v=71ca0f75">
 <link rel="stylesheet" href="css/auth/auth.css?v=f1e72018">
 </head>

--- a/confidence.html
+++ b/confidence.html
@@ -13,8 +13,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=9e119a4e">
 <link rel="stylesheet" href="css/shared/topbar.css?v=1b5edcc1">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
-<link rel="stylesheet" href="css/shared/cards.css?v=3d5cd654">
-<link rel="stylesheet" href="css/app/game-header.css?v=510455ae">
+<link rel="stylesheet" href="css/shared/cards.css?v=5b30165c">
+<link rel="stylesheet" href="css/app/game-header.css?v=f144a9b7">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=58f2ef97">
 <link rel="stylesheet" href="css/app/modals.css?v=1d1a3a89">
@@ -204,7 +204,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=7917046a"></script>
+<script src="js/lib/topbar.js?v=08584723"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/css/app/game-header.css
+++ b/css/app/game-header.css
@@ -497,6 +497,31 @@
 }
 .game-header-art-col .game-header-art { width: 100%; height: auto; }
 
+/* #246: badge overlay on the detail-page artwork. The wrapper exists only to
+   give the absolutely-positioned badges a containing block; it must not add
+   layout of its own or the art column's flex gap doubles up. */
+.game-header-art-wrap { position: relative; display: block; min-width: 0; }
+/* Deliberately NOT driven by data-store-pill-pos. That preference shuffles the
+   store pill around a grid of small cards; here there is one large artwork, so
+   a fixed corner is easier to find than a badge that moves with a setting the
+   user last touched months ago. */
+.game-header-art-badges {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  z-index: 2;
+  pointer-events: none;   /* never swallow a click meant for the artwork */
+}
+/* The badges carry their own colors from cards.css; the shadow is what keeps
+   them legible over a bright or busy header image. */
+.game-header-art-badges > * {
+  pointer-events: auto;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.55);
+}
+
 /* Unified tag row under the artwork (#266 refinement): OS availability
    chips (Win / macOS / Linux) plus user-context tags (On wishlist / In
    library) share one .game-tag rounded-square shape (matches the Submit
@@ -525,6 +550,8 @@
   gap: 6px;
 }
 .game-user-tags:empty { display: none; }
+.game-vr-strip { display: flex; flex-wrap: wrap; gap: 6px; }
+.game-vr-strip[hidden] { display: none; }
 .game-type-strip { display: flex; flex-wrap: wrap; gap: 6px; }
 .game-type-strip[hidden] { display: none; }
 /* App type chip (mod / dlc / software) under the artwork. Same rounded-square
@@ -578,13 +605,33 @@
 .game-tag svg { display: block; }
 /* OS chips: buttons -- clicking opens the metadata modal. Off state is
    muted; on state lights up green because Steam advertises the platform. */
+/* #246: same .game-tag shape as the OS chips so the row reads as one strip,
+   but in the VR chip's amber so it ties back to the card badge. Two-class
+   selector on purpose: a bare .game-tag--vr has the same specificity as
+   .game-tag and lost to its `color: var(--muted)`, which rendered the chip
+   grey and indistinguishable from an unsupported platform. It only renders
+   when the game HAS VR, so it is always the lit state. */
+/* Same treatment as a supported OS chip: this row answers one question --
+   where does this game run -- so every chip in it reads the same. The amber
+   is the CARD badge's colour, where VR has to stand out against a store pill;
+   here it just made a five-chip row look like five unrelated things. */
+.game-tag.game-tag--vr {
+  color: var(--accent, #58a6ff);
+  border-color: rgba(88, 166, 255, 0.55);
+  background: rgba(88, 166, 255, 0.08);
+  opacity: 1;
+}
+
 .game-os-chip { cursor: pointer; opacity: 0.55; }
+/* .game-tag sets display:inline-flex, so [hidden] alone does not hide a chip
+   the JS marks as not-applicable. */
+.game-tag[hidden] { display: none; }
 .game-os-chip:hover { border-color: var(--accent); }
 .game-os-chip--on {
   opacity: 1;
-  color: #7ed37a;
-  border-color: rgba(126,211,122,0.55);
-  background: rgba(126,211,122,0.08);
+  color: var(--accent, #58a6ff);
+  border-color: rgba(88, 166, 255, 0.55);
+  background: rgba(88, 166, 255, 0.08);
 }
 .game-os-chip--on:hover {
   border-color: rgba(126,211,122,0.9);
@@ -682,12 +729,18 @@
 /* Light the active tab + reveal its panel off the matching checked radio. */
 #dt-deck:checked    ~ .dt-tabbar .dt-tab[for="dt-deck"],
 #dt-machine:checked ~ .dt-tabbar .dt-tab[for="dt-machine"],
-#dt-steamos:checked ~ .dt-tabbar .dt-tab[for="dt-steamos"] {
+#dt-steamos:checked ~ .dt-tabbar .dt-tab[for="dt-steamos"],
+#dt-vr:checked      ~ .dt-tabbar .dt-tab[for="dt-vr"] {
   background: var(--strong); color: var(--bg); border-color: var(--strong);
 }
 #dt-deck:checked    ~ .dt-panel-deck,
 #dt-machine:checked ~ .dt-panel-machine,
-#dt-steamos:checked ~ .dt-panel-steamos { display: block; }
+#dt-steamos:checked ~ .dt-panel-steamos,
+#dt-vr:checked      ~ .dt-panel-vr { display: block; }
+/* #246: the VR tab is hidden until fillVrOnLinuxTab confirms VRDB has reports
+   for this game, so most games keep three tabs rather than showing an empty
+   fourth. [hidden] needs the explicit none because .dt-tab sets display. */
+.dt-tab--vr[hidden] { display: none; }
 .dt-source { color: var(--muted); font-size: 0.72rem; margin: 0; font-style: italic; }
 @media (max-width: 480px) { .dt-tab-name { display: none; } }
 .deck-status-badge.deck-status-unknown {
@@ -2049,6 +2102,21 @@ button.hub-link:disabled { opacity: 0.5; cursor: default; }
 .sf-draft-restore button:hover { background: rgba(102, 192, 244, 0.1); }
 
 /* Replaced-by banner + REPLACED pill on the game header (#199 follow-up) */
+/* #246: VR-only notice. Same shape as the replaced banner but in the VR
+   chip's colour family so the banner and the badge read as the same feature.
+   Informational, not a warning: VR-only is a fact about the game, not a
+   problem with it. */
+.game-vr-banner {
+  margin-bottom: 12px;
+  padding: 10px 14px;
+  border-radius: 6px;
+  border: 1px solid var(--vr-banner-border, rgba(232, 163, 61, 0.38));
+  background: var(--vr-banner-bg, rgba(232, 163, 61, 0.10));
+  color: var(--text);
+  font-size: 0.86rem;
+  line-height: 1.45;
+}
+
 .game-replaced-banner {
   margin-bottom: 12px;
   padding: 10px 14px;

--- a/css/shared/cards.css
+++ b/css/shared/cards.css
@@ -181,34 +181,55 @@
   color: var(--delisted-chip-fg, #fff);
 }
 
-/* #246 VR chip. Same geometry as the delisted chip so the two stack cleanly
-   in the same strip. Two variants: "VR" (playable either way) stays quiet in
-   the Steam cyan family, "VR Only" is warmer because a headset requirement is
-   a hard gate for a flatscreen player, not a nice-to-have. */
+/* #246 VR chip. Sized to the 18px box the store icon and owner badges use.
+   Amber because the chip sits directly against the store pill, and every
+   store colour is in the blue/purple/grey family: Steam #1689d0, GOG #7a3fcf,
+   PCGWiki #4d5f9c, Epic #555. The first version was a muted blue and read as
+   part of the Steam pill rather than a separate badge. Amber is also unused
+   elsewhere in the card chrome and does not collide with any tier colour.
+   One variant only -- VR-only games say so in a banner on the detail page,
+   not with a second chip colour that says "different somehow" without
+   saying how. */
 .game-card-vr-chip {
-  display: inline-block;
-  padding: 0 5px;
-  border-radius: 3px;
-  font-size: 0.62em;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 6px;
+  font-size: 0.68rem;
   font-weight: 800;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  line-height: 1.5;
+  line-height: 18px;
   white-space: nowrap;
+  background: var(--vr-chip-bg, #e8a33d);
+  color: var(--vr-chip-fg, #16130c);
+  /* No radius of its own: the badge container's radius caps the strip (see
+     the bleed rules below), the same way .game-card-combo-tag already builds
+     its two-tone chip. A chip with its own corners sat as a square block
+     inside a curved badge and the leading end read as uncapped. */
+  border-radius: 0;
 }
-.game-card-vr-chip--supported {
-  background: var(--vr-chip-bg, rgba(65, 122, 155, 0.92));
-  color: var(--vr-chip-fg, #fff);
+
+/* Bleed the leading chip out through the container's padding so it reaches
+   the edge, then let the container clip it to its own curve. Each badge
+   variant has different padding, so each declares its own bleed; the chip
+   rule above stays generic. Only :first-child bleeds -- when a Delisted chip
+   precedes it, that one owns the leading edge instead. */
+.game-card-store-tag,
+.game-card-store-pill,
+.game-card-corner-tag,
+.game-card-strip-store { overflow: hidden; }
+
+.game-card-vr-chip:first-child {
+  align-self: stretch;
+  margin-top: calc(-1 * var(--badge-pad-y, 0px));
+  margin-bottom: calc(-1 * var(--badge-pad-y, 0px));
+  margin-left: calc(-1 * var(--badge-pad-x, 0px));
 }
-.game-card-vr-chip--only {
-  background: var(--vr-only-chip-bg, rgba(150, 95, 175, 0.92));
-  color: var(--vr-only-chip-fg, #fff);
-}
-[data-theme="light"] .game-card-vr-chip--supported {
-  background: var(--vr-chip-bg, rgba(55, 105, 135, 0.95));
-}
-[data-theme="light"] .game-card-vr-chip--only {
-  background: var(--vr-only-chip-bg, rgba(130, 80, 155, 0.95));
+.game-card-store-tag  { --badge-pad-y: 1px; --badge-pad-x: 5px; }
+.game-card-store-pill { --badge-pad-y: 4px; --badge-pad-x: 10px; }
+.game-card-corner-tag {
+  --badge-pad-y: calc(var(--owner-badge-size, 18px) * 0.12);
+  --badge-pad-x: calc(var(--owner-badge-size, 18px) * 0.42);
 }
 
 /* Owner badges (Subaru "Badge of Ownership" style): dark chrome chips
@@ -238,6 +259,11 @@
   height: var(--owner-badge-size, 18px);
   display: block;
 }
+/* Hover recolours the GLYPH, not the chip. Works because the sprites use
+   fill="currentColor" -- with the old fill="#fff" on the <symbol> the colour
+   was set inside the shadow tree and no outside rule could touch it. */
+.game-card-owner-badge { transition: color 0.15s ease; }
+.game-card-owner-badge:hover { color: var(--accent, #58a6ff); }
 /* Small gap before the store text so the icons read as attached but
    distinct decals rather than merging with the "STEAM" label. */
 .game-card-owner-badge:last-of-type { margin-right: 3px; }

--- a/game-stats.html
+++ b/game-stats.html
@@ -13,8 +13,8 @@
 <link rel="stylesheet" href="css/shared/base.css?v=9e119a4e">
 <link rel="stylesheet" href="css/shared/topbar.css?v=1b5edcc1">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
-<link rel="stylesheet" href="css/shared/cards.css?v=3d5cd654">
-<link rel="stylesheet" href="css/app/game-header.css?v=510455ae">
+<link rel="stylesheet" href="css/shared/cards.css?v=5b30165c">
+<link rel="stylesheet" href="css/app/game-header.css?v=f144a9b7">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=58f2ef97">
 <link rel="stylesheet" href="css/app/modals.css?v=1d1a3a89">
@@ -699,7 +699,7 @@ h1 {
 </style>
 </head>
 <body>
-<script src="js/lib/topbar.js?v=7917046a"></script>
+<script src="js/lib/topbar.js?v=08584723"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=1b5edcc1">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/filters.css?v=f7ac5796">
-<link rel="stylesheet" href="css/shared/cards.css?v=3d5cd654">
+<link rel="stylesheet" href="css/shared/cards.css?v=5b30165c">
 <link rel="stylesheet" href="css/index/index.css?v=54fb9989">
 </head>
 <body>
@@ -223,7 +223,7 @@
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script type="module" src="js/lib/log-buffer.js?v=6d7ce577"></script>
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
-<script src="js/lib/topbar.js?v=7917046a"></script>
+<script src="js/lib/topbar.js?v=08584723"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/index/main.js?v=6771661e"></script>
 </body>

--- a/js/app/api/deck-status.js
+++ b/js/app/api/deck-status.js
@@ -3,8 +3,78 @@
 import { dataUrl } from '../../lib/data-url.js?v=0de73aed';
 
 export const DECK_CAT_MAP = { 0: 'unknown', 1: 'unsupported', 2: 'playable', 3: 'verified' };
+// Steam Machine shares Deck's scale; SteamOS only ever shows Compatible as the
+// positive verdict, so 2 and 3 both map there. Mirrors MACHINE_CAT_MAP /
+// STEAMOS_CAT_MAP in scripts/pipeline/deck_status.py -- the live fallback below
+// must agree with the published map or the same game reads differently
+// depending on whether the pipeline happened to cover it.
+export const MACHINE_CAT_MAP = DECK_CAT_MAP;
+export const STEAMOS_CAT_MAP = { 0: 'unknown', 1: 'unsupported', 2: 'compatible', 3: 'compatible' };
 // display_type in resolved_items: 2=fail, 3=info/caveat, 4=pass
 export const DECK_DISPLAY_MAP = { 4: true, 3: null, 2: false };
+
+const STEAM_EXPLORE_URL = 'https://ilsgdshkaocrmibwdezk.supabase.co/functions/v1/steam-explore';
+
+function _extractCriteria(items, prefix) {
+  if (!Array.isArray(items)) return [];
+  const out = [];
+  for (const it of items) {
+    if (!it || typeof it !== 'object') continue;
+    const tok = String(it.loc_token || '');
+    out.push([it.display_type, tok.startsWith(prefix) ? tok.slice(prefix.length) : tok]);
+  }
+  return out;
+}
+
+/**
+ * Live Deck verdict for one app via the public steam-explore proxy.
+ *
+ * Steam's endpoint is not CORS-enabled, hence the proxy. This is the on-demand
+ * path for games the pipeline has not covered: the published map is capped per
+ * run, so the long tail of catalog stubs would otherwise render "no data"
+ * forever even though a real verdict exists upstream.
+ *
+ * Returns null on any failure -- callers treat that as "no data", never as a
+ * verdict.
+ * @param {string|number} appId
+ * @returns {Promise<object|null>}
+ */
+export async function fetchLiveDeckStatus(appId) {
+  const id = String(appId == null ? '' : appId).trim();
+  if (!/^\d+$/.test(id)) return null;
+  try {
+    const res = await fetch(STEAM_EXPLORE_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ endpoint: 'steam_deck', id }),
+    });
+    if (!res.ok) {
+      console.debug('[deck-status] live lookup non-2xx', { appId: id, status: res.status });
+      return null;
+    }
+    const body = await res.json();
+    const results = (body && body.data && body.data.results) || null;
+    if (!body?.ok || !results) return null;
+
+    const deckCat = Number(results.resolved_category) || 0;
+    const machineCat = Number(results.machine_resolved_category) || 0;
+    const steamosCat = Number(results.steamos_resolved_category) || 0;
+    // Nothing rated on any target: Valve genuinely has no verdict. That is a
+    // real answer, distinct from a failed lookup, so report it as data.
+    const items = Array.isArray(results.resolved_items) ? results.resolved_items : [];
+    return {
+      status: DECK_CAT_MAP[deckCat] || 'unknown',
+      criteria: items.length >= 4 ? items.slice(0, 4).map((i) => DECK_DISPLAY_MAP[i?.display_type]) : null,
+      machine: MACHINE_CAT_MAP[machineCat] || 'unknown',
+      steamos: STEAMOS_CAT_MAP[steamosCat] || 'unknown',
+      machine_criteria: _extractCriteria(results.machine_resolved_items, '#SteamMachine_TestResult_'),
+      steamos_criteria: _extractCriteria(results.steamos_resolved_items, '#SteamOS_TestResult_'),
+    };
+  } catch (err) {
+    console.debug('[deck-status] live lookup failed', { appId: id, error: String(err) });
+    return null;
+  }
+}
 
 // cache fetched deck compat so we dont re-fetch on every render
 export const _deckCache = {};
@@ -53,9 +123,26 @@ export async function fetchDeckStatusForApp(appId) {
         machine_criteria: Array.isArray(entry.machine_criteria) ? entry.machine_criteria : [],
         steamos_criteria: Array.isArray(entry.steamos_criteria) ? entry.steamos_criteria : [],
       }
-    : { status: 'unknown', criteria: null, machine: 'unknown', steamos: 'unknown', machine_criteria: [], steamos_criteria: [] };
-  _deckCache[appId] = ret;
-  return ret;
+    // hasData:false is NOT the same as Valve rating a game Unknown. The
+    // published map only covers what the pipeline has fetched so far, so a
+    // miss means "we have not asked yet". Rendering it as "Valve has not
+    // evaluated this title" asserted a fact about a third party we never
+    // checked -- CS2 read that way while the store page said Playable.
+    : null;
+  if (ret) {
+    ret.hasData = true;
+    _deckCache[appId] = ret;
+    return ret;
+  }
+  // Not in the published map. Ask upstream directly rather than telling the
+  // user Valve has no verdict -- the map only covers what the pipeline has
+  // fetched so far, and every catalog stub has a game page.
+  const live = await fetchLiveDeckStatus(appId);
+  const out = live
+    ? { ...live, hasData: true }
+    : { status: 'unknown', hasData: false, criteria: null, machine: 'unknown', steamos: 'unknown', machine_criteria: [], steamos_criteria: [] };
+  _deckCache[appId] = out;
+  return out;
 }
 
 // synchronous fallback used for initial render before the async fetch returns

--- a/js/app/api/reports.js
+++ b/js/app/api/reports.js
@@ -1,6 +1,6 @@
 // reports (api) for the app page. Relocated from app.js.
 
-import { SB_KEY, SB_URL } from '../config.js?v=a75604f5';
+import { SB_KEY, SB_URL } from '../config.js?v=7873e060';
 import { latestPerApp } from '../utils.js?v=4630c3d5';
 
 /**

--- a/js/app/api/supabase.js
+++ b/js/app/api/supabase.js
@@ -1,6 +1,6 @@
 // supabase (api) for the app page. Relocated from app.js.
 
-import { SB_KEY, SB_URL } from '../config.js?v=a75604f5';
+import { SB_KEY, SB_URL } from '../config.js?v=7873e060';
 import { configKey, latestPerClient } from '../utils.js?v=4630c3d5';
 
 export async function fetchSupabase(appId) {

--- a/js/app/api/votes.js
+++ b/js/app/api/votes.js
@@ -1,7 +1,7 @@
 // votes (api) for the app page. Relocated from app.js.
 
 import { getWebClientId } from '../../shared/submit.js?v=dc1442eb';
-import { SB_KEY, SB_URL } from '../config.js?v=a75604f5';
+import { SB_KEY, SB_URL } from '../config.js?v=7873e060';
 
 export async function fetchVotes(appId) {
   try {

--- a/js/app/api/votes.js
+++ b/js/app/api/votes.js
@@ -1,6 +1,6 @@
 // votes (api) for the app page. Relocated from app.js.
 
-import { getWebClientId } from '../../shared/submit.js?v=5bf5d430';
+import { getWebClientId } from '../../shared/submit.js?v=dc1442eb';
 import { SB_KEY, SB_URL } from '../config.js?v=a75604f5';
 
 export async function fetchVotes(appId) {

--- a/js/app/components/author.js
+++ b/js/app/components/author.js
@@ -1,7 +1,7 @@
 // author (components) for the app page. Relocated from app.js.
 
 import { fetchAuthorAvatar, fetchAuthorStats, getAuthorIdentity } from '../api/author.js?v=0d33fd7b';
-import { CDN } from '../config.js?v=a75604f5';
+import { CDN } from '../config.js?v=7873e060';
 import { route } from '../router.js?v=cf79f6bc';
 import { esc } from '../utils.js?v=4630c3d5';
 

--- a/js/app/components/config-cards.js
+++ b/js/app/components/config-cards.js
@@ -1,7 +1,7 @@
 // config-cards (components) for the app page. Relocated from app.js.
 
 import { getWebClientId } from '../../shared/submit.js?v=dc1442eb';
-import { isNonSteamAppId } from '../config.js?v=a75604f5';
+import { isNonSteamAppId } from '../config.js?v=7873e060';
 import { cfgNa, configKey, esc, utcStamp } from '../utils.js?v=4630c3d5';
 
 export const FORM_RESPONSE_LABELS = {

--- a/js/app/components/config-cards.js
+++ b/js/app/components/config-cards.js
@@ -1,6 +1,6 @@
 // config-cards (components) for the app page. Relocated from app.js.
 
-import { getWebClientId } from '../../shared/submit.js?v=5bf5d430';
+import { getWebClientId } from '../../shared/submit.js?v=dc1442eb';
 import { isNonSteamAppId } from '../config.js?v=a75604f5';
 import { cfgNa, configKey, esc, utcStamp } from '../utils.js?v=4630c3d5';
 

--- a/js/app/components/deck-status.js
+++ b/js/app/components/deck-status.js
@@ -1,7 +1,8 @@
 // deck-status (components) for the app page. Relocated from app.js.
 
-import { getDeckStatusForApp } from '../api/deck-status.js?v=0bbdc652';
+import { getDeckStatusForApp } from '../api/deck-status.js?v=c941cca9';
 import { esc } from '../utils.js?v=4630c3d5';
+import { VRDB_RATINGS, vrRuntimeLabel, vrdbRatingColor } from '../../shared/vr.js?v=8759ee7d';
 
 export const DECK_STATUS_LABELS = {
   verified:    'Verified',
@@ -118,17 +119,20 @@ const _DEVICE_SUMMARY = {
     playable:    'This game is <strong>Playable</strong> on Steam Deck. Functional, but may require extra effort to interact with or configure.',
     unsupported: 'This game is <strong>not supported</strong> on Steam Deck. Will not run, or critical features are unavailable.',
     unknown:     'Steam Deck compatibility is <strong>Unknown</strong>. Valve has not evaluated this title yet.',
+    nodata:      'We do not have a Steam Deck verdict for this title yet. Check the store page for Valve\'s current rating.',
   },
   machine: {
     verified:    'This game is <strong>Verified</strong> on Steam Machine. Fully functional out of the box.',
     playable:    'This game is <strong>Playable</strong> on Steam Machine. Functional, but may require some configuration.',
     unsupported: 'This game is <strong>not supported</strong> on Steam Machine.',
     unknown:     'Steam Machine compatibility is <strong>Unknown</strong>. Valve has not evaluated this title yet.',
+    nodata:      'We do not have a Steam Machine verdict for this title yet. Check the store page for Valve\'s current rating.',
   },
   steamos: {
     compatible:  'This game is <strong>Compatible</strong> with devices running SteamOS, based on Steam Deck verification results. Performance and input may vary by hardware.',
     unsupported: 'This game is <strong>not supported</strong> on SteamOS.',
     unknown:     'SteamOS compatibility is <strong>Unknown</strong>. Valve has not evaluated this title yet.',
+    nodata:      'We do not have a SteamOS verdict for this title yet. Check the store page for Valve\'s current rating.',
   },
 };
 
@@ -139,12 +143,14 @@ export function renderDeckStatusButton(appId) {
   // list - keep the button clickable so users still see the explanation, but
   // tag it visually so it reads as "definitively negative"
   const disabledClass = status === 'unsupported' ? ' deck-status-btn-unsupported' : '';
-  // Button label is just "Steam Deck" - the colored icon already encodes
-  // the status (green check, yellow i, red x, gray ?). Full "Steam Deck:
-  // Verified" string lives in the modal heading + the title-attr tooltip
-  return `<button class="info-btn info-btn-labeled deck-status-btn${disabledClass}" id="deck-status-btn" title="Steam Deck: ${label} (click for details)">
+  // Label is "Compatibility", not "Steam Deck": the modal behind it covers
+  // Steam Deck, Steam Machine, SteamOS and (when we have data) VR on Linux,
+  // so naming it after one tab undersells the other three. The coloured icon
+  // still encodes the DECK status, which is the headline verdict, and the
+  // title attribute spells it out.
+  return `<button class="info-btn info-btn-labeled deck-status-btn${disabledClass}" id="deck-status-btn" title="Steam Deck: ${label} (click for Deck, Machine, SteamOS and VR details)">
     <svg width="16" height="16" viewBox="0 0 24 24">${DECK_STATUS_ICON_SVG[status] || DECK_STATUS_ICON_SVG.unknown}</svg>
-    <span>Steam Deck</span>
+    <span>Compatibility</span>
   </button>`;
 }
 
@@ -167,9 +173,13 @@ function _tabLabel(id, iconId, name, status) {
 // `[[display_type, short_token], ...]` arrays; we look up the token in
 // CRITERIA_TOKEN_LABELS and fall back to camelCase-to-prose conversion so a
 // new Valve token still reads reasonably even before we tune the label.
-function _devicePanel(kind, name, status, criteria, tokenizedCriteria) {
+function _devicePanel(kind, name, status, criteria, tokenizedCriteria, hasData = true) {
   const label = _statusLabel(kind, status);
-  const summary = (_DEVICE_SUMMARY[kind] || {})[status] || '';
+  // A missing entry is not a Valve verdict. Only claim Valve rated something
+  // Unknown when the fetch actually returned that; otherwise say we have no
+  // data and point at the store page.
+  const summaryKey = (!hasData && status === 'unknown') ? 'nodata' : status;
+  const summary = (_DEVICE_SUMMARY[kind] || {})[summaryKey] || '';
   let body = '';
   if (kind === 'deck' && Array.isArray(criteria)) {
     body = `<div class="deck-criteria-list">${criteria.map((pass, i) => {
@@ -182,7 +192,12 @@ function _devicePanel(kind, name, status, criteria, tokenizedCriteria) {
       return `<div class="deck-criterion"><span class="deck-criterion-icon"><svg width="18" height="18" viewBox="0 0 24 24">${DECK_STATUS_ICON_SVG[iconKey]}</svg></span><span>${esc(_criterionLabel(tok))}</span></div>`;
     }).join('')}</div>`;
   } else {
-    body = `<p class="dt-source">${status === 'unknown' ? 'Valve has not published a verdict for this title yet.' : "Source: Valve's official compatibility report."}</p>`;
+    const sourceNote = status !== 'unknown'
+      ? "Source: Valve's official compatibility report."
+      : hasData
+        ? 'Valve has not published a verdict for this title yet.'
+        : 'Not yet fetched by our pipeline. This is not a statement about how the game runs.';
+    body = `<p class="dt-source">${sourceNote}</p>`;
   }
   return `
     <h3 style="margin:0 0 8px;font-size:0.95rem;color:var(--strong)">${esc(name)} Compatibility: <span class="deck-status-badge deck-status-${status}">${label}</span></h3>
@@ -198,20 +213,78 @@ export function renderDeckStatusModalContent(appId) {
   const deckStatus = d.status || 'unknown';
   const machineStatus = d.machine || 'unknown';
   const osStatus = d.steamos || 'unknown';
+  // #246: VR on Linux joins the device tabs. It is the same question the other
+  // three answer ("will this run on my hardware"), and it was buried in the
+  // Metadata modal where nobody looking for compatibility would find it.
+  // The panel body fills in asynchronously -- vrdb.json is a separate fetch
+  // and the modal must not wait on it to open.
   return `
     <div class="deck-tabs">
       <input type="radio" name="devtab" id="dt-deck" class="dt-radio" checked>
       <input type="radio" name="devtab" id="dt-machine" class="dt-radio">
       <input type="radio" name="devtab" id="dt-steamos" class="dt-radio">
+      <input type="radio" name="devtab" id="dt-vr" class="dt-radio">
       <div class="dt-tabbar" role="tablist">
         ${_tabLabel('deck', 'icon-steam-deck', 'Steam Deck', deckStatus)}
         ${_tabLabel('machine', 'icon-steam-machine', 'Steam Machine', machineStatus)}
         ${_tabLabel('steamos', 'icon-steamos', 'SteamOS', osStatus)}
+        <label for="dt-vr" class="dt-tab dt-tab--vr" title="VR on Linux" id="dt-vr-tab" hidden>
+          <svg class="dt-tab-glyph" viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M3 8h18a1 1 0 0 1 1 1v5a3 3 0 0 1-3 3h-3.2a2 2 0 0 1-1.7-.9l-1.3-2a1 1 0 0 0-1.6 0l-1.3 2a2 2 0 0 1-1.7.9H5a3 3 0 0 1-3-3V9a1 1 0 0 1 1-1z"/></svg>
+          <span class="dt-tab-name">VR on Linux</span>
+        </label>
       </div>
-      <div class="dt-panel dt-panel-deck">${_devicePanel('deck', 'Steam Deck', deckStatus, d.criteria, null)}</div>
-      <div class="dt-panel dt-panel-machine">${_devicePanel('machine', 'Steam Machine', machineStatus, null, d.machine_criteria)}</div>
-      <div class="dt-panel dt-panel-steamos">${_devicePanel('steamos', 'SteamOS', osStatus, null, d.steamos_criteria)}</div>
+      <div class="dt-panel dt-panel-deck">${_devicePanel('deck', 'Steam Deck', deckStatus, d.criteria, null, d.hasData !== false)}</div>
+      <div class="dt-panel dt-panel-machine">${_devicePanel('machine', 'Steam Machine', machineStatus, null, d.machine_criteria, d.hasData !== false)}</div>
+      <div class="dt-panel dt-panel-steamos">${_devicePanel('steamos', 'SteamOS', osStatus, null, d.steamos_criteria, d.hasData !== false)}</div>
+      <div class="dt-panel dt-panel-vr" id="dt-panel-vr"></div>
     </div>`;
+}
+
+/**
+ * Fill the VR on Linux tab, and reveal it only when VRDB has reports.
+ *
+ * Kept out of renderDeckStatusModalContent because that function is
+ * synchronous (it renders off the in-memory deck cache so the modal opens
+ * instantly) while VRDB is a separate fetch. A game with no VRDB entry keeps
+ * three tabs rather than showing an empty fourth.
+ *
+ * @param {Element} root - The rendered modal content.
+ * @param {object|null} entry - VRDB game record, or null when we have none.
+ * @param {string|number} appId - Steam app id, for the deep link.
+ */
+export function fillVrOnLinuxTab(root, entry, appId) {
+  if (!root) return;
+  const tab = root.querySelector('#dt-vr-tab');
+  const panel = root.querySelector('#dt-panel-vr');
+  if (!tab || !panel) return;
+  const runtimes = entry && entry.runtimes && typeof entry.runtimes === 'object' ? entry.runtimes : null;
+  const rows = runtimes ? Object.entries(runtimes) : [];
+  if (!rows.length) return;   // no data: leave the tab hidden
+
+  // Best rating first so the most promising runtime leads.
+  rows.sort((a, b) => (Number(a[1]?.best) || 9) - (Number(b[1]?.best) || 9));
+  const body = rows.map(([runtime, stats]) => {
+    const best = Number(stats?.best);
+    const count = Number(stats?.count) || 0;
+    return `<div class="gm-vr-row">
+      <span class="gm-vr-runtime">${esc(vrRuntimeLabel(runtime))}</span>
+      <span class="gm-vr-rating" style="background:${vrdbRatingColor(best)}">${esc(VRDB_RATINGS[best] || 'Unrated')}</span>
+      <span class="gm-mute">${count} report${count === 1 ? '' : 's'}</span>
+    </div>`;
+  }).join('');
+  const devices = Array.isArray(entry.devices) && entry.devices.length
+    ? `<div class="gm-chips" style="margin-top:8px">${entry.devices.slice(0, 8).map(dv => `<span class="gm-chip">${esc(dv)}</span>`).join('')}</div>`
+    : '';
+  const latest = entry.latest ? ` \u00b7 latest ${esc(String(entry.latest))}` : '';
+  const url = `https://db.vronlinux.org/games/${encodeURIComponent(String(appId))}.html`;
+  panel.innerHTML = `
+    <h3 style="margin:0 0 8px;font-size:0.95rem;color:var(--strong)">VR on Linux</h3>
+    <p style="color:var(--muted);font-size:0.84rem;margin:0 0 12px;line-height:1.5">
+      Community reports per VR runtime. Their scale runs 1 = best, the opposite way to a Pulse tier, so it is shown with their own labels and never mixed into our scoring.
+    </p>
+    ${body}${devices}
+    <p class="dt-source" style="margin-top:8px">Source: <a href="${esc(url)}" target="_blank" rel="noopener">VR on Linux DB</a> (MIT)${latest}</p>`;
+  tab.hidden = false;
 }
 
 // - Author / signals / permalink helpers --------------

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -4,15 +4,15 @@ import { appIdToDir } from '../../lib/app-id.js?v=6159afa9';
 import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=b4fbb7ef';
 import { populateScoringTooltip, pulseTierFromReports, estimateScore } from '../../shared/scoring.js?v=852c9d97';
 import { computeCompatTrend, computeConfidence, RECENT_DAYS, PRIOR_WINDOW_DAYS } from '../../lib/scoring/gameStats.js?v=6a63af50';
-import { getWebClientId } from '../../shared/submit.js?v=5bf5d430';
-import { fetchAppDepotInfo, fetchAppMetadata, fetchAppNews, fetchDeckStatusForApp, fetchMinRequirements, fetchLinuxNativeSupport } from '../api/deck-status.js?v=0bbdc652';
+import { getWebClientId } from '../../shared/submit.js?v=dc1442eb';
+import { fetchAppDepotInfo, fetchAppMetadata, fetchAppNews, fetchDeckStatusForApp, fetchMinRequirements, fetchLinuxNativeSupport } from '../api/deck-status.js?v=c941cca9';
 import { fetchCdn, fetchProtonDbLive, readProtonDbLiveCache } from '../api/protondb.js?v=b7ff6a75';
 import { readSharedField, writeShared, clearShared, isEnabled as isSharedEnabled } from '../../shared/filters-shared.js?v=2d441093';
 import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagReport } from '../api/supabase.js?v=3aeaaba2';
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=aba6619f';
 import { enhanceAuthorBlocks } from './author.js?v=3a8cb3c7';
 import { renderConfigCard } from './config-cards.js?v=c67740f8';
-import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, _STEAM_MACHINE_RE, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=830efdfb';
+import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, _STEAM_MACHINE_RE, fillVrOnLinuxTab, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=01ba8999';
 import { renderCard } from './report-card.js?v=5e25c644';
 import { loadExtendedSteamIndex, extendedSteamIndex } from './search.js?v=091f940b';
 import { getGamesByIds } from '../api/search-games.js?v=0b6c4bb3';
@@ -90,6 +90,7 @@ import { getMyWishlistAppIds } from '../lib/user-wishlist.js?v=9c88bc65';
 import { computeBadgesForAppId } from '../../lib/card-badges.js?v=5b71af11';
 import { getAntiCheatForApp, bucketAntiCheatStatus, humanAntiCheatStatus } from '../lib/anti-cheat.js?v=34f8a0a7';
 import { getVrdbForApp } from '../lib/vrdb.js?v=f7c0f65a';
+import { loadVrIndex, vrForApp } from '../lib/vr-index.js?v=f094c84f';
 import { VRDB_RATINGS, vrRuntimeLabel, vrdbRatingColor } from '../../shared/vr.js?v=8759ee7d';
 import { getPCGamingWikiForApp, humanPCGamingWikiOs, pcgamingwikiSearchUrl } from '../lib/pcgamingwiki.js?v=50ac9a1a';
 
@@ -717,7 +718,12 @@ async function _openMetadataModal(appId) {
       ? `<div class="gm-chips" style="margin-top:6px">${vrdb.devices.slice(0, 6).map(d => `<span class="gm-chip">${esc(d)}</span>`).join('')}</div>`
       : '';
     const latest = vrdb.latest ? ` \u00b7 latest ${esc(String(vrdb.latest))}` : '';
-    const src = `<div class="gm-mute" style="margin-top:4px; font-size:0.75rem">Source: <a href="https://db.vronlinux.org/" target="_blank" rel="noopener">VR on Linux DB</a> (MIT)${latest}. Separate methodology from Pulse scoring.</div>`;
+    // Deep-link to this game's VRDB page rather than the site root: the
+    // reader is looking at one game's reports and wants the rest of them, not
+    // a search box. Their pages are keyed on the Steam appid, and this block
+    // only renders when we matched a VRDB entry for that id.
+    const vrdbUrl = `https://db.vronlinux.org/games/${encodeURIComponent(String(appId))}.html`;
+    const src = `<div class="gm-mute" style="margin-top:4px; font-size:0.75rem">Source: <a href="${esc(vrdbUrl)}" target="_blank" rel="noopener">VR on Linux DB</a> (MIT)${latest}. Separate methodology from Pulse scoring.</div>`;
     return `${rows}${devices}${src}`;
   };
 
@@ -1497,12 +1503,19 @@ export async function renderGamePage(appId) {
           Reports on this page cover the original build; if you meant to report on the current version, use the link above.
         </div>`
       : '';
+    // #246: VR-only games get a banner instead of a second chip variant. On a
+    // card there is room for one badge and "VR" is the useful bit; the
+    // headset REQUIREMENT is a detail-page concern, and a sentence says it
+    // unambiguously where a second colour of chip did not. Populated async
+    // below so a slow vr-index fetch never delays the header.
+    const vrOnlyBanner = '<div class="game-vr-banner" id="game-vr-banner" hidden></div>';
     const submitHref = `submit.html?app=${appId}&title=${encodeURIComponent(title)}`;
     const submitBtnTitle = '';
 
     el.innerHTML = `
       <div class="game-header">
         ${replacedBanner}
+        ${vrOnlyBanner}
         <div class="game-title">${esc(title)} <span class="game-title-store" title="Storefront this entry originated from">(${esc(_titleStoreLabel(appId, replacedBy) || 'Steam')})</span>${isDelisted ? ' <span class="game-detail-delisted" title="Removed from the Steam store. Reports still apply -- people still own this via family share, backups, or regional accounts.">DELISTED</span>' : ''}${/\bdemo\b/i.test(title) ? ' <span class="game-title-demo-pill" title="This entry looks like a demo based on the title. Reports may not reflect the full game.">DEMO</span>' : ''}</div>
         <div class="game-header-grid">
           <div class="game-header-art-col">
@@ -1517,7 +1530,16 @@ export async function renderGamePage(appId) {
                  portrait cover is still shown when nothing better exists,
                  just never as the first-choice src that would flash a
                  broken image on load. #471. -->
-            <img class="game-header-art" src="${esc(sgdbCover || STEAM_IMG(appId))}" referrerpolicy="no-referrer" data-appid="${appId}" alt="" onerror="window.__steamImgLoad(this)">
+            <div class="game-header-art-wrap">
+              <img class="game-header-art" src="${esc(sgdbCover || STEAM_IMG(appId))}" referrerpolicy="no-referrer" data-appid="${appId}" alt="" onerror="window.__steamImgLoad(this)">
+              <!-- #246: the same badges the browse cards show (In library, On
+                   wishlist, VR), overlaid on the artwork. Pinned top-right
+                   regardless of the store-pill position preference: that pref
+                   moves the STORE pill around a grid of small cards, but on
+                   the detail page there is one large artwork and a single
+                   predictable corner is easier to read than a moving target. -->
+              <div class="game-header-art-badges" id="game-art-badges" hidden aria-label="Game badges"></div>
+            </div>
           </div>
           ${ratingPanel}
           <!-- Uniform tag row under the artwork: OS chips + user-context
@@ -1537,10 +1559,16 @@ export async function renderGamePage(appId) {
                 <span>macOS</span>
               </button>
               <button type="button" class="game-tag game-os-chip" data-os="linux" title="Linux">
-                <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M12 2c-1.66 0-3 1.34-3 3v3.5c-1.5 1-3 2.5-3 5.5 0 2.5 1 4.5 2 5.5.5.5 1 1 1 2v.5h6V21c0-1 .5-1.5 1-2 1-1 2-3 2-5.5 0-3-1.5-4.5-3-5.5V5c0-1.66-1.34-3-3-3zm-1.5 5c.28 0 .5.22.5.5s-.22.5-.5.5-.5-.22-.5-.5.22-.5.5-.5zm3 0c.28 0 .5.22.5.5s-.22.5-.5.5-.5-.22-.5-.5.22-.5.5-.5zM12 11l-1.5 2h3L12 11z"/></svg>
+                <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path fill="currentColor" d="M12 1.8c-2.3 0-4 1.8-4 4.1v2.4c0 .9-.4 1.6-1 2.4-1.2 1.5-2 3-2.4 4.6-.2.9.2 1.5 1 1.7.5.1 1 0 1.4-.3.2 1.6 1.2 2.7 2.6 3.2 1.6.6 3.3.6 4.9 0 1.4-.5 2.4-1.6 2.6-3.2.4.3.9.4 1.4.3.8-.2 1.2-.8 1-1.7-.4-1.6-1.2-3.1-2.4-4.6-.6-.8-1-1.5-1-2.4V5.9c0-2.3-1.8-4.1-4.1-4.1z"/><ellipse cx="12" cy="15.4" rx="3.1" ry="4" fill="#fff" opacity=".92"/><circle cx="10.4" cy="6.2" r="1.35" fill="#fff"/><circle cx="13.6" cy="6.2" r="1.35" fill="#fff"/><circle cx="10.6" cy="6.4" r=".62" fill="#0b0f14"/><circle cx="13.4" cy="6.4" r=".62" fill="#0b0f14"/><path fill="#f5a623" d="M12 7.5c.85 0 1.55.42 1.55.95 0 .52-.7.95-1.55.95s-1.55-.43-1.55-.95c0-.53.7-.95 1.55-.95z"/><path fill="#f5a623" d="M9.1 20.5c-.6.5-1.6.6-2 .1-.3-.4 0-.9.7-1.3l1.7-1zM14.9 20.5c.6.5 1.6.6 2 .1.3-.4 0-.9-.7-1.3l-1.7-1z"/></svg>
                 <span>Linux</span>
               </button>
             </div>
+            <!-- #246: VR sits beside the OS chips, not inside them. That
+                 container is aria-label="Supported operating systems" and VR
+                 is a capability, not an OS -- folding it in would make the
+                 label wrong for screen readers. Same .game-tag shape so it
+                 reads as part of the same row. -->
+            <div class="game-vr-strip" id="game-vr-strip" hidden aria-label="VR support"></div>
             <div class="game-type-strip" id="game-type-strip" hidden aria-label="App type"></div>
             <div class="game-user-tags" id="game-user-tags" aria-label="Your Steam context"></div>
           </div>
@@ -2331,10 +2359,89 @@ export async function renderGamePage(appId) {
       // Render each badge as a .game-tag pill so it matches the OS chips
       // in size + shape. Steam-blue background + white text keeps them
       // reading as "yours" without competing with the green OS chips.
-      host.innerHTML = badges.map((b) =>
-        `<span class="game-tag game-tag--user" data-badge="${b.key}" style="background:${b.color}">${b.label}</span>`,
-      ).join('');
+      // Ownership shows as an icon on the artwork overlay instead. Rendering
+      // it here too put "In library" in the platform row, which is answering
+      // a different question (where it runs) and made the row look like it
+      // held five unrelated facts.
+      host.innerHTML = '';
     })();
+
+    // Artwork badge overlay (#246). Separate from the tag row above because
+    // it renders for signed-out users too: VR capability is a property of the
+    // game, not of the viewer, so gating it behind sign-in would hide it from
+    // most visitors. Owner badges still require a session.
+    void (async () => {
+      // VR on Linux tab in the compatibility modal. Independent of the vr-index
+      // capability flag below: a game can have VRDB reports without Steam
+      // flagging it VR, and vice versa.
+      void getVrdbForApp(appId)
+        .then((e) => fillVrOnLinuxTab(el.querySelector('#deck-status-content'), e, appId))
+        .catch(() => {});
+
+      const vr = vrForApp(await loadVrIndex().catch(() => ({})), appId);
+      const only = vr === 'only';
+
+      // Tag row chip first, and NOT gated on the artwork overlay existing.
+      // These used to share an `if (!host) return` guard, so a missing
+      // #game-art-badges silently took the tag-row chip down with it.
+      // One label: "VR" means the game has VR, full stop. VR-only is said in
+      // the banner, the same call as the cards -- a second label here would
+      // reintroduce the "different somehow" problem we removed there.
+      if (vr) {
+        const strip = el.querySelector('#game-vr-strip');
+        if (strip) {
+          strip.innerHTML = '<span class="game-tag game-tag--vr"'
+            + ` title="${only ? 'VR only: requires a headset' : 'Playable in VR or on a monitor'}">`
+            + '<svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true">'
+            + '<path d="M3 8h18a1 1 0 0 1 1 1v5a3 3 0 0 1-3 3h-3.2a2 2 0 0 1-1.7-.9l-1.3-2a1 1 0 0 0-1.6 0l-1.3 2a2 2 0 0 1-1.7.9H5a3 3 0 0 1-3-3V9a1 1 0 0 1 1-1z"/>'
+            + '</svg><span>VR</span></span>';
+          strip.hidden = false;
+        }
+        if (only) {
+          const banner = el.querySelector('#game-vr-banner');
+          if (banner) {
+            banner.innerHTML = '<strong>This game is VR only.</strong> '
+              + 'It requires a VR headset and cannot be played on a monitor. '
+              + 'Reports here describe VR play.';
+            banner.hidden = false;
+          }
+        }
+      }
+
+      // Artwork overlay carries ownership only. VR lives in the tag row under
+      // the artwork (and the banner when it is VR-only); a chip on the art as
+      // well was the same fact twice, competing with the box art.
+      const host = el.querySelector('#game-art-badges');
+      if (!host) return;
+      const parts = [];
+
+      try {
+        const session = await window.SupaAuth?.getSession?.();
+        if (session && session.user) {
+          const [libraryAppIds, wishlistAppIds] = await Promise.all([
+            getMyLibraryAppIds().catch(() => new Set()),
+            getMyWishlistAppIds().catch(() => new Set()),
+          ]);
+          const numericId = Number(appId);
+          if (libraryAppIds && libraryAppIds.has(numericId)) {
+            parts.push('<span class="game-card-owner-badge game-card-owner-badge--library" title="In Library" aria-label="In Library"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="#icon-book-open"/></svg></span>');
+          }
+          if (wishlistAppIds && wishlistAppIds.has(numericId)) {
+            parts.push('<span class="game-card-owner-badge game-card-owner-badge--wishlist" title="On your Steam wishlist" aria-label="On wishlist"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="#icon-wishlist-heart"/></svg></span>');
+          }
+        }
+      } catch { /* signed out -- VR chip alone is still worth showing */ }
+
+      if (parts.length) {
+        host.innerHTML = parts.join('');
+        host.hidden = false;
+      }
+    })().catch((err) => {
+      // Without this the whole block is an unhandled rejection: a missing
+      // import took out the VR chip, the VR-only banner AND the artwork
+      // badges at once, with an empty console. Log loudly instead.
+      console.error('[game-page] VR / owner badge render failed', { appId, error: String(err) });
+    });
 
     // fetch real Steam Deck compat + min requirements and patch the UI.
     // Also probe platforms.linux via the same shared appdetails cache so
@@ -2361,6 +2468,11 @@ export async function renderGamePage(appId) {
           for (const chip of strip.querySelectorAll('.game-os-chip')) {
             const key = chip.dataset.os; // 'windows' | 'mac' | 'linux'
             const on = !!platforms[key];
+            // Show only what applies. A row of greyed-out chips for every OS
+            // the game does NOT support is noise: the reader wants to know
+            // where it runs, not where it does not. Same rule the VR chip
+            // already follows (it renders only when the game has VR).
+            chip.hidden = !on;
             chip.classList.toggle('game-os-chip--on', on);
             const label = { windows: 'Windows', mac: 'macOS', linux: 'Linux' }[key] || key;
             chip.title = on
@@ -2394,7 +2506,11 @@ export async function renderGamePage(appId) {
         deckBtn.title = `Steam Deck: ${lbl} (click for details)`;
       }
       const deckTip = el.querySelector('#deck-status-tip');
-      if (deckTip) deckTip.innerHTML = `<div class="info-tooltip-inner">${renderDeckStatusModalContent(appId)}</div>`;
+      if (deckTip) {
+        deckTip.innerHTML = `<div class="info-tooltip-inner">${renderDeckStatusModalContent(appId)}</div>`;
+        // Re-render wipes the VR tab, so refill it from the memoized payload.
+        void getVrdbForApp(appId).then((e) => fillVrOnLinuxTab(deckTip, e, appId)).catch(() => {});
+      }
 
       // fill min requirements panel
       const reqsEl = el.querySelector('#min-reqs-content');

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -81,7 +81,7 @@ async function _sgdbCoverFor(appId) {
 }
 import { showAdultAllowed } from '../../lib/adult-filter.js?v=e4e9d845';
 import { loadGameHides } from '../lib/game-hides.js?v=2d7d7afe';
-import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, appTypeFromAppId, dataFilesHref, storeLabel, storeLabelFromAppId } from '../config.js?v=a75604f5';
+import { CDN, RATING_COLORS, RATING_TEXT, SB_KEY, SB_URL, SITE_ROOT, STEAM_IMG, appTypeFromAppId, dataFileHref, dataFilesHref, storeLabel, storeLabelFromAppId } from '../config.js?v=7873e060';
 import { loadSteamImg as _loadSteamImg } from '../lib/steam-img.js?v=5adc7e54';
 import { configKey, daysAgo, downloadJson, esc, mergeReportsById, reportKey } from '../utils.js?v=4630c3d5';
 import { dataUrl } from '../../lib/data-url.js?v=0de73aed';
@@ -556,9 +556,12 @@ async function _openMetadataModal(appId) {
       return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
     };
     // #237: brown package icon that deep-links to the per-game depots.json
-    // we publish alongside latest.json. GitHub blob URL so users see the
-    // raw JSON with syntax highlighting + a "Raw" download button.
-    const DEPOT_FILE_URL = `https://github.com/mdeguzis/proton-pulse-web/blob/gh-pages/data/${esc(String(meta.appId))}/depots.json`;
+    // we publish alongside latest.json. Routed through dataFileHref so it
+    // hits the R2 data host the pipeline actually syncs to, and so non-Steam
+    // canonical ids get the colon -> underscore directory mapping. This was
+    // a hardcoded github.com/.../blob/gh-pages/... URL, which 404s: gh-pages
+    // is the branch #396 archives and it never carried depots.json.
+    const DEPOT_FILE_URL = dataFileHref(meta.appId, 'depots.json');
     const row = (key, label) => {
       const on = !!p[key];
       const cached = dOs[key];

--- a/js/app/components/home-library-chart.js
+++ b/js/app/components/home-library-chart.js
@@ -22,7 +22,7 @@ async function _tierRowsFor(view, appIds) {
   }
   return rows;
 }
-import { RATING_COLORS, RATING_TEXT } from '../config.js?v=a75604f5';
+import { RATING_COLORS, RATING_TEXT } from '../config.js?v=7873e060';
 import { esc } from '../utils.js?v=4630c3d5';
 import { loadDeckStatusMap } from '../api/deck-status.js?v=c941cca9';
 

--- a/js/app/components/home-library-chart.js
+++ b/js/app/components/home-library-chart.js
@@ -24,7 +24,7 @@ async function _tierRowsFor(view, appIds) {
 }
 import { RATING_COLORS, RATING_TEXT } from '../config.js?v=a75604f5';
 import { esc } from '../utils.js?v=4630c3d5';
-import { loadDeckStatusMap } from '../api/deck-status.js?v=0bbdc652';
+import { loadDeckStatusMap } from '../api/deck-status.js?v=c941cca9';
 
 const TIER_ORDER = ['platinum', 'gold', 'silver', 'bronze', 'borked'];
 const TIER_LABEL = {

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -5,7 +5,7 @@ import { loadGameHides } from '../lib/game-hides.js?v=2d7d7afe';
 import { browseGames, getGamesByIds } from '../api/search-games.js?v=0b6c4bb3';
 import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '../config.js?v=a75604f5';
 import { daysAgo, latestPerApp } from '../utils.js?v=4630c3d5';
-import { renderGameCard } from '../lib/card.js?v=287d13ce';
+import { renderGameCard } from '../lib/card.js?v=bdeb653b';
 import { dataUrl } from '../../lib/data-url.js?v=0de73aed';
 import { padTileRows, watchTileRerender, pageSizeForFullRows, targetRowsForViewport } from '../../lib/tile-pad.js?v=ad4b114d';
 import { getEffectivePageSize, isAutoLoadEnabled } from '../../lib/pagination-prefs.js?v=15d0747d';
@@ -17,7 +17,7 @@ import { renderHomeLibraryChart } from './home-library-chart.js?v=65bf9f7a';
 import { getMyLibraryAppIds } from '../lib/user-library.js?v=1d8e72df';
 import { getMyWishlistAppIds } from '../lib/user-wishlist.js?v=9c88bc65';
 import { getSavedLookupLibraryAppIds, getSavedLookupWishlistAppIds, hasSavedLookup } from '../lib/saved-lookup.js?v=7c45ae8b';
-import { loadDeckStatusMap } from '../api/deck-status.js?v=0bbdc652';
+import { loadDeckStatusMap } from '../api/deck-status.js?v=c941cca9';
 import { loadVrIndex, matchesVrFilter, vrForApp } from '../lib/vr-index.js?v=f094c84f';
 import { readShowOwnerBadgesLocal, pullShowOwnerBadges } from '../../lib/user-prefs.js?v=09b673c8';
 import { pageNavHtml, wirePageNav } from '../lib/page-nav.js?v=2cdc55e4';
@@ -721,6 +721,38 @@ export async function renderHomePage() {
       }
     }
 
+    // #246: VR browse pool. most_played.json is Steam's top ~55 chart, so
+    // filtering it for VR yields a handful of games while the catalog has
+    // ~1,300. Picking a VR filter therefore BROWSES rather than narrowing:
+    // the search API already supports a server-side vr filter, so ask it for
+    // VR titles the same way the non-Steam stores do above. Without this,
+    // "VR" reads as "VR games that happen to be trending right now".
+    const HOME_VR_CAP = 500;
+    let _homeVrRows = [];
+    const _homeVrFetched = new Set();
+    async function _ensureHomeVr(filter) {
+      if (!filter || filter === 'all' || _homeVrFetched.has(filter)) return;
+      const rows = [];
+      let offset = 0;
+      while (offset < HOME_VR_CAP) {
+        const { results } = await browseGames({ sort: 'popular', limit: 100, offset, vr: filter });
+        for (const r of results) {
+          const t = String(r.tier || '').toLowerCase();
+          rows.push({
+            appId: r.appId, title: r.title,
+            tier: KNOWN_TIERS.has(t) ? t : 'pending',
+            protondbCount: r.protondbCount || 0, pulseCount: r.pulseCount || 0,
+            appType: r.source, delisted: r.delisted === true,
+          });
+        }
+        _addEnrichmentRows(results);
+        offset += 100;
+        if (results.length < 100) break;
+      }
+      _homeVrRows = rows;
+      _homeVrFetched.add(filter);
+    }
+
     // The previous super-condensed list-row renderer is gone -- the two
     // layouts now are 'list' (horizontal cards from _recentCardHtml /
     // popular item) and 'grid' (the same cards re-flowed into Steam-
@@ -771,15 +803,23 @@ export async function renderHomePage() {
         const noTierFilter = tierSel.size === 0 || tierSel.has('all');
         const wantUnrated = noTierFilter || tierSel.has('unrated');
         const onlyUnrated = tierSel.size === 1 && tierSel.has('unrated');
-        const pool = [
-          ...(onlyUnrated ? [] : ratedGames),
-          ...(wantUnrated ? unratedGames : []),
-        ];
+        // #246: with a VR filter on, browse the catalog slice the API returned
+        // instead of the top-55 chart. _filterByVr below still runs and is a
+        // no-op on these rows (they already match), which keeps the chain
+        // uniform and still filters the chart rows when the fetch failed.
+        const vrFilterActive = vrSel.size > 0 && !vrSel.has('all');
+        const pool = vrFilterActive && _homeVrRows.length
+          ? _homeVrRows
+          : [
+            ...(onlyUnrated ? [] : ratedGames),
+            ...(wantUnrated ? unratedGames : []),
+          ];
         // Map rating -> tier ('pending' for unrated) so the shared Set-based tier
         // filter treats them consistently with recent reports.
         asReports = pool.map(g => {
-          const t = String(g.rating || '').toLowerCase();
-          return { ...g, tier: KNOWN_TIERS.has(t) ? t : 'pending', delisted: _isDelisted(g.appId) };
+          // Chart rows carry `rating`; API-browsed VR rows already carry `tier`.
+          const t = String(g.rating || g.tier || '').toLowerCase();
+          return { ...g, tier: KNOWN_TIERS.has(t) ? t : 'pending', delisted: g.delisted === true || _isDelisted(g.appId) };
         });
       }
       const filtered = filterDelisted(filterAdult(_filterByText(_filterByVr(_filterByKind(_filterBySteamOS(_filterByMachine(_filterByDeck(_filterByWishlist(_filterByLibrary(_filterByStore(_filterByType(_filterByTier(asReports, tierSel), sourceSel), storeSel), librarySel, libraryAppIds), wishlistSel, wishlistAppIds), deckSel, deckStatusMap), machineSel, deckStatusMap), steamosSel, deckStatusMap), kindSel), vrSel, vrMap), textFilter)));
@@ -1266,6 +1306,10 @@ export async function renderHomePage() {
       vrSel = sel;
       const needMap = sel && sel.size > 0 && !sel.has('all');
       if (needMap && !vrMap) vrMap = await loadVrIndex().catch(() => ({}));
+      // Browse the catalog for VR titles rather than narrowing the top-55
+      // chart. Failure leaves _homeVrRows empty and the chart-filter path
+      // takes over, which is thin but never blank.
+      if (needMap) await _ensureHomeVr([...sel][0]).catch(() => {});
       updateFilterBadge(); applyRecentFilters(); applyPopularFilters(); _saveFiltersIfEnabled();
     }});
 

--- a/js/app/components/home.js
+++ b/js/app/components/home.js
@@ -3,7 +3,7 @@
 import { fetchRecentPulseReports } from '../api/reports.js?v=003f23c0';
 import { loadGameHides } from '../lib/game-hides.js?v=2d7d7afe';
 import { browseGames, getGamesByIds } from '../api/search-games.js?v=0b6c4bb3';
-import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '../config.js?v=a75604f5';
+import { SB_KEY, SB_URL, isNonSteamAppId, appTypeFromAppId, storeLabel } from '../config.js?v=7873e060';
 import { daysAgo, latestPerApp } from '../utils.js?v=4630c3d5';
 import { renderGameCard } from '../lib/card.js?v=bdeb653b';
 import { dataUrl } from '../../lib/data-url.js?v=0de73aed';

--- a/js/app/components/report-card.js
+++ b/js/app/components/report-card.js
@@ -5,7 +5,7 @@ import { detectGpuArch } from '../../lib/gpu-arch-detector.js?v=b4fbb7ef';
 import { renderAuthorBlock } from './author.js?v=3a8cb3c7';
 import { buildFormRows } from './config-cards.js?v=c67740f8';
 import { renderSignalStrip } from './signals.js?v=ff2ad4c9';
-import { RATING_COLORS, RATING_TEXT } from '../config.js?v=a75604f5';
+import { RATING_COLORS, RATING_TEXT } from '../config.js?v=7873e060';
 import { confColor, confTextColor, configKey, daysAgo, esc, renderNotes, fmtDuration, fmtMinutes, hashReportKey, reportKey } from '../utils.js?v=4630c3d5';
 
 export function renderPermalink(r) {

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,8 +2,8 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=852c9d97';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=003f23c0';
-import { renderGamePage } from './game-page.js?v=31eb38cf';
-import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId, fetchDataWithProdFallback } from '../config.js?v=a75604f5';
+import { renderGamePage } from './game-page.js?v=01232d6b';
+import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId, fetchDataWithProdFallback } from '../config.js?v=7873e060';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=4630c3d5';
 import { renderGameCard } from '../lib/card.js?v=bdeb653b';
 import { dataUrl } from '../../lib/data-url.js?v=0de73aed';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,10 +2,10 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=852c9d97';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=003f23c0';
-import { renderGamePage } from './game-page.js?v=adfa8bf4';
+import { renderGamePage } from './game-page.js?v=31eb38cf';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId, fetchDataWithProdFallback } from '../config.js?v=a75604f5';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=4630c3d5';
-import { renderGameCard } from '../lib/card.js?v=287d13ce';
+import { renderGameCard } from '../lib/card.js?v=bdeb653b';
 import { dataUrl } from '../../lib/data-url.js?v=0de73aed';
 import { filterAdultEntries, isAdultEntry } from '../../lib/adult-filter.js?v=e4e9d845';
 import { filterDelistedEntries, countHiddenDelisted, showDelistedAllowed } from '../../lib/delisted-filter.js?v=42858e22';

--- a/js/app/components/signals.js
+++ b/js/app/components/signals.js
@@ -1,6 +1,6 @@
 // signals (components) for the app page. Relocated from app.js.
 
-import { isSteamDeckHardware, isSteamMachineHardware } from './deck-status.js?v=830efdfb';
+import { isSteamDeckHardware, isSteamMachineHardware } from './deck-status.js?v=01ba8999';
 
 export const SIGNAL_ICON_SVG = {
   install: '<path fill="currentColor" d="M5 20h14v-2H5v2zm7-2 5-5h-3V4h-4v9H7l5 5z"/>',

--- a/js/app/config.js
+++ b/js/app/config.js
@@ -54,7 +54,15 @@ function _dataHost() {
 }
 // appIdToDir matches the pipeline's on-disk layout (colon -> underscore);
 // a raw canonical id 404s on R2 for gog:/epic:/pgwiki: entries.
-export const dataFilesHref = appId => `${_dataHost()}/data/${appIdToDir(appId)}/latest.json`;
+// Every per-game file the pipeline emits (latest.json, the year buckets,
+// votes.json, depots.json) lands in the same directory and syncs to the same
+// R2 bucket, so one builder covers all of them. Anything linking at a
+// per-game file must go through here: a hand-built GitHub blob URL pointed
+// at the gh-pages branch, which #396 archives, and skipped appIdToDir so
+// gog:/epic: ids 404'd on top of that.
+export const dataFileHref = (appId, file = 'latest.json') =>
+  `${_dataHost()}/data/${appIdToDir(appId)}/${file}`;
+export const dataFilesHref = appId => dataFileHref(appId, 'latest.json');
 
 // Fetch a pipeline data path from the current origin first; if it 404s,
 // retry once against production so a staging build that hasn't run the

--- a/js/app/lib/card.js
+++ b/js/app/lib/card.js
@@ -71,12 +71,15 @@ export function renderGameCard({ href, appId, title, sub, tier, badge, badgeBg, 
   const delistedChip = delisted
     ? `<span class="game-card-delisted-chip" title="${delistedTitle}" aria-label="Delisted">Delisted</span>`
     : '';
-  // #246: VR chip rides in the same strip as the delisted chip. "VR Only" is
-  // called out separately from "VR" because a headset requirement is the thing
-  // a flatscreen player needs to see before clicking through.
+  // #246: VR chip rides in the same strip as the delisted chip. ONE variant:
+  // a card has room for one badge and "VR" is the useful bit at a glance. The
+  // headset requirement is a detail-page concern, surfaced there as a banner
+  // -- a second chip colour said "this is different somehow" without saying
+  // how, and "VR ONLY" doubled the width of the strip on the S card size.
+  // The distinction still exists in the data and drives the VR Only filter.
   const vrKey = vr === 'only' || vr === 'supported' ? vr : '';
   const vrChip = vrKey
-    ? `<span class="game-card-vr-chip game-card-vr-chip--${vrKey}" title="${vrKey === 'only' ? 'Requires a VR headset' : 'Playable in VR or on a monitor'}" aria-label="${vrKey === 'only' ? 'VR only' : 'VR supported'}">${vrKey === 'only' ? 'VR Only' : 'VR'}</span>`
+    ? `<span class="game-card-vr-chip" title="${vrKey === 'only' ? 'VR only: requires a headset' : 'Playable in VR or on a monitor'}" aria-label="${vrKey === 'only' ? 'VR only' : 'VR supported'}">VR</span>`
     : '';
   // #431: owner badges (library / wishlist) live INSIDE every store-badge
   // variant so they always ride along with the store banner wherever the

--- a/js/app/lib/card.js
+++ b/js/app/lib/card.js
@@ -1,6 +1,6 @@
 // Unified game card renderer. Single source of truth for the
 // thumbnail | title + sub | badge card layout used everywhere.
-import { STEAM_IMG } from '../config.js?v=a75604f5';
+import { STEAM_IMG } from '../config.js?v=7873e060';
 import { esc } from '../utils.js?v=4630c3d5';
 import { loadSteamImg as _loadSteamImg } from './steam-img.js?v=5adc7e54';
 

--- a/js/app/lib/game-hides.js
+++ b/js/app/lib/game-hides.js
@@ -3,7 +3,7 @@
 // policy on the table lets browse / search / game-page reject hidden
 // appids without needing a user session. Cached once per page load in a
 // Promise so parallel callers share a single fetch.
-import { SB_URL, SB_KEY } from '../config.js?v=a75604f5';
+import { SB_URL, SB_KEY } from '../config.js?v=7873e060';
 
 let _hidesPromise = null;
 

--- a/js/app/lib/user-library.js
+++ b/js/app/lib/user-library.js
@@ -1,7 +1,7 @@
 // Cached lookup of the signed-in user's Steam library appids, backed by the
 // user_steam_library Supabase table. Loaded once per page and shared across
 // components (home chart, ownership checks, etc.) (#199).
-import { SB_URL, SB_KEY } from '../config.js?v=a75604f5';
+import { SB_URL, SB_KEY } from '../config.js?v=7873e060';
 
 let _appIdsCache = null; // Set<number> | null
 

--- a/js/app/lib/user-wishlist.js
+++ b/js/app/lib/user-wishlist.js
@@ -6,7 +6,7 @@
 // way profile.html auto-syncs the library on first visit): try to read the
 // cached row; if it doesn't exist, POST to the sync-steam-wishlist edge
 // function once, then re-read. Only fires when the user is signed in.
-import { SB_URL, SB_KEY } from '../config.js?v=a75604f5';
+import { SB_URL, SB_KEY } from '../config.js?v=7873e060';
 
 let _appIdsCache = null; // Set<number> | null
 

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,7 +1,7 @@
 // router (entry) for the app page. Relocated from app.js.
 
 import { pcgwSlugToPwId } from '../lib/app-id.js?v=6159afa9';
-import { renderGamePage } from './components/game-page.js?v=31eb38cf';
+import { renderGamePage } from './components/game-page.js?v=01232d6b';
 import { renderHomePage } from './components/home.js?v=183b5b8f';
 import { renderSearchPage } from './components/search.js?v=091f940b';
 

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,8 +1,8 @@
 // router (entry) for the app page. Relocated from app.js.
 
 import { pcgwSlugToPwId } from '../lib/app-id.js?v=6159afa9';
-import { renderGamePage } from './components/game-page.js?v=adfa8bf4';
-import { renderHomePage } from './components/home.js?v=f55f4612';
+import { renderGamePage } from './components/game-page.js?v=31eb38cf';
+import { renderHomePage } from './components/home.js?v=183b5b8f';
 import { renderSearchPage } from './components/search.js?v=091f940b';
 
 export function getRoute() {

--- a/js/index/main.js
+++ b/js/index/main.js
@@ -4,7 +4,7 @@ import { dataUrl } from '../lib/data-url.js?v=0de73aed';
 import { padTileRows, watchTileRerender, pageSizeForFullRows, targetRowsForViewport, currentColCount } from '../lib/tile-pad.js?v=ad4b114d';
 import { filterAdult } from '../lib/adult-filter.js?v=e4e9d845';
 import { filterDelisted } from '../lib/delisted-filter.js?v=42858e22';
-import { renderGameCard } from '../app/lib/card.js?v=287d13ce';
+import { renderGameCard } from '../app/lib/card.js?v=bdeb653b';
 import { browseGames, getGamesByIds } from '../app/api/search-games.js?v=0b6c4bb3';
 import { initCardSizeToggle, setCardSizeButtonsEnabled } from '../lib/card-size.js?v=3402f405';
 

--- a/js/lib/topbar.js
+++ b/js/lib/topbar.js
@@ -65,7 +65,7 @@
          store-pill color at 11-13px without the old white halo. Id kept for
          call-site stability (home.js references #icon-wishlist-heart). -->
     <symbol id="icon-wishlist-heart" viewBox="0 0 24 24">
-      <g fill="#fff" stroke="#000" stroke-width="1.2" stroke-linejoin="round">
+      <g fill="currentColor" stroke="#000" stroke-width="1.2" stroke-linejoin="round">
         <path d="M4.6 8.2h14.8v3.4H4.6z"/>
         <path d="M5.6 11.6h12.8v7a1.4 1.4 0 0 1-1.4 1.4H7a1.4 1.4 0 0 1-1.4-1.4z"/>
         <path d="M12 8.2C10.6 8.2 8 7.9 7.5 6.3 7.1 5.1 8.4 4.3 9.5 5 10.6 5.7 11.5 6.8 12 8.2z"/>
@@ -77,7 +77,7 @@
          white fill with no outline so it reads on any store-pill color at
          11-13px. Replaced the old 2x2 collection grid. Id kept for call-site
          stability (home.js references #icon-book-open). -->
-    <symbol id="icon-book-open" viewBox="0 0 24 24" fill="#fff">
+    <symbol id="icon-book-open" viewBox="0 0 24 24" fill="currentColor">
       <rect x="3.5" y="4.8"  width="17" height="3.6" rx="1.8"/>
       <rect x="3.5" y="10.2" width="17" height="3.6" rx="1.8"/>
       <rect x="3.5" y="15.6" width="17" height="3.6" rx="1.8"/>

--- a/js/lookup/main.js
+++ b/js/lookup/main.js
@@ -14,7 +14,7 @@
 
 import { computeLibraryTierCounts } from '../app/components/home-library-chart.js?v=65bf9f7a';
 import { getGamesByIds } from '../app/api/search-games.js?v=0b6c4bb3';
-import { RATING_COLORS, RATING_TEXT } from '../app/config.js?v=a75604f5';
+import { RATING_COLORS, RATING_TEXT } from '../app/config.js?v=7873e060';
 import { esc } from '../app/utils.js?v=4630c3d5';
 // localStorage keys the /lookup page reads + writes are defined in the
 // shared module so the inline "Library" panel + the nav fallback + this

--- a/js/profile/components/edit-modals.js
+++ b/js/profile/components/edit-modals.js
@@ -11,7 +11,7 @@ import {
   fetchReportHistory, patchUserConfig,
 } from '../api/configs.js?v=2f08c67b';
 import { updateSystem } from '../api/systems.js?v=770d14b7';
-import { notesFormattingHelpHtml } from '../../shared/submit.js?v=5bf5d430';
+import { notesFormattingHelpHtml } from '../../shared/submit.js?v=dc1442eb';
 
 export let _cloudEditModal = null;
 export function getCloudEditModal() {

--- a/js/shared/submit.js
+++ b/js/shared/submit.js
@@ -739,7 +739,7 @@ export async function populateSubmitForm(el) {
       <div class="sf-row sf-row--play-mode">
         <label>Play Mode *</label>
         <div class="sf-yn" id="sf-play-mode">
-          <label class="sf-yn-btn"><input type="radio" name="playMode" value="flat" checked> Flatscreen</label>
+          <label class="sf-yn-btn"><input type="radio" name="playMode" value="flat"> Flatscreen</label>
           <label class="sf-yn-btn"><input type="radio" name="playMode" value="vr"> VR</label>
         </div>
       </div>
@@ -1258,6 +1258,39 @@ export function setRunTypeNativeAvailable(container, isAvailable) {
  * change of mind. Headset "Other" opens a free-text box.
  * @param {Element} container - The form container.
  */
+/**
+ * Preselect Play Mode from the game's VR capability (#246).
+ *
+ *   'only'      -> VR        (it cannot be played any other way)
+ *   null        -> Flatscreen (it has no VR mode at all)
+ *   'supported' -> neither, and the field becomes required
+ *
+ * The "supported" case is the whole point of not hardcoding a default: those
+ * games are genuinely playable both ways, and a preselected answer there is
+ * one the reporter never consciously made. Guessing wrong is worse than
+ * asking, because play mode changes what "runs well" even means.
+ *
+ * @param {Element} container - The form container.
+ * @param {string|null} vr - search_index.vr for this game.
+ * @returns {'flat'|'vr'|null} What was preselected, or null when left blank.
+ */
+export function applyPlayModeDefault(container, vr) {
+  if (!container) return null;
+  const radios = [...container.querySelectorAll('input[name="playMode"]')];
+  if (!radios.length) return null;
+  const want = vr === 'only' ? 'vr' : (vr ? null : 'flat');
+  for (const radio of radios) {
+    radio.checked = want != null && radio.value === want;
+    // Playable both ways: force a deliberate choice rather than shipping a
+    // default the reporter did not make.
+    radio.required = want == null;
+  }
+  // Programmatic .checked does not fire change, so the VR runtime + headset
+  // rows would stay hidden on a VR-only game without this.
+  if (want) radios.find((r) => r.value === want)?.dispatchEvent(new Event('change', { bubbles: true }));
+  return want;
+}
+
 function wirePlayModeToggle(container) {
   const radios = container.querySelectorAll('input[name="playMode"]');
   if (!radios.length) return;

--- a/js/submit/main.js
+++ b/js/submit/main.js
@@ -1,7 +1,8 @@
 // Entry module for submit.html. Migrated from the page's inline script.
 import { FAULT_KEYS_WEB } from '../shared/scoring.js?v=852c9d97';
-import { applyDraftSnapshot, populateSubmitForm, prefillSubmitFormFromMyHardware, renderVerifiedOwnerStatus, setRunTypeNativeAvailable, submitReport } from '../shared/submit.js?v=5bf5d430';
-import { fetchLinuxNativeSupport } from '../app/api/deck-status.js?v=0bbdc652';
+import { loadVrIndex, vrForApp } from '../app/lib/vr-index.js?v=f094c84f';
+import { applyDraftSnapshot, applyPlayModeDefault, populateSubmitForm, prefillSubmitFormFromMyHardware, renderVerifiedOwnerStatus, setRunTypeNativeAvailable, submitReport } from '../shared/submit.js?v=dc1442eb';
+import { fetchLinuxNativeSupport } from '../app/api/deck-status.js?v=c941cca9';
 import {
   deleteDraft, deleteLocalDraft, draftStampSuffix as stampSuffix, snapshotFormData, saveDraft, loadBestDraft, makeAutoSaver,
 } from '../shared/drafts.js?v=9f4cdcaf';
@@ -190,6 +191,12 @@ import { getGamesByIds } from '../app/api/search-games.js?v=0b6c4bb3';
   const el = document.querySelector('.main-inner');
   try {
     await populateSubmitForm(el);
+    // Preselect Play Mode from the game's VR capability. VR-only games default
+    // to VR, non-VR games to Flatscreen, and games playable both ways are left
+    // blank so the reporter picks (see applyPlayModeDefault).
+    void loadVrIndex()
+      .then((map) => applyPlayModeDefault(el, vrForApp(map, appId)))
+      .catch((err) => console.debug('[submit] play mode default skipped', { appId, error: String(err) }));
   } catch (err) {
     console.error('[submit] populateSubmitForm failed:', err);
     document.getElementById('submit-form-content').innerHTML =

--- a/lookup.html
+++ b/lookup.html
@@ -122,7 +122,7 @@
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script type="module" src="js/lib/log-buffer.js?v=6d7ce577"></script>
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
-<script src="js/lib/topbar.js?v=7917046a"></script>
+<script src="js/lib/topbar.js?v=08584723"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/lookup/main.js?v=8d9f5128"></script>
 </body>

--- a/options.html
+++ b/options.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=9e119a4e">
 <link rel="stylesheet" href="css/shared/topbar.css?v=1b5edcc1">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
-<link rel="stylesheet" href="css/shared/cards.css?v=3d5cd654">
+<link rel="stylesheet" href="css/shared/cards.css?v=5b30165c">
 <link rel="stylesheet" href="css/options/options.css?v=585c31e7">
 </head>
 <body>
@@ -328,7 +328,7 @@
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script type="module" src="js/lib/log-buffer.js?v=6d7ce577"></script>
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
-<script src="js/lib/topbar.js?v=7917046a"></script>
+<script src="js/lib/topbar.js?v=08584723"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/options/main.js?v=67ecae23"></script>
 </body>

--- a/plugin-link.html
+++ b/plugin-link.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=9e119a4e">
 <link rel="stylesheet" href="css/shared/topbar.css?v=1b5edcc1">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
-<link rel="stylesheet" href="css/shared/cards.css?v=3d5cd654">
+<link rel="stylesheet" href="css/shared/cards.css?v=5b30165c">
 <link rel="stylesheet" href="css/plugin-link/plugin-link.css?v=05cefd1d">
 </head>
 <body>

--- a/privacy.html
+++ b/privacy.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=9e119a4e">
 <link rel="stylesheet" href="css/shared/topbar.css?v=1b5edcc1">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
-<link rel="stylesheet" href="css/shared/cards.css?v=3d5cd654">
+<link rel="stylesheet" href="css/shared/cards.css?v=5b30165c">
 <link rel="stylesheet" href="css/index/index.css?v=54fb9989">
 <style>
   .prose { max-width: 760px; margin: 2rem auto; line-height: 1.7; padding: 0 16px; }
@@ -197,7 +197,7 @@
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script type="module" src="js/lib/log-buffer.js?v=6d7ce577"></script>
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
-<script src="js/lib/topbar.js?v=7917046a"></script>
+<script src="js/lib/topbar.js?v=08584723"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=9e119a4e">
 <link rel="stylesheet" href="css/shared/topbar.css?v=1b5edcc1">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
-<link rel="stylesheet" href="css/shared/cards.css?v=3d5cd654">
+<link rel="stylesheet" href="css/shared/cards.css?v=5b30165c">
 <link rel="stylesheet" href="css/shared/lookup-inline.css?v=71ca0f75">
 <link rel="stylesheet" href="css/profile/profile.css?v=e9fe4860">
 </head>
@@ -381,7 +381,7 @@
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script type="module" src="js/lib/log-buffer.js?v=6d7ce577"></script>
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
-<script src="js/lib/topbar.js?v=7917046a"></script>
+<script src="js/lib/topbar.js?v=08584723"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/profile/main.js?v=512ce309"></script>
 </body>

--- a/scoring.html
+++ b/scoring.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=9e119a4e">
 <link rel="stylesheet" href="css/shared/topbar.css?v=1b5edcc1">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
-<link rel="stylesheet" href="css/shared/cards.css?v=3d5cd654">
+<link rel="stylesheet" href="css/shared/cards.css?v=5b30165c">
 <style>
 h1 {
   font-family: var(--font-display);
@@ -495,7 +495,7 @@ h2 small {
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script type="module" src="js/lib/log-buffer.js?v=6d7ce577"></script>
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
-<script src="js/lib/topbar.js?v=7917046a"></script>
+<script src="js/lib/topbar.js?v=08584723"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/scripts/pipeline/cli.py
+++ b/scripts/pipeline/cli.py
@@ -127,6 +127,17 @@ def build_parser():
         "deck-status",
         help="Build deck-status.json (Valve's per-game Steam Deck verdict, fetched server-side)",
     )
+    deck_status_parser.add_argument(
+        "--budget", type=int, default=None,
+        help="Max NEW verdict fetches this run (default: the pipeline's per-run budget). "
+             "Use a large value (or 0 for no cap) for an ad-hoc full fill.",
+    )
+    deck_status_parser.add_argument(
+        "--delay", type=float, default=0.35,
+        help="Seconds between requests (default: 0.35). Measured sustainable rate on this "
+             "endpoint is ~3 req/s with no throttling; it is a store widget, not the "
+             "appdetails API that caps at 200 per 5 minutes.",
+    )
     add_shared_output_arg(deck_status_parser)
 
     vr_backfill_parser = subparsers.add_parser(
@@ -208,7 +219,14 @@ def main():
         return
 
     if command == "deck-status":
-        build_deck_status(args.output_dir)
+        from .deck_status import steam_app_ids_for_deck_status
+        # budget=0 means "no cap" -- the full-fill path.
+        if args.budget is None:
+            ids = None
+        else:
+            budget = args.budget if args.budget > 0 else 10 ** 9
+            ids = steam_app_ids_for_deck_status(args.output_dir, budget=budget)
+        build_deck_status(args.output_dir, app_ids=ids, delay=args.delay)
         return
 
     if command == "vr-backfill":

--- a/scripts/pipeline/deck_status.py
+++ b/scripts/pipeline/deck_status.py
@@ -178,25 +178,96 @@ def fetch_deck_compat(app_id):
     return val
 
 
-def steam_app_ids_with_reports(output_dir):
-    """Steam app ids from search-index.json that have at least one report.
+# Per-run budget for NEW Deck verdict fetches. Cached ids cost nothing (30-day
+# TTL), so the map accumulates across runs rather than re-fetching the catalog.
+DECK_FETCH_BUDGET = 400
 
-    Scopes the fetch to games users actually inspect (they have a real game
-    page), instead of every catalog stub. search-index row shape:
-    [app_id, title, tier, protondb_count, pulse_count, app_type, ...].
+
+def _json_or_empty(path):
+    """Read a pipeline JSON side-file, or return None when it is absent.
+
+    These are optional inputs: on a finalize-only run most_played.json may not
+    have been regenerated. Missing means "no priority hint", not an error.
     """
-    rows = json.loads((Path(output_dir) / "search-index.json").read_text(encoding="utf-8"))
-    ids = []
+    try:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def steam_app_ids_for_deck_status(output_dir, budget=DECK_FETCH_BUDGET):
+    """Steam app ids to fetch Deck verdicts for, most-visible first.
+
+    Deliberately NOT gated on report counts. It used to be
+    `(protondb_count + pulse_count) > 0`, which was fine while ProtonDB counts
+    populated the index -- then #474 decoupled ProtonDB, every protondb_count
+    went to 0, and the scope silently collapsed from thousands of games to 17.
+    Nothing failed: the file wrote successfully and the log reported the new
+    count as if it were normal. Counter-Strike 2 showed "Valve has not
+    evaluated this title yet" while the store page said Playable.
+
+    Priority order, because the budget cannot cover 32k Steam rows in one run:
+      1. games with Pulse reports      (someone cared enough to report)
+      2. Steam's most-played chart     (what the home page shows)
+      3. recently reported games       (the other home section)
+      4. everything else in the index  (fills the remaining budget)
+
+    Ids already in the verdict cache are returned too and cost no request, so
+    the published map keeps growing instead of churning.
+    """
+    out = Path(output_dir)
+    rows = json.loads((out / "search-index.json").read_text(encoding="utf-8"))
+
+    steam_ids, reported = [], []
     for row in rows:
         if not isinstance(row, list) or len(row) < 6:
             continue
         app_id = str(row[0])
-        app_type = row[5] or "steam"
-        pdb = row[3] or 0
-        pulse = row[4] or 0
-        if app_type == "steam" and app_id.isdigit() and (pdb + pulse) > 0:
-            ids.append(app_id)
-    return ids
+        if (row[5] or "steam") != "steam" or not app_id.isdigit():
+            continue
+        steam_ids.append(app_id)
+        if (row[3] or 0) + (row[4] or 0) > 0:
+            reported.append(app_id)
+
+    def _ids_from(payload, keys=("appId", "appid", "app_id", "id")):
+        found = []
+        for entry in payload or []:
+            if not isinstance(entry, dict):
+                continue
+            for key in keys:
+                val = entry.get(key)
+                if val is not None:
+                    found.append(str(val))
+                    break
+        return found
+
+    ordered, seen = [], set()
+    for group in (
+        reported,
+        _ids_from(_json_or_empty(out / "most_played.json")),
+        _ids_from(_json_or_empty(out / "recent-reports.json")),
+        steam_ids,
+    ):
+        for app_id in group:
+            if app_id.isdigit() and app_id not in seen:
+                seen.add(app_id)
+                ordered.append(app_id)
+
+    # Everything already cached rides along for free; the budget only limits
+    # ids that would cost a request.
+    cache = _load_cache()
+    cached_ids = [a for a in ordered if a in cache]
+    fresh = [a for a in ordered if a not in cache][:budget]
+    log(
+        f"[deck-status] scope: {len(ordered):,} steam apps, {len(cached_ids):,} already cached, "
+        f"fetching up to {len(fresh):,} new (budget {budget})"
+    )
+    return cached_ids + fresh
+
+
+# Back-compat alias: the old name said "with reports", which is exactly the
+# assumption that broke. Kept so any external caller keeps working.
+steam_app_ids_with_reports = steam_app_ids_for_deck_status
 
 
 def build_deck_status(output_dir, app_ids=None, delay=0.0):
@@ -205,7 +276,7 @@ def build_deck_status(output_dir, app_ids=None, delay=0.0):
     Returns the ``{app_id: {status, criteria}}`` map that was written.
     """
     out_dir = Path(output_dir)
-    ids = app_ids if app_ids is not None else steam_app_ids_with_reports(out_dir)
+    ids = app_ids if app_ids is not None else steam_app_ids_for_deck_status(out_dir)
     result = {}
     for app_id in ids:
         val = fetch_deck_compat(app_id)

--- a/scripts/pipeline/most_played.py
+++ b/scripts/pipeline/most_played.py
@@ -96,7 +96,13 @@ def _last_report_date(data_dir: Path, app_id: str) -> str | None:
 def build_most_played(
     output_dir,
     limit: int = 100,
-    unrated_limit: int = 50,
+    # Sized to cover Steam's whole chart (100 entries) on its own. It used to
+    # be 50, which worked while `limit` rated games carried the section and
+    # unrated ones were a supplement. #474 decoupled ProtonDB, every
+    # protondb_count went to 0 and nearly every tier became "pending", so the
+    # unrated bucket became the ENTIRE section and its supplementary cap
+    # silently truncated Steam's top 100 down to ~55.
+    unrated_limit: int = 100,
     catalog_limit: int = 20,
     ranks: list[dict] | None = None,
 ) -> list[dict]:

--- a/stats.html
+++ b/stats.html
@@ -14,7 +14,7 @@
 <link rel="stylesheet" href="css/shared/topbar.css?v=1b5edcc1">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
 <link rel="stylesheet" href="css/shared/filters.css?v=f7ac5796">
-<link rel="stylesheet" href="css/shared/cards.css?v=3d5cd654">
+<link rel="stylesheet" href="css/shared/cards.css?v=5b30165c">
 <style>
 h1 {
   font-family: var(--font-display);
@@ -762,7 +762,7 @@ h2 {
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script type="module" src="js/lib/log-buffer.js?v=6d7ce577"></script>
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
-<script src="js/lib/topbar.js?v=7917046a"></script>
+<script src="js/lib/topbar.js?v=08584723"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content"><div class="main-inner">

--- a/status.html
+++ b/status.html
@@ -117,7 +117,7 @@
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script type="module" src="js/lib/log-buffer.js?v=6d7ce577"></script>
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
-<script src="js/lib/topbar.js?v=7917046a"></script>
+<script src="js/lib/topbar.js?v=08584723"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <script type="module" src="js/status/main.js?v=98034590"></script>
 

--- a/submit.html
+++ b/submit.html
@@ -12,9 +12,9 @@
 <link rel="stylesheet" href="css/shared/base.css?v=9e119a4e">
 <link rel="stylesheet" href="css/shared/topbar.css?v=1b5edcc1">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
-<link rel="stylesheet" href="css/shared/cards.css?v=3d5cd654">
+<link rel="stylesheet" href="css/shared/cards.css?v=5b30165c">
 <link rel="stylesheet" href="css/shared/lookup-inline.css?v=71ca0f75">
-<link rel="stylesheet" href="css/app/game-header.css?v=510455ae">
+<link rel="stylesheet" href="css/app/game-header.css?v=f144a9b7">
 <link rel="stylesheet" href="css/app/configs.css?v=90d5bed5">
 <link rel="stylesheet" href="css/app/reports.css?v=58f2ef97">
 <link rel="stylesheet" href="css/app/modals.css?v=1d1a3a89">
@@ -26,7 +26,7 @@
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script type="module" src="js/lib/log-buffer.js?v=6d7ce577"></script>
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
-<script src="js/lib/topbar.js?v=7917046a"></script>
+<script src="js/lib/topbar.js?v=08584723"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 <!-- Markdown editor spike (?md=1). Loaded eagerly but only wired when the
      flag is on -- window.markdownit stays unused otherwise. -->
@@ -66,6 +66,6 @@
   </div>
 </div>
 
-<script type="module" src="js/submit/main.js?v=28ae41b1"></script>
+<script type="module" src="js/submit/main.js?v=8d98c5cc"></script>
 </body>
 </html>

--- a/system-edit.html
+++ b/system-edit.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=9e119a4e">
 <link rel="stylesheet" href="css/shared/topbar.css?v=1b5edcc1">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
-<link rel="stylesheet" href="css/shared/cards.css?v=3d5cd654">
+<link rel="stylesheet" href="css/shared/cards.css?v=5b30165c">
 <link rel="stylesheet" href="css/profile/profile.css?v=e9fe4860">
 </head>
 <body>
@@ -21,7 +21,7 @@
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script type="module" src="js/lib/log-buffer.js?v=6d7ce577"></script>
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
-<script src="js/lib/topbar.js?v=7917046a"></script>
+<script src="js/lib/topbar.js?v=08584723"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 
 <div class="main-content">

--- a/terms.html
+++ b/terms.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/shared/base.css?v=9e119a4e">
 <link rel="stylesheet" href="css/shared/topbar.css?v=1b5edcc1">
 <link rel="stylesheet" href="css/shared/site.css?v=619dee5a">
-<link rel="stylesheet" href="css/shared/cards.css?v=3d5cd654">
+<link rel="stylesheet" href="css/shared/cards.css?v=5b30165c">
 <link rel="stylesheet" href="css/index/index.css?v=54fb9989">
 <style>
   .prose { max-width: 720px; margin: 2rem auto; line-height: 1.7; }
@@ -94,7 +94,7 @@
 <script src="js/lib/supabase-client.js?v=79bf62c6"></script>
 <script type="module" src="js/lib/log-buffer.js?v=6d7ce577"></script>
 <script src="js/lib/analytics.js?v=c2ea2b1c"></script>
-<script src="js/lib/topbar.js?v=7917046a"></script>
+<script src="js/lib/topbar.js?v=08584723"></script>
 <script src="js/lib/toast.js?v=7bb23014"></script>
 </body>
 </html>

--- a/tests/aboutIconLegend.test.js
+++ b/tests/aboutIconLegend.test.js
@@ -1,0 +1,58 @@
+/**
+ * The about page's icon legend must match the icons the app actually renders.
+ *
+ * The legend is static HTML while the real icons are an SVG sprite injected at
+ * runtime by js/lib/topbar.js, so the two can drift with nothing failing. The
+ * "In your library" entry drew a four-square grid long after the badge itself
+ * became the three-bar #icon-book-open, so the page documenting the icons was
+ * teaching the wrong one.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO = path.join(__dirname, '..');
+const ABOUT = fs.readFileSync(path.join(REPO, 'about.html'), 'utf8');
+const TOPBAR = fs.readFileSync(path.join(REPO, 'js', 'lib', 'topbar.js'), 'utf8');
+
+function spriteBody(id) {
+  const m = TOPBAR.match(new RegExp(`<symbol id="${id}"[^>]*>([\\s\\S]*?)</symbol>`));
+  if (!m) throw new Error(`sprite ${id} not found in topbar.js`);
+  return m[1];
+}
+
+// Compare on geometry, not whitespace or attribute order.
+function shapes(svg) {
+  return [...svg.matchAll(/<(rect|path|circle|ellipse)\b([^>]*)>/g)].map(([, tag, attrs]) => {
+    const keep = ['x', 'y', 'width', 'height', 'rx', 'd', 'cx', 'cy', 'r'];
+    const parts = keep
+      .map((k) => {
+        const v = attrs.match(new RegExp(`(?<![-\\w])${k}="([^"]*)"`));
+        return v ? `${k}=${v[1].replace(/\s+/g, ' ').trim()}` : null;
+      })
+      .filter(Boolean);
+    return `${tag}:${parts.join(',')}`;
+  });
+}
+
+describe('about page icon legend matches the real sprites', () => {
+  test('In your library uses the same shapes as #icon-book-open', () => {
+    const row = ABOUT.slice(ABOUT.indexOf('In your account'), ABOUT.indexOf('On your wishlist'));
+    const legend = shapes(row);
+    const real = shapes(spriteBody('icon-book-open'));
+    expect(real.length).toBeGreaterThan(0);
+    for (const shape of real) expect(legend).toContain(shape);
+  });
+
+  test('the legend no longer draws the retired four-square grid', () => {
+    expect(ABOUT).not.toContain('<rect x="3.4" y="3.4" width="7" height="7" rx="1.5"/>');
+  });
+
+  test('On your wishlist uses the same shapes as #icon-wishlist-heart', () => {
+    const start = ABOUT.indexOf('On your wishlist');
+    const row = ABOUT.slice(ABOUT.lastIndexOf('<div class="il-row">', start), start);
+    const legend = shapes(row);
+    const real = shapes(spriteBody('icon-wishlist-heart'));
+    for (const shape of real) expect(legend).toContain(shape);
+  });
+});

--- a/tests/appIdToDir.test.js
+++ b/tests/appIdToDir.test.js
@@ -52,7 +52,15 @@ describe('dataFilesHref uses the shared appIdToDir (data-disconnect guard)', () 
   const CFG = fs.readFileSync(path.join(__dirname, '..', 'js/app/config.js'), 'utf8');
 
   test('routes through appIdToDir, never the raw canonical id', () => {
-    expect(CFG).toMatch(/dataFilesHref = appId => .*appIdToDir\(appId\)/);
+    // The mapping lives in dataFileHref now -- every per-game file link
+    // (latest.json, depots.json, year buckets) shares that one builder, so
+    // guarding it here covers all of them.
+    expect(CFG).toMatch(/dataFileHref = \(appId, file = 'latest\.json'\) =>/);
+    expect(CFG).toMatch(/appIdToDir\(appId\)/);
     expect(CFG).toMatch(/import \{ appIdToDir \} from '\.\.\/lib\/app-id\.js/);
+  });
+
+  test('dataFilesHref delegates rather than rebuilding the path', () => {
+    expect(CFG).toMatch(/dataFilesHref = appId => dataFileHref\(appId, 'latest\.json'\)/);
   });
 });

--- a/tests/cardMiniBadges.test.js
+++ b/tests/cardMiniBadges.test.js
@@ -151,9 +151,15 @@ describe('game-page.js: unified tag row under the artwork', () => {
     expect(artColMatch).not.toBeNull();
   });
 
-  test('user tags use .game-tag + .game-tag--user; OS chips use .game-tag + .game-os-chip', () => {
-    expect(GAME_PAGE_SRC).toMatch(/class="game-tag game-tag--user"/);
+  test('OS chips use .game-tag + .game-os-chip', () => {
     expect(GAME_PAGE_SRC).toMatch(/class="game-tag game-os-chip"/);
+  });
+
+  test('ownership is no longer a pill in the platform row', () => {
+    // It renders as an icon on the artwork overlay instead. The platform row
+    // answers "where does this run"; "In library" is a different question and
+    // made the row read as five unrelated facts.
+    expect(GAME_PAGE_SRC).not.toMatch(/class="game-tag game-tag--user"/);
   });
 
   test('tag-row filler returns early when the user is signed out', () => {

--- a/tests/dataFileHref.test.js
+++ b/tests/dataFileHref.test.js
@@ -1,0 +1,68 @@
+/**
+ * dataFileHref() per-game data-file links.
+ *
+ * Every per-game file the pipeline emits (latest.json, year buckets,
+ * votes.json, depots.json) lands in the same data/<dir>/ folder and syncs to
+ * the same R2 bucket. The depot link in the metadata modal used to be a
+ * hand-built `github.com/.../blob/gh-pages/data/<rawId>/depots.json` URL,
+ * which 404'd twice over: gh-pages is the branch #396 archives and never
+ * carried depots.json, and the raw canonical id skipped the appIdToDir
+ * colon -> underscore mapping so gog:/epic: games missed the directory too.
+ *
+ * These pin the host routing and the id mapping so a future per-game link
+ * cannot regress back to a hardcoded branch URL.
+ */
+
+function loadConfigOn(hostname) {
+  jest.resetModules();
+  delete global.window;
+  global.window = { location: { hostname, pathname: '/', origin: `https://${hostname}` } };
+  return require('../js/app/config.js');
+}
+
+afterEach(() => { delete global.window; });
+
+describe('dataFileHref', () => {
+  test('routes per-game files at the production R2 data host', () => {
+    const { dataFileHref } = loadConfigOn('www.proton-pulse.com');
+    expect(dataFileHref('730', 'depots.json'))
+      .toBe('https://data.proton-pulse.com/data/730/depots.json');
+  });
+
+  test('staging routes at the staging data host, not prod', () => {
+    const { dataFileHref } = loadConfigOn('staging.proton-pulse.com');
+    expect(dataFileHref('730', 'depots.json'))
+      .toBe('https://staging-data.proton-pulse.com/data/730/depots.json');
+  });
+
+  test('defaults to latest.json when no file is named', () => {
+    const { dataFileHref } = loadConfigOn('www.proton-pulse.com');
+    expect(dataFileHref('730')).toBe('https://data.proton-pulse.com/data/730/latest.json');
+  });
+
+  test('applies the appIdToDir colon mapping for non-Steam ids', () => {
+    const { dataFileHref } = loadConfigOn('www.proton-pulse.com');
+    expect(dataFileHref('gog:1207658930', 'depots.json'))
+      .toBe('https://data.proton-pulse.com/data/gog_1207658930/depots.json');
+    // Multi-colon pgwiki slugs must map every colon, not just the first.
+    expect(dataFileHref('pgwiki:The_Chronicles:_Escape'))
+      .toBe('https://data.proton-pulse.com/data/pgwiki_The_Chronicles__Escape/latest.json');
+  });
+
+  test('dataFilesHref stays a latest.json wrapper over the same builder', () => {
+    const { dataFileHref, dataFilesHref } = loadConfigOn('www.proton-pulse.com');
+    expect(dataFilesHref('epic:abc')).toBe(dataFileHref('epic:abc', 'latest.json'));
+  });
+});
+
+describe('per-game data links do not hardcode a git branch', () => {
+  test('game-page.js builds the depot link through dataFileHref', () => {
+    const fs = require('fs');
+    const raw = fs.readFileSync(require.resolve('../js/app/components/game-page.js'), 'utf8');
+    // Strip line comments so the assertion is about code, not the comment
+    // that explains why the old hardcoded branch URL was wrong.
+    const code = raw.replace(/^\s*\/\/.*$/gm, '');
+    expect(code).not.toMatch(/github\.com\/[^\s'"`]*\/blob\//);
+    expect(code).toMatch(/dataFileHref\(meta\.appId, 'depots\.json'\)/);
+  });
+});

--- a/tests/dataFilesShipped.test.js
+++ b/tests/dataFilesShipped.test.js
@@ -20,6 +20,24 @@ const path = require('path');
 
 const REPO = path.join(__dirname, '..');
 const PUBLISH_SH = fs.readFileSync(path.join(REPO, 'scripts', 'publish-cloudflare.sh'), 'utf8');
+const PUBLISH_SHELL_YML = fs.readFileSync(path.join(REPO, '.github', 'workflows', 'publish-shell.yml'), 'utf8');
+
+// publish-shell.yml keeps a SECOND list: the shell-only deploy re-fetches
+// these from the live site so a CSS-tweak deploy does not wipe pipeline data
+// it never built. A file in SMALL_DATA but missing here survives the pipeline
+// and then vanishes on the next shell deploy -- which is how vr-index.json,
+// vrdb.json and anti-cheat.json went missing while looking fine for hours.
+const PRESERVED = (() => {
+  const lines = PUBLISH_SHELL_YML.split('\n');
+  const start = lines.findIndex((l) => /^\s*FILES=\(/.test(l));
+  if (start === -1) throw new Error('FILES=( not found in publish-shell.yml');
+  const names = new Set();
+  for (let i = start + 1; i < lines.length; i += 1) {
+    if (/^\s*\)\s*$/.test(lines[i])) return names;
+    for (const t of lines[i].replace(/#.*$/, '').split(/\s+/)) if (t) names.add(t);
+  }
+  throw new Error('FILES=( is not terminated');
+})();
 
 // Parse the SMALL_DATA array into a set of filenames. Tokenizing beats
 // regex-matching the raw file on two counts: it checks the actual shipping
@@ -109,6 +127,14 @@ describe('pipeline data files reach the deployed site', () => {
     for (const f of ['vr-index.json', 'vrdb.json', 'anti-cheat.json']) {
       expect(SHIPPED.has(f)).toBe(true);
     }
+  });
+
+  test('every shipped data file is also preserved across shell deploys', () => {
+    // Otherwise the file ships on a pipeline run and disappears the next time
+    // someone deploys a CSS change, which reads as "it worked yesterday".
+    const jsonOnly = [...SHIPPED].filter((f) => f.endsWith('.json'));
+    const missing = jsonOnly.filter((f) => !PRESERVED.has(f));
+    expect(missing).toEqual([]);
   });
 
   test('data/ paths are exempt because they reroute to R2', () => {

--- a/tests/deckStatusLiveFallback.test.js
+++ b/tests/deckStatusLiveFallback.test.js
@@ -1,0 +1,155 @@
+/**
+ * Deck verdict on-demand fallback.
+ *
+ * The published deck-status.json only covers what the pipeline has fetched.
+ * It shipped 16 entries for a 32k-row Steam catalog after #474 zeroed the
+ * report counts the scope keyed off, so Counter-Strike 2 rendered "Valve has
+ * not evaluated this title yet" while the store page said Playable. Every
+ * catalog stub has a game page, so a page with no map entry now asks upstream
+ * instead of asserting a verdict.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// Required directly rather than loaded through vm: js/app/api/deck-status.js is
+// in collectCoverageFrom, and a vm-evaluated copy is invisible to Jest's
+// instrumentation -- adding code this way silently drops global coverage.
+// jest.config.js maps away the ?v= suffix so the ESM import resolves.
+function loadModule() {
+  jest.resetModules();               // _deckCache / _deckMap are module state
+  return require('../js/app/api/deck-status.js');
+}
+
+function mockFetch({ map = {}, live = null, mapFails = false, liveFails = false, liveStatus = 200 }) {
+  const calls = [];
+  global.fetch = jest.fn(async (url) => {
+    calls.push(String(url));
+    if (String(url).includes('steam-explore')) {
+      if (liveFails) throw new Error('network down');
+      if (liveStatus !== 200) return { ok: false, status: liveStatus, json: async () => ({}) };
+      return { ok: true, status: 200, json: async () => ({ ok: true, data: { results: live } }) };
+    }
+    if (mapFails) throw new Error('map 500');
+    return { ok: true, json: async () => map };
+  });
+  return calls;
+}
+
+afterEach(() => { delete global.fetch; });
+
+const CS2_RESULTS = {
+  appid: 730,
+  resolved_category: 2,
+  resolved_items: [
+    { display_type: 3, loc_token: '#SteamDeckVerified_TestResult_ControllerGlyphsDoNotMatchDeckDevice' },
+    { display_type: 3, loc_token: '#SteamDeckVerified_TestResult_InterfaceTextIsNotLegible' },
+    { display_type: 4, loc_token: '#SteamDeckVerified_TestResult_DefaultControllerConfigFullyFunctional' },
+    { display_type: 4, loc_token: '#SteamDeckVerified_TestResult_DefaultConfigurationIsPerformant' },
+  ],
+  machine_resolved_category: 2,
+  steamos_resolved_category: 3,
+  machine_resolved_items: [{ display_type: 4, loc_token: '#SteamMachine_TestResult_Playable' }],
+  steamos_resolved_items: [{ display_type: 4, loc_token: '#SteamOS_TestResult_Compatible' }],
+};
+
+function fetchFor({ map = {}, live = null, mapFails = false, liveFails = false, liveStatus = 200 }) {
+  return async (url, opts) => {
+    if (String(url).includes('steam-explore')) {
+      if (liveFails) throw new Error('network down');
+      if (liveStatus !== 200) return { ok: false, status: liveStatus, json: async () => ({}) };
+      return { ok: true, status: 200, json: async () => ({ ok: true, data: { results: live } }) };
+    }
+    if (mapFails) throw new Error('map 500');
+    return { ok: true, json: async () => map };
+  };
+}
+
+describe('published map hit', () => {
+  test('uses the map and never calls upstream', async () => {
+    const calls = mockFetch({ map: { 730: { status: 'verified', criteria: null } } });
+    const mod = loadModule();
+    const out = await mod.fetchDeckStatusForApp('730');
+    expect(out.status).toBe('verified');
+    expect(out.hasData).toBe(true);
+    expect(calls.some((u) => u.includes('steam-explore'))).toBe(false);
+  });
+});
+
+describe('map miss falls back to upstream', () => {
+  test('parses a real CS2 payload into the same shape as the pipeline', async () => {
+    mockFetch({ map: {}, live: CS2_RESULTS });
+    const out = await loadModule().fetchDeckStatusForApp('730');
+    expect(out.status).toBe('playable');
+    expect(out.hasData).toBe(true);
+    expect(out.machine).toBe('playable');
+    // SteamOS category 3 collapses to 'compatible' -- Valve's modal only ever
+    // shows Compatible as the positive verdict.
+    expect(out.steamos).toBe('compatible');
+    // display_type 3 = caveat (null), 4 = pass (true).
+    expect(out.criteria).toEqual([null, null, true, true]);
+    // Token prefixes are stripped to match the published map's compact form.
+    expect(out.machine_criteria).toEqual([[4, 'Playable']]);
+    expect(out.steamos_criteria).toEqual([[4, 'Compatible']]);
+  });
+
+  test('a genuine no-verdict from Valve is recorded as data, not a gap', async () => {
+    // All categories 0 means Valve really has not rated it. That is an answer.
+    mockFetch({ map: {}, live: { resolved_category: 0, machine_resolved_category: 0, steamos_resolved_category: 0 } });
+    const out = await loadModule().fetchDeckStatusForApp('999');
+    expect(out.status).toBe('unknown');
+    expect(out.hasData).toBe(true);
+  });
+
+  test('fewer than four items yields null criteria rather than a short array', async () => {
+    mockFetch({ map: {}, live: { resolved_category: 2, resolved_items: [{ display_type: 4 }] } });
+    const out = await loadModule().fetchDeckStatusForApp('123');
+    expect(out.criteria).toBeNull();
+  });
+});
+
+describe('failures never fabricate a verdict', () => {
+  test('upstream error leaves hasData false', async () => {
+    mockFetch({ map: {}, liveFails: true });
+    const out = await loadModule().fetchDeckStatusForApp('730');
+    expect(out.status).toBe('unknown');
+    expect(out.hasData).toBe(false);
+  });
+
+  test('non-2xx from the proxy leaves hasData false', async () => {
+    mockFetch({ map: {}, liveStatus: 429 });
+    const out = await loadModule().fetchDeckStatusForApp('730');
+    expect(out.hasData).toBe(false);
+  });
+
+  test('non-numeric app ids skip the lookup entirely', async () => {
+    const calls = mockFetch({ map: {} });
+    const out = await loadModule().fetchDeckStatusForApp('gog:123');
+    expect(out.hasData).toBe(false);
+    expect(calls.some((u) => u.includes('steam-explore'))).toBe(false);
+  });
+});
+
+describe('caching', () => {
+  test('a second call for the same app does not refetch', async () => {
+    const calls = mockFetch({ map: {}, live: CS2_RESULTS });
+    const mod = loadModule();
+    await mod.fetchDeckStatusForApp('730');
+    await mod.fetchDeckStatusForApp('730');
+    expect(calls.filter((u) => u.includes('steam-explore'))).toHaveLength(1);
+  });
+});
+
+describe('parity with the pipeline', () => {
+  test('the category maps match scripts/pipeline/deck_status.py', () => {
+    const py = fs.readFileSync(path.join(__dirname, '..', 'scripts', 'pipeline', 'deck_status.py'), 'utf8');
+    mockFetch({ map: {} });
+    const mod = loadModule();
+    // A drift here means the same game reads differently depending on whether
+    // the pipeline happened to cover it.
+    expect(py).toContain('DECK_CAT_MAP = {0: "unknown", 1: "unsupported", 2: "playable", 3: "verified"}');
+    expect(mod.DECK_CAT_MAP).toEqual({ 0: 'unknown', 1: 'unsupported', 2: 'playable', 3: 'verified' });
+    expect(py).toContain('STEAMOS_CAT_MAP = {0: "unknown", 1: "unsupported", 2: "compatible", 3: "compatible"}');
+    expect(mod.STEAMOS_CAT_MAP).toEqual({ 0: 'unknown', 1: 'unsupported', 2: 'compatible', 3: 'compatible' });
+  });
+});

--- a/tests/depotFile.test.js
+++ b/tests/depotFile.test.js
@@ -79,9 +79,13 @@ describe('#237: metadata modal wires tracked_since + depot file icon', () => {
     expect(COMP).toContain('Earliest observation date we recorded');
   });
 
-  test('brown package icon links to the gh-pages depots.json blob', () => {
+  test('brown package icon links to the published depots.json', () => {
     expect(COMP).toContain('gm-depot-file');
-    expect(COMP).toContain('/blob/gh-pages/data/${esc(String(meta.appId))}/depots.json');
+    // Built through dataFileHref so it resolves against the R2 data host the
+    // pipeline syncs to, with the appIdToDir mapping applied. It used to be a
+    // hardcoded gh-pages blob URL, which 404'd: that branch is the one #396
+    // archives and it never carried depots.json.
+    expect(COMP).toContain("dataFileHref(meta.appId, 'depots.json')");
     // Deep-links to the OS anchor so we can scroll to a specific block later.
     expect(COMP).toContain('#os=${esc(key)}');
     // Package icon markup lives in an inline SVG so we don't need a new asset.

--- a/tests/importUsageConsistency.test.js
+++ b/tests/importUsageConsistency.test.js
@@ -1,0 +1,76 @@
+/**
+ * Every helper a module CALLS must be one it imports.
+ *
+ * Motivating bug: game-page.js called loadVrIndex() and vrForApp() without
+ * importing js/app/lib/vr-index.js. Both were undefined at runtime, so the
+ * block threw a ReferenceError -- and because it is a
+ * `void (async () => {...})()` with no catch, the throw became an unhandled
+ * rejection. The VR chip, the VR-only banner AND the artwork badges all
+ * vanished together with an empty console, and it survived a full pre-push
+ * plus several deploys because nothing here executes that path.
+ *
+ * The import went missing because a scripted replace did not match and was
+ * not asserted, which is exactly the silent failure this repo's own
+ * no-silent-failures rule warns about.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO = path.join(__dirname, '..');
+
+// Helpers that are only ever legitimate via an import. Deliberately narrow:
+// this guards the modules where a missing import fails silently rather than
+// trying to be a general linter.
+const GUARDED = {
+  'lib/vr-index.js': ['loadVrIndex', 'vrForApp', 'matchesVrFilter'],
+  'lib/vrdb.js': ['getVrdbForApp', 'loadVrdb', 'bestVrdbRuntime'],
+  'shared/vr.js': ['normalizePlayMode', 'normalizeVrRuntime', 'vrRuntimeLabel', 'vrdbRatingColor'],
+};
+
+function jsFiles(dir, out = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) jsFiles(full, out);
+    else if (entry.name.endsWith('.js')) out.push(full);
+  }
+  return out;
+}
+
+const FILES = jsFiles(path.join(REPO, 'js'));
+
+describe('called helpers are imported', () => {
+  const cases = [];
+  for (const file of FILES) {
+    const src = fs.readFileSync(file, 'utf8');
+    for (const [module, helpers] of Object.entries(GUARDED)) {
+      // The module never needs to import itself.
+      if (file.endsWith(module.split('/').pop()) && file.includes(module.split('/')[0])) continue;
+      for (const helper of helpers) {
+        const called = new RegExp(`\\b${helper}\\s*\\(`).test(src);
+        if (!called) continue;
+        // Defined locally (the module itself) rather than called as an import.
+        if (new RegExp(`(function|const|let)\\s+${helper}\\b`).test(src)) continue;
+        cases.push([path.relative(REPO, file), helper, module, src]);
+      }
+    }
+  }
+
+  test('the scan finds real call sites', () => {
+    // Guard the guard: if the helpers are renamed this test would pass by
+    // examining nothing.
+    expect(cases.length).toBeGreaterThan(0);
+  });
+
+  test.each(cases.map(([f, h, m]) => [f, h, m]))(
+    '%s calls %s so it must import %s',
+    (file, helper, module) => {
+      const src = fs.readFileSync(path.join(REPO, file), 'utf8');
+      const base = module.split('/').pop();
+      // Import of the right module, and the helper named in it.
+      const importLine = (src.match(new RegExp(`^import \\{[^}]*\\} from '[^']*${base.replace('.', '\\.')}[^']*';`, 'm')) || [])[0];
+      expect(importLine).toBeDefined();
+      expect(importLine).toContain(helper);
+    },
+  );
+});

--- a/tests/orphanDeployScriptStaging.test.js
+++ b/tests/orphanDeployScriptStaging.test.js
@@ -1,0 +1,77 @@
+/**
+ * Scripts invoked after the gh-pages orphan deploy must be staged outside the
+ * workspace first.
+ *
+ * The finalize job's "Deploy to gh-pages (orphan, no history)" step runs
+ * `git rm -rf .`, which deletes every tracked file in the workspace. Any later
+ * step that shells out to a repo script therefore has to run it from a copy
+ * made BEFORE that wipe -- the preserve-* scripts already do this.
+ *
+ * backup-to-release.sh did not. Every scheduled run from 2026-08-19 onward
+ * failed with "scripts/backup-to-release.sh: No such file or directory" and
+ * the nightly data backup stopped for five days. The workflow still reported
+ * the deploy as done; only the trailing backup step went red.
+ *
+ * This pins the invariant rather than the single fix, so the next script added
+ * after the orphan step cannot reintroduce it.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const WF_PATH = path.join(__dirname, '..', '.github/workflows/update-data.yml');
+const RAW = fs.readFileSync(WF_PATH, 'utf8');
+// js-yaml reads the unquoted `on:` key as boolean true; irrelevant here, we
+// only walk jobs.
+const WF = yaml.load(RAW);
+const FINALIZE = WF.jobs.finalize;
+
+function stepIndex(pred) {
+  return FINALIZE.steps.findIndex(pred);
+}
+
+describe('gh-pages orphan wipe does not strip scripts later steps need', () => {
+  const orphanIdx = stepIndex(s => /Deploy to gh-pages \(orphan/.test(s.name || ''));
+
+  test('the orphan deploy step exists and still wipes the workspace', () => {
+    expect(orphanIdx).toBeGreaterThan(-1);
+    expect(FINALIZE.steps[orphanIdx].run).toMatch(/git rm -rf \./);
+  });
+
+  test('no step after the wipe runs a script from the workspace path', () => {
+    const after = FINALIZE.steps.slice(orphanIdx + 1);
+    const offenders = [];
+    for (const step of after) {
+      const run = step.run || '';
+      // `bash scripts/foo.sh` / `sh scripts/foo.sh` / bare `scripts/foo.sh`
+      const m = run.match(/(?:^|\n)\s*(?:bash |sh |\.\/)?(scripts\/[\w.-]+\.sh)/g);
+      if (m) offenders.push({ name: step.name, refs: m.map(x => x.trim()) });
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  test('backup runs from the staged /tmp copy, not the workspace', () => {
+    const backup = FINALIZE.steps.find(s => /Backup data to GitHub Release/.test(s.name || ''));
+    expect(backup).toBeDefined();
+    expect(backup.run).toMatch(/bash \/tmp\/backup-to-release\.sh/);
+    expect(backup.run).not.toMatch(/scripts\/backup-to-release\.sh/);
+  });
+
+  test('the staging copy happens before the wipe, on every deploy target', () => {
+    const stageIdx = stepIndex(s => (s.run || '').includes('cp scripts/backup-to-release.sh /tmp/'));
+    expect(stageIdx).toBeGreaterThan(-1);
+    expect(stageIdx).toBeLessThan(orphanIdx);
+    // The orphan step is skipped when deploy_target=cloudflare, but the backup
+    // step still runs, so the staging copy must not be gated on that target.
+    const stage = FINALIZE.steps[stageIdx];
+    expect(String(stage.if || '')).not.toMatch(/deploy_target/);
+  });
+
+  test('staging copy and backup share the same run condition', () => {
+    const stage = FINALIZE.steps[stepIndex(s => (s.run || '').includes('cp scripts/backup-to-release.sh /tmp/'))];
+    const backup = FINALIZE.steps.find(s => /Backup data to GitHub Release/.test(s.name || ''));
+    // Otherwise the backup could fire on a run where the copy never happened.
+    expect(String(stage.if || '').trim()).toBe(String(backup.if || '').trim());
+  });
+});

--- a/tests/publishShellWorkflow.test.js
+++ b/tests/publishShellWorkflow.test.js
@@ -185,3 +185,31 @@ describe('publish job wires the deploy correctly', () => {
     expect(RAW).toContain('CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}');
   });
 });
+
+describe('gh-pages deploy targets stay removed', () => {
+  const fs = require('fs');
+  const path = require('path');
+  const MK = fs.readFileSync(path.join(__dirname, '..', 'Makefile'), 'utf8');
+
+  test('no gh-pages-only or gh-staging target exists', () => {
+    // Removed 2026-08-14. They pushed to the gh-pages branch + staging repo
+    // that #362 replaced with Cloudflare Pages, and both read like the
+    // obvious command while publishing somewhere nobody looks -- `make
+    // gh-staging` deployed to the rollback repo while the reviewer waited on
+    // staging.proton-pulse.com.
+    expect(MK).not.toMatch(/^gh-pages-only:/m);
+    expect(MK).not.toMatch(/^gh-staging:/m);
+  });
+
+  test('the Cloudflare targets are the replacement', () => {
+    expect(MK).toMatch(/^cf-staging:/m);
+    expect(MK).toMatch(/^cf-prod:/m);
+  });
+
+  test('the gh-* PIPELINE targets are untouched', () => {
+    // Unrelated to gh-pages: these dispatch update-data.yml.
+    for (const t of ['gh-run', 'gh-staging-pipeline', 'gh-staging-finalize', 'gh-resume']) {
+      expect(MK).toMatch(new RegExp(`^${t}:`, 'm'));
+    }
+  });
+});

--- a/tests/submitPlayMode.test.js
+++ b/tests/submitPlayMode.test.js
@@ -114,9 +114,12 @@ describe('vrFieldsFromForm', () => {
 describe('submit form markup', () => {
   const submitSrc = fs.readFileSync(path.join(__dirname, '..', 'js/shared/submit.js'), 'utf8');
 
-  test('renders the Play Mode radios with flatscreen preselected', () => {
-    expect(submitSrc).toContain('name="playMode" value="flat" checked');
+  test('renders the Play Mode radios with no hardcoded default', () => {
+    // The default now depends on the game: VR-only preselects VR, non-VR
+    // preselects Flatscreen, and playable-both is left blank on purpose.
+    expect(submitSrc).toContain('name="playMode" value="flat"');
     expect(submitSrc).toContain('name="playMode" value="vr"');
+    expect(submitSrc).not.toContain('value="flat" checked');
   });
 
   test('VR rows start hidden and are wired to the toggle', () => {
@@ -127,5 +130,86 @@ describe('submit form markup', () => {
 
   test('the payload includes the VR columns', () => {
     expect(submitSrc).toContain('...vrFieldsFromForm(form)');
+  });
+});
+
+describe('applyPlayModeDefault (#246)', () => {
+  const fs = require('fs');
+  const path = require('path');
+  const vm = require('vm');
+
+  function loadHelper() {
+    const src = fs.readFileSync(path.join(__dirname, '..', 'js/shared/submit.js'), 'utf8');
+    const start = src.indexOf('export function applyPlayModeDefault');
+    const end = src.indexOf('function wirePlayModeToggle');
+    const slice = src.slice(start, end).replace(/^export\s+function\s/gm, 'function ');
+    const sandbox = { Event, module: { exports: {} } };
+    vm.createContext(sandbox);
+    vm.runInContext(slice + '\nmodule.exports = applyPlayModeDefault;', sandbox);
+    return sandbox.module.exports;
+  }
+  const applyPlayModeDefault = loadHelper();
+
+  function makeContainer() {
+    const radios = ['flat', 'vr'].map((value) => ({
+      value, checked: false, required: false, events: [],
+      dispatchEvent(e) { this.events.push(e.type); return true; },
+    }));
+    return {
+      radios,
+      querySelectorAll: () => radios,
+    };
+  }
+
+  test('VR-only games preselect VR', () => {
+    const c = makeContainer();
+    expect(applyPlayModeDefault(c, 'only')).toBe('vr');
+    expect(c.radios.find((r) => r.value === 'vr').checked).toBe(true);
+    expect(c.radios.find((r) => r.value === 'flat').checked).toBe(false);
+  });
+
+  test('non-VR games preselect Flatscreen', () => {
+    const c = makeContainer();
+    expect(applyPlayModeDefault(c, null)).toBe('flat');
+    expect(c.radios.find((r) => r.value === 'flat').checked).toBe(true);
+  });
+
+  test('games playable both ways are left blank and become required', () => {
+    // A preselected answer here is one the reporter never consciously made,
+    // and play mode changes what "runs well" even means.
+    const c = makeContainer();
+    expect(applyPlayModeDefault(c, 'supported')).toBeNull();
+    expect(c.radios.some((r) => r.checked)).toBe(false);
+    expect(c.radios.every((r) => r.required)).toBe(true);
+  });
+
+  test('a preselected mode is not left required', () => {
+    const c = makeContainer();
+    applyPlayModeDefault(c, 'only');
+    expect(c.radios.every((r) => r.required === false)).toBe(true);
+  });
+
+  test('preselecting VR fires change so the runtime rows reveal', () => {
+    // Setting .checked programmatically does not fire change, so the VR
+    // runtime + headset rows would stay hidden on a VR-only game.
+    const c = makeContainer();
+    applyPlayModeDefault(c, 'only');
+    expect(c.radios.find((r) => r.value === 'vr').events).toContain('change');
+  });
+
+  test('the blank case fires no change event', () => {
+    const c = makeContainer();
+    applyPlayModeDefault(c, 'supported');
+    expect(c.radios.flatMap((r) => r.events)).toEqual([]);
+  });
+
+  test('survives a missing container or radios', () => {
+    expect(applyPlayModeDefault(null, 'only')).toBeNull();
+    expect(applyPlayModeDefault({ querySelectorAll: () => [] }, 'only')).toBeNull();
+  });
+
+  test('the markup no longer hardcodes a checked default', () => {
+    const src = fs.readFileSync(path.join(__dirname, '..', 'js/shared/submit.js'), 'utf8');
+    expect(src).not.toContain('name="playMode" value="flat" checked');
   });
 });

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -95,9 +95,23 @@ def test_main_most_played_with_limit(tmp_path):
 
 
 def test_main_deck_status(tmp_path):
+    # No --budget: keep the pipeline's own per-run scope (app_ids=None) so the
+    # in-pipeline call is unchanged by the ad-hoc backfill flags.
     with patch("scripts.pipeline.cli.build_deck_status") as mock_deck:
         _run_main("deck-status", str(tmp_path))
-        mock_deck.assert_called_once_with(str(tmp_path))
+        mock_deck.assert_called_once_with(str(tmp_path), app_ids=None, delay=0.35)
+
+
+def test_main_deck_status_full_fill(tmp_path):
+    # --budget 0 means "no cap": the ad-hoc full fill resolves the id list up
+    # front instead of deferring to the pipeline's budget.
+    with (
+        patch("scripts.pipeline.cli.build_deck_status") as mock_deck,
+        patch("scripts.pipeline.deck_status.steam_app_ids_for_deck_status", return_value=["730"]) as mock_scope,
+    ):
+        _run_main("deck-status", str(tmp_path), "--budget", "0", "--delay", "0.2")
+        assert mock_scope.call_args.kwargs["budget"] >= 10 ** 6
+        mock_deck.assert_called_once_with(str(tmp_path), app_ids=["730"], delay=0.2)
 
 
 def test_main_reindex(tmp_path):

--- a/tests/test_deck_backfill_workflow.py
+++ b/tests/test_deck_backfill_workflow.py
@@ -1,0 +1,98 @@
+"""Gates on the ad-hoc Deck verdict backfill workflow.
+
+The delay default is the load-bearing detail. Every OTHER appdetails enricher
+in this repo uses 2.0s because store.steampowered.com/api/appdetails
+soft-throttles at ~200 requests / 5 minutes. This workflow hits a different
+endpoint (saleaction/ajaxgetdeckappcompatibilityreport), measured at ~3 req/s
+with zero failures over 80 consecutive requests. Copying the appdetails
+spacing here would turn a 3-hour full fill into an 18-hour one that cannot
+finish inside a job.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "deck-backfill.yml"
+
+
+@pytest.fixture(scope="module")
+def wf():
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _on(doc):
+    return doc[True] if True in doc else doc["on"]
+
+
+def _steps(doc):
+    return doc["jobs"]["backfill"]["steps"]
+
+
+def test_is_manual_only(wf):
+    assert list(_on(wf)) == ["workflow_dispatch"]
+
+
+def test_defaults_to_a_full_fill(wf):
+    # budget 0 = no cap. The whole point of the workflow.
+    assert _on(wf)["workflow_dispatch"]["inputs"]["budget"]["default"] == "0"
+
+
+def test_delay_is_tuned_to_this_endpoint_not_appdetails(wf):
+    delay = float(_on(wf)["workflow_dispatch"]["inputs"]["delay"]["default"])
+    # Fast enough to finish, slow enough to sit under the measured ceiling.
+    assert 0.1 <= delay <= 1.0, "appdetails' 2.0s does not apply to this endpoint"
+
+
+def test_timeout_fits_a_full_catalog_pass(wf):
+    # ~32k rows at 0.35s is roughly 3 hours; the cap must clear that.
+    assert wf["jobs"]["backfill"]["timeout-minutes"] >= 200
+
+
+def test_serializes_runs(wf):
+    assert wf["concurrency"]["group"] == "deck-backfill"
+    assert wf["concurrency"]["cancel-in-progress"] is False
+
+
+def test_shares_the_pipeline_cache_prefix(wf):
+    restore = next(s for s in _steps(wf) if str(s.get("uses", "")).startswith("actions/cache/restore"))
+    save = next(s for s in _steps(wf) if str(s.get("uses", "")).startswith("actions/cache/save"))
+    assert restore["with"]["path"] == ".cache"
+    # Must name update-data.yml, not this workflow, or the two never share.
+    assert "update-data.yml" in restore["with"]["restore-keys"]
+    assert "update-data.yml" in save["with"]["key"]
+
+
+def test_saves_the_cache_even_on_failure(wf):
+    save = next(s for s in _steps(wf) if str(s.get("uses", "")).startswith("actions/cache/save"))
+    assert save.get("if") == "always()"
+
+
+def test_sources_the_id_list_from_the_published_index(wf):
+    # A fresh checkout has no pipeline output; deck-status scopes itself from
+    # search-index.json, so the job must fetch it before running.
+    body = WORKFLOW.read_text(encoding="utf-8")
+    assert "search-index.json" in body
+    # Hard-fail when the index is missing rather than silently scoping to zero
+    # apps and reporting success -- that is the exact failure mode this whole
+    # workflow exists to fix.
+    assert "test -s /tmp/protondb-output/search-index.json" in body
+
+
+def test_optional_priority_files_do_not_fail_the_run(wf):
+    body = WORKFLOW.read_text(encoding="utf-8")
+    assert "|| echo \"skip $f (optional)\"" in body
+
+
+def test_does_not_deploy(wf):
+    body = WORKFLOW.read_text(encoding="utf-8")
+    for forbidden in ["publish-cloudflare.sh", "gh-pages", "wrangler", "s3 sync"]:
+        assert forbidden not in body
+
+
+def test_passes_output_dir_positionally(wf):
+    # The CLI takes output_dir as a positional; --output-dir is rejected.
+    body = WORKFLOW.read_text(encoding="utf-8")
+    assert "deck-status \\\n            /tmp/protondb-output" in body
+    assert "--output-dir" not in body

--- a/tests/test_deck_status.py
+++ b/tests/test_deck_status.py
@@ -155,14 +155,25 @@ def test_network_error_does_not_poison_cache(tmp_path):
         assert m2.call_count == 1
 
 
-def test_steam_app_ids_with_reports_scopes_to_reported_steam_games(tmp_path):
+def test_steam_app_ids_scopes_to_steam_and_ranks_reported_first(tmp_path):
+    """Unreported Steam games are INCLUDED, just ranked lower.
+
+    This test used to assert that 0-report games were skipped. That was the
+    bug: the scope keyed off (protondb_count + pulse_count) > 0, so when #474
+    decoupled ProtonDB and zeroed every protondb_count, the fetch list
+    collapsed to a handful of games and Counter-Strike 2's page claimed Valve
+    had not evaluated it. Every catalog stub has a game page, so every Steam
+    row is in scope; the ordering decides who gets fetched first.
+    """
     rows = [
+        ["480", "No reports", "", 0, 0, "steam", None, None, False],
         ["1245620", "Elden Ring", "platinum", 100, 2, "steam", None, None, False],
-        ["480", "No reports", "", 0, 0, "steam", None, None, False],   # skipped: 0 reports
-        ["gog:123", "GOG game", "gold", 5, 0, "gog"],                    # skipped: not steam
+        ["gog:123", "GOG game", "gold", 5, 0, "gog"],   # still skipped: not Steam
     ]
     (tmp_path / "search-index.json").write_text(json.dumps(rows))
-    assert steam_app_ids_with_reports(tmp_path) == ["1245620"]
+    ids = steam_app_ids_with_reports(tmp_path)
+    assert ids == ["1245620", "480"]
+    assert "gog:123" not in ids
 
 
 def test_build_writes_only_evaluated_games(tmp_path):

--- a/tests/test_deck_status_scope.py
+++ b/tests/test_deck_status_scope.py
@@ -1,0 +1,114 @@
+"""Deck-status fetch scope (regression for the CS2 "Unknown" bug).
+
+The scope used to be `(protondb_count + pulse_count) > 0`. That held while
+ProtonDB counts populated the search index. #474 decoupled ProtonDB, every
+protondb_count became 0, and the scope silently collapsed from thousands of
+games to 17 -- deck-status.json shipped 16 entries for a 32k-row Steam
+catalog. Nothing errored; the file wrote fine and the log reported the count
+as though it were normal. Counter-Strike 2 rendered "Valve has not evaluated
+this title yet" while the store page said Playable.
+"""
+
+import json
+
+import pytest
+
+from scripts.pipeline import deck_status as ds
+
+
+@pytest.fixture(autouse=True)
+def _empty_cache(monkeypatch):
+    monkeypatch.setattr(ds, "_load_cache", lambda: {})
+
+
+def _write_index(tmp_path, rows):
+    (tmp_path / "search-index.json").write_text(json.dumps(rows), encoding="utf-8")
+
+
+def test_scope_does_not_depend_on_report_counts(tmp_path):
+    # The exact shape that broke: real Steam games, zero reports on all of them.
+    _write_index(tmp_path, [
+        ["730", "Counter-Strike 2", "pending", 0, 0, "steam"],
+        ["570", "Dota 2", "pending", 0, 0, "steam"],
+    ])
+    ids = ds.steam_app_ids_for_deck_status(tmp_path)
+    assert "730" in ids and "570" in ids
+
+
+def test_reported_games_come_first(tmp_path):
+    _write_index(tmp_path, [
+        ["111", "No reports", "pending", 0, 0, "steam"],
+        ["730", "Has a report", "gold", 0, 3, "steam"],
+    ])
+    ids = ds.steam_app_ids_for_deck_status(tmp_path)
+    assert ids[0] == "730"
+
+
+def test_most_played_outranks_the_long_tail(tmp_path):
+    _write_index(tmp_path, [
+        ["111", "Long tail", "pending", 0, 0, "steam"],
+        ["222", "Long tail 2", "pending", 0, 0, "steam"],
+        ["730", "Charting", "pending", 0, 0, "steam"],
+    ])
+    (tmp_path / "most_played.json").write_text(json.dumps([{"appId": "730"}]), encoding="utf-8")
+    ids = ds.steam_app_ids_for_deck_status(tmp_path)
+    assert ids[0] == "730"
+
+
+def test_recent_reports_outrank_the_long_tail(tmp_path):
+    _write_index(tmp_path, [
+        ["111", "Long tail", "pending", 0, 0, "steam"],
+        ["999", "Recently reported", "pending", 0, 0, "steam"],
+    ])
+    (tmp_path / "recent-reports.json").write_text(json.dumps([{"appId": "999"}]), encoding="utf-8")
+    ids = ds.steam_app_ids_for_deck_status(tmp_path)
+    assert ids[0] == "999"
+
+
+def test_missing_side_files_are_not_fatal(tmp_path):
+    # A finalize-only run may not have regenerated most_played.json. Absent
+    # means "no priority hint", not an error.
+    _write_index(tmp_path, [["730", "CS2", "pending", 0, 0, "steam"]])
+    assert ds.steam_app_ids_for_deck_status(tmp_path) == ["730"]
+
+
+def test_budget_caps_new_fetches(tmp_path):
+    _write_index(tmp_path, [[str(i), f"G{i}", "pending", 0, 0, "steam"] for i in range(1000, 1100)])
+    ids = ds.steam_app_ids_for_deck_status(tmp_path, budget=10)
+    assert len(ids) == 10
+
+
+def test_cached_ids_ride_along_free(tmp_path, monkeypatch):
+    # A cached verdict costs no request, so it must not consume the budget --
+    # otherwise the published map churns instead of accumulating.
+    monkeypatch.setattr(ds, "_load_cache", lambda: {"730": {}, "570": {}})
+    _write_index(tmp_path, [
+        ["730", "Cached", "pending", 0, 0, "steam"],
+        ["570", "Cached too", "pending", 0, 0, "steam"],
+        ["111", "New", "pending", 0, 0, "steam"],
+    ])
+    ids = ds.steam_app_ids_for_deck_status(tmp_path, budget=1)
+    assert set(ids) == {"730", "570", "111"}
+
+
+def test_non_steam_and_malformed_rows_are_skipped(tmp_path):
+    _write_index(tmp_path, [
+        ["gog:1", "GOG game", "pending", 0, 0, "gog"],
+        ["pw_abc", "PCGW game", "pending", 0, 0, "pgwiki"],
+        "not a row",
+        ["730"],
+        ["730", "CS2", "pending", 0, 0, "steam"],
+    ])
+    assert ds.steam_app_ids_for_deck_status(tmp_path) == ["730"]
+
+
+def test_no_duplicates_across_priority_groups(tmp_path):
+    _write_index(tmp_path, [["730", "CS2", "gold", 0, 2, "steam"]])
+    (tmp_path / "most_played.json").write_text(json.dumps([{"appId": "730"}]), encoding="utf-8")
+    (tmp_path / "recent-reports.json").write_text(json.dumps([{"appId": "730"}]), encoding="utf-8")
+    assert ds.steam_app_ids_for_deck_status(tmp_path) == ["730"]
+
+
+def test_legacy_alias_still_resolves():
+    # Any out-of-tree caller of the old name keeps working.
+    assert ds.steam_app_ids_with_reports is ds.steam_app_ids_for_deck_status

--- a/tests/test_most_played.py
+++ b/tests/test_most_played.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import patch
 
 from scripts.pipeline.most_played import build_most_played
 
@@ -91,3 +92,25 @@ def test_handles_non_int_peak(tmp_path):
     assert out[0]["peak"] is None
     assert out[0]["rating"] == "gold"
     assert out[0]["protondbCount"] == 10
+
+
+def test_unrated_bucket_covers_the_whole_steam_chart(tmp_path):
+    """Regression for the #474 knock-on that truncated the popular section.
+
+    unrated_limit was 50, sized as a supplement to `limit` rated games. When
+    #474 decoupled ProtonDB, protondb_count went to 0 everywhere and almost
+    every tier became "pending", so the unrated bucket became the entire
+    section and its cap silently dropped 46 of Steam's top 100. Nothing
+    failed -- most_played.json wrote fine, just short.
+    """
+    ranks = [{"appid": 1000 + i, "peak_in_game": 5000 - i} for i in range(100)]
+    rows = [[str(1000 + i), f"Game {i}", "pending", 0, 0, "steam"] for i in range(100)]
+    (tmp_path / "search-index.json").write_text(json.dumps(rows), encoding="utf-8")
+    (tmp_path / "data").mkdir(exist_ok=True)
+
+    with patch("scripts.pipeline.most_played.is_adult_app", return_value=False):
+        out = build_most_played(tmp_path, ranks=ranks, catalog_limit=0)
+
+    # Every charting game we know about is published, not just the first 50.
+    assert len(out) == 100
+    assert all(r["rating"] == "pending" for r in out)

--- a/tests/vr.test.js
+++ b/tests/vr.test.js
@@ -173,3 +173,342 @@ describe('matchesVrFilter', () => {
     expect(matchesVrFilter('only', 'bogus')).toBe(true);
   });
 });
+
+describe('game page artwork badges (#246)', () => {
+  const fs = require('fs');
+  const path = require('path');
+  const src = fs.readFileSync(
+    path.join(__dirname, '..', 'js', 'app', 'components', 'game-page.js'), 'utf8');
+  const css = fs.readFileSync(
+    path.join(__dirname, '..', 'css', 'app', 'game-header.css'), 'utf8');
+
+  test('the overlay lives inside a positioned wrapper on the artwork', () => {
+    expect(src).toContain('game-header-art-wrap');
+    expect(src).toContain('id="game-art-badges"');
+    expect(css).toMatch(/\.game-header-art-wrap\s*\{[^}]*position:\s*relative/);
+  });
+
+  test('badges pin top-right and are not driven by the store-pill preference', () => {
+    const block = css.match(/\.game-header-art-badges\s*\{[^}]*\}/)[0];
+    expect(block).toMatch(/position:\s*absolute/);
+    expect(block).toMatch(/top:\s*8px/);
+    expect(block).toMatch(/right:\s*8px/);
+    // The pref moves the store pill around browse cards; the detail page keeps
+    // one predictable corner. Strip comments before checking -- the comment
+    // above the rule names the attribute precisely to say it is NOT used, and
+    // a raw scan matches that prose instead of a real selector.
+    const noComments = css.replace(/\/\*[\s\S]*?\*\//g, '');
+    const rules = noComments.match(/[^{}]+(?=\{)/g) || [];
+    const badgeRules = rules.filter((sel) => sel.includes('.game-header-art-badges'));
+    expect(badgeRules.length).toBeGreaterThan(0);
+    expect(badgeRules.some((sel) => sel.includes('data-store-pill-pos'))).toBe(false);
+  });
+
+  test('the overlay carries ownership only, not VR', () => {
+    // VR lives in the tag row under the artwork (and the banner when it is
+    // VR-only). A chip on the art as well was the same fact twice, competing
+    // with the box art.
+    const overlay = src.slice(src.indexOf("querySelector('#game-art-badges')"), src.indexOf('parts.length'));
+    expect(overlay).not.toContain('game-card-vr-chip');
+    expect(src).toContain('game-card-owner-badge game-card-owner-badge--library');
+    expect(src).toContain('game-card-owner-badge game-card-owner-badge--wishlist');
+  });
+
+  test('the library badge tooltip reads In Library', () => {
+    expect(src).toContain('title="In Library" aria-label="In Library"');
+  });
+
+  test('VR renders for signed-out visitors; owner badges do not', () => {
+    // VR capability is a property of the game, not the viewer. Gating it
+    // behind a session would hide it from most visitors.
+    // VR is resolved before the artwork host is even looked up, and well
+    // before any session check, so a signed-out visitor still gets it.
+    const block = src.slice(src.indexOf('const vr = vrForApp('));
+    const sessionIdx = block.indexOf('SupaAuth?.getSession');
+    const stripIdx = block.indexOf("game-vr-strip'");
+    expect(stripIdx).toBeGreaterThan(-1);
+    expect(sessionIdx).toBeGreaterThan(stripIdx);
+  });
+
+  test('the VR chip is sized to the 18px icon box, not the delisted chip em', () => {
+    const cards = fs.readFileSync(
+      path.join(__dirname, '..', 'css', 'shared', 'cards.css'), 'utf8');
+    const chip = cards.match(/\.game-card-vr-chip\s*\{[^}]*\}/)[0];
+    // 0.62em resolved against the store pill's 0.7rem rendered at ~0.43rem,
+    // which read as a footnote next to the 18px icons beside it.
+    expect(chip).not.toMatch(/font-size:\s*0\.62em/);
+    expect(chip).toMatch(/line-height:\s*18px/);
+  });
+});
+
+describe('VR chip is one variant, VR-only is a banner (#246 follow-up)', () => {
+  const fs = require('fs');
+  const path = require('path');
+  const cardSrc = fs.readFileSync(path.join(__dirname, '..', 'js', 'app', 'lib', 'card.js'), 'utf8');
+  const pageSrc = fs.readFileSync(path.join(__dirname, '..', 'js', 'app', 'components', 'game-page.js'), 'utf8');
+  const cardsCss = fs.readFileSync(path.join(__dirname, '..', 'css', 'shared', 'cards.css'), 'utf8');
+
+  test('cards render a single VR label, never VR Only', () => {
+    // One badge fits a card, and "VR ONLY" doubled the strip width at the S
+    // size. The requirement is stated on the detail page instead.
+    expect(cardSrc).not.toContain('VR Only<');
+    expect(cardSrc).toMatch(/>VR<\/span>/);
+  });
+
+  test('the only/supported distinction survives in the tooltip and the data', () => {
+    // Dropping the second chip must not drop the information: the filter and
+    // the banner both still depend on vr === 'only'.
+    expect(cardSrc).toContain("vrKey === 'only' ? 'VR only: requires a headset'");
+    expect(cardSrc).toContain("vr === 'only' || vr === 'supported'");
+  });
+
+  test('no VR chip colour variants remain in CSS', () => {
+    expect(cardsCss).not.toContain('.game-card-vr-chip--only');
+    expect(cardsCss).not.toContain('.game-card-vr-chip--supported');
+  });
+
+  test('the chip is amber so it does not merge with the store pill', () => {
+    // Every store colour is blue/purple/grey: Steam #1689d0, GOG #7a3fcf,
+    // PCGWiki #4d5f9c, Epic #555. The first version was a muted blue against
+    // the Steam pill.
+    const chip = cardsCss.match(/\.game-card-vr-chip\s*\{[^}]*\}/)[0];
+    expect(chip).toMatch(/#e8a33d/i);
+  });
+
+  test('the game page carries a VR-only banner element', () => {
+    expect(pageSrc).toContain('id="game-vr-banner"');
+    expect(pageSrc).toContain('This game is VR only.');
+    // Hidden by default so a non-VR game never renders an empty banner.
+    expect(pageSrc).toMatch(/id="game-vr-banner" hidden/);
+  });
+
+  test('the banner only fires for VR-only games', () => {
+    const block = pageSrc.slice(pageSrc.indexOf("const vr = vrForApp("));
+    const onlyIdx = block.indexOf('if (only) {');
+    const bannerIdx = block.indexOf("#game-vr-banner");
+    expect(onlyIdx).toBeGreaterThan(-1);
+    expect(bannerIdx).toBeGreaterThan(onlyIdx);
+  });
+});
+
+describe('VR chip caps the badge strip (#246 follow-up)', () => {
+  const fs = require('fs');
+  const path = require('path');
+  const css = fs.readFileSync(path.join(__dirname, '..', 'css', 'shared', 'cards.css'), 'utf8');
+  const chip = css.match(/\.game-card-vr-chip\s*\{[^}]*\}/)[0];
+
+  test('the chip carries no radius of its own', () => {
+    // The container's radius caps the strip. A chip with its own corners sat
+    // as a square block inside a curved badge and the leading end looked
+    // uncapped where the badge curved away from it.
+    expect(chip).toMatch(/border-radius:\s*0/);
+  });
+
+  test('badge containers clip their contents', () => {
+    // Without overflow:hidden the bled chip escapes the rounded corner.
+    for (const sel of ['.game-card-store-tag', '.game-card-store-pill',
+                       '.game-card-corner-tag', '.game-card-strip-store']) {
+      const re = new RegExp(`${sel.replace('.', '\\.')}[^{]*\\{[^}]*overflow:\\s*hidden`);
+      expect(css).toMatch(re);
+    }
+  });
+
+  test('every container that clips also declares its bleed', () => {
+    // The chip bleeds out through the container padding by negative margin;
+    // each variant has different padding, so a container that clips without
+    // declaring --badge-pad-* leaves a gap at the leading edge.
+    for (const sel of ['.game-card-store-tag', '.game-card-store-pill', '.game-card-corner-tag']) {
+      const re = new RegExp(`${sel.replace('.', '\\.')}\\s*\\{[^}]*--badge-pad-x`);
+      expect(css).toMatch(re);
+    }
+  });
+
+  test('only the leading chip bleeds', () => {
+    // A Delisted chip renders before VR; when present it owns the leading
+    // edge, so VR must not pull itself out of the container there.
+    expect(css).toMatch(/\.game-card-vr-chip:first-child\s*\{/);
+  });
+
+  test('the combo layout still renders the chip', () => {
+    // combo hides store-tag / corner-tag / store-pill, so a chip that only
+    // lived in those would vanish entirely in that layout.
+    const cardSrc = fs.readFileSync(path.join(__dirname, '..', 'js', 'app', 'lib', 'card.js'), 'utf8');
+    const combo = cardSrc.match(/game-card-combo-tag[\s\S]{0,400}/)[0];
+    expect(combo).toContain('${vrChip}');
+  });
+});
+
+describe('VR in the game-page tag row (#246 follow-up)', () => {
+  const fs = require('fs');
+  const path = require('path');
+  const src = fs.readFileSync(path.join(__dirname, '..', 'js', 'app', 'components', 'game-page.js'), 'utf8');
+  const css = fs.readFileSync(path.join(__dirname, '..', 'css', 'app', 'game-header.css'), 'utf8');
+
+  test('VR gets its own strip, not folded into the OS chips', () => {
+    // .game-os-strip is aria-label="Supported operating systems"; VR is a
+    // capability, not an OS, so folding it in makes that label wrong.
+    expect(src).toContain('id="game-vr-strip"');
+    expect(src).toContain('aria-label="VR support"');
+    const osStrip = src.slice(src.indexOf('game-os-strip'), src.indexOf('game-vr-strip'));
+    expect(osStrip).not.toContain('game-tag--vr');
+  });
+
+  test('the strip stays hidden for non-VR games', () => {
+    expect(src).toMatch(/id="game-vr-strip" hidden/);
+    expect(css).toContain('.game-vr-strip[hidden] { display: none; }');
+  });
+
+  test('it reuses the OS chip shape AND colour so the row reads as one thing', () => {
+    // Deliberately NOT the card's amber: on a card the chip fights a store
+    // pill, but this row answers a single question and three colours made it
+    // look like three unrelated facts.
+    expect(src).toContain('game-tag game-tag--vr');
+    const rule = css.match(/\.game-tag\.game-tag--vr\s*\{[^}]*\}/)[0];
+    expect(rule).toContain('--accent');
+    const osRule = css.match(/\.game-os-chip--on\s*\{[^}]*\}/)[0];
+    expect(osRule).toContain('--accent');
+  });
+
+  test('the tag-row chip always reads VR, never VR Only', () => {
+    // Same call as the cards: "VR" means the game has VR. The headset
+    // requirement is the banner's job, not a second label in a row of
+    // platform chips.
+    const block = src.slice(src.indexOf("game-vr-strip'"), src.indexOf('#game-vr-banner'));
+    expect(block).toContain('<span>VR</span>');
+    expect(block).not.toContain('VR Only');
+    expect(css).not.toContain('.game-tag--vr[data-vr="only"]');
+  });
+
+  test('the tag-row chip is not gated on the artwork overlay', () => {
+    // These shared an `if (!host) return` guard, so a missing
+    // #game-art-badges silently took the tag-row chip down with it.
+    const stripIdx = src.indexOf("game-vr-strip'");
+    const guardIdx = src.indexOf("const host = el.querySelector('#game-art-badges')");
+    expect(stripIdx).toBeGreaterThan(-1);
+    expect(stripIdx).toBeLessThan(guardIdx);
+  });
+
+  test('the VRDB source deep-links to the game, not the site root', () => {
+    expect(src).toContain('db.vronlinux.org/games/');
+    expect(src).not.toMatch(/href="https:\/\/db\.vronlinux\.org\/"/);
+  });
+});
+
+describe('VR on Linux as a compatibility tab (#246 follow-up)', () => {
+  const fs = require('fs');
+  const path = require('path');
+  const deck = fs.readFileSync(path.join(__dirname, '..', 'js', 'app', 'components', 'deck-status.js'), 'utf8');
+  const page = fs.readFileSync(path.join(__dirname, '..', 'js', 'app', 'components', 'game-page.js'), 'utf8');
+  const css = fs.readFileSync(path.join(__dirname, '..', 'css', 'app', 'game-header.css'), 'utf8');
+
+  test('the button says Compatibility, not Steam Deck', () => {
+    // The modal covers four surfaces; naming it after one tab undersells the
+    // rest and hides where the VR data lives.
+    expect(deck).toContain('<span>Compatibility</span>');
+    expect(deck).not.toContain('<span>Steam Deck</span>');
+  });
+
+  test('a fourth radio + panel exist for VR', () => {
+    expect(deck).toContain('id="dt-vr"');
+    expect(deck).toContain('dt-panel-vr');
+    expect(css).toContain('#dt-vr:checked      ~ .dt-panel-vr { display: block; }');
+  });
+
+  test('the VR tab starts hidden so non-VR games keep three tabs', () => {
+    expect(deck).toMatch(/id="dt-vr-tab" hidden/);
+    // .dt-tab sets display:inline-flex, so [hidden] needs an explicit rule.
+    expect(css).toContain('.dt-tab--vr[hidden] { display: none; }');
+  });
+
+  test('fillVrOnLinuxTab reveals the tab only when there are runtime reports', () => {
+    const fn = deck.slice(deck.indexOf('export function fillVrOnLinuxTab'));
+    expect(fn).toContain('if (!rows.length) return;');
+    expect(fn.indexOf('tab.hidden = false')).toBeGreaterThan(fn.indexOf('if (!rows.length) return;'));
+  });
+
+  test('the panel is filled async so the modal opens without waiting on vrdb.json', () => {
+    // renderDeckStatusModalContent is synchronous by design (renders off the
+    // in-memory deck cache); VRDB is a separate fetch.
+    expect(deck).toContain('export function fillVrOnLinuxTab');
+    expect(page).toContain('fillVrOnLinuxTab(');
+  });
+
+  test('both modal render paths refill the tab', () => {
+    // The deck fetch re-renders the modal body, which would wipe the tab.
+    const calls = page.match(/fillVrOnLinuxTab\(/g) || [];
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('the tab keeps the VRDB attribution and deep link', () => {
+    const fn = deck.slice(deck.indexOf('export function fillVrOnLinuxTab'));
+    expect(fn).toContain('db.vronlinux.org/games/');
+    expect(fn).toContain('(MIT)');
+    expect(fn).toMatch(/never mixed into our scoring|opposite way to a Pulse tier/);
+  });
+});
+
+describe('tag row shows only what applies (#246 follow-up)', () => {
+  const fs = require('fs');
+  const path = require('path');
+  const src = fs.readFileSync(path.join(__dirname, '..', 'js', 'app', 'components', 'game-page.js'), 'utf8');
+  const css = fs.readFileSync(path.join(__dirname, '..', 'css', 'app', 'game-header.css'), 'utf8');
+
+  test('unsupported OS chips are hidden, not greyed out', () => {
+    // A row of greyed chips for every OS the game does not support is noise;
+    // the reader wants to know where it runs.
+    expect(src).toContain('chip.hidden = !on;');
+  });
+
+  test('[hidden] actually hides a .game-tag', () => {
+    // .game-tag sets display:inline-flex, which defeats the hidden attribute.
+    expect(css).toContain('.game-tag[hidden] { display: none; }');
+  });
+
+  test('the VR chip beats .game-tag on specificity', () => {
+    // A bare .game-tag--vr ties with .game-tag and lost to its
+    // color: var(--muted), rendering the chip grey and indistinguishable
+    // from an unsupported platform.
+    expect(css).toContain('.game-tag.game-tag--vr');
+    expect(css).not.toMatch(/^\.game-tag--vr\s*\{/m);
+    const rule = css.match(/\.game-tag\.game-tag--vr\s*\{[^}]*\}/)[0];
+    expect(rule).toContain('opacity: 1');
+    expect(rule).toContain('--accent');
+  });
+
+  test('the VR chip only renders when the game has VR', () => {
+    // So it is always its lit state -- there is no dim VR variant.
+    const block = src.slice(src.indexOf('const vr = vrForApp('));
+    const stripIdx = block.indexOf("game-vr-strip'");
+    expect(block.slice(0, stripIdx)).toContain('if (vr) {');
+  });
+});
+
+describe('owner badge hover recolours the glyph', () => {
+  const fs = require('fs');
+  const path = require('path');
+  const cards = fs.readFileSync(path.join(__dirname, '..', 'css', 'shared', 'cards.css'), 'utf8');
+  const topbar = fs.readFileSync(path.join(__dirname, '..', 'js', 'lib', 'topbar.js'), 'utf8');
+
+  test('the sprites use currentColor so outside CSS can reach them', () => {
+    // A <symbol fill="#fff"> sets fill on the symbol, so its children inherit
+    // white from INSIDE the shadow tree and no page rule can override it --
+    // the reason a hover rule on the badge did nothing to the icon.
+    const book = topbar.match(/<symbol id="icon-book-open"[^>]*>/)[0];
+    expect(book).toContain('fill="currentColor"');
+    const wish = topbar.slice(topbar.indexOf('<symbol id="icon-wishlist-heart"'));
+    expect(wish.slice(0, 200)).toContain('fill="currentColor"');
+  });
+
+  test('hover changes color, not the border or box-shadow', () => {
+    const rule = cards.match(/\.game-card-owner-badge:hover\s*\{[^}]*\}/)[0];
+    expect(rule).toContain('color');
+    expect(rule).not.toContain('box-shadow');
+    expect(rule).not.toContain('border');
+  });
+
+  test('the badges still default to white', () => {
+    // currentColor only helps if something sets it; .game-card-owner-badge
+    // already does, so every existing usage is unchanged.
+    expect(cards).toMatch(/\.game-card-owner-badge\s*\{[^}]*color:\s*#fff/);
+  });
+});

--- a/tests/whatsNewRelease.test.js
+++ b/tests/whatsNewRelease.test.js
@@ -27,9 +27,11 @@ describe("What's New -> GitHub releases", () => {
 describe('draft-release automation', () => {
   test('prod deploy targets call the draft script', () => {
     expect(MAKEFILE).toContain('draft-release:');
-    // Both prod paths (full pipeline + pages-only promote) leave a draft.
+    // The prod pipeline path leaves a draft. Was 3 when gh-pages-only also
+    // called it; that target is gone (the gh-pages deploy path was retired
+    // after #362 moved publishing to Cloudflare Pages).
     const calls = MAKEFILE.match(/bash scripts\/draft-release\.sh/g) || [];
-    expect(calls.length).toBeGreaterThanOrEqual(3); // gh-run, gh-pages-only, draft-release
+    expect(calls.length).toBeGreaterThanOrEqual(2); // gh-run, draft-release
   });
 
   test('the script only ever drafts -- publishing stays human', () => {


### PR DESCRIPTION
Follow-up to #485. Three data-accuracy bugs, the VR UI polish from review, and two deploy-pipeline repairs.

## Deck verdicts were wrong for nearly every game

Counter-Strike 2's page said "Valve has not evaluated this title yet" while the store page said Playable.

`deck_status` scoped its fetch to `(protondb_count + pulse_count) > 0`. #474 decoupled ProtonDB, every protondb_count went to 0, and the scope collapsed to 17 games -- deck-status.json shipped 16 entries for a 32,325-row Steam catalog. Nothing errored; the file wrote fine and the log printed the new count as if it were normal. The verdicts were already sitting in the cache, the scope was just discarding them: the same run published **9,829** after the fix.

A missing map entry also returned `status: 'unknown'`, indistinguishable from Valve rating a game Unknown, and the copy then asserted a fact about a third party we never checked. There is a `hasData` flag now, and a map miss asks upstream through the existing public steam-explore proxy so every catalog stub can answer.

Auditing for the same assumption found a second victim: `most_played` capped its unrated bucket at 50, sized back when rated games carried the section. It was publishing 55 of Steam's top 100 -- which is also why the VR filter looked like it only matched 5 games.

## Deploy pipeline was deleting data files

`publish-shell.yml` keeps a list of pipeline data to re-fetch from the live site so a CSS-only deploy does not wipe data it never built. That is a FOURTH place a data file must be registered, after gh-pages-manifest.txt, the update-data.yml copy loops, and publish-cloudflare.sh SMALL_DATA. vr-index.json and vrdb.json were not on it, so every shell deploy dropped them -- and because the loop's only source is the live site, once dropped they could never self-recover. Both lists are now cross-checked by a test.

## VR polish from review

One amber `VR` chip on cards (VR-only is a banner on the detail page, not a second chip colour). Capped chip shape. The tag row shows only platforms that apply instead of greying out the rest, all in one accent colour. VR on Linux is a fourth tab in the Compatibility modal, which was called "Steam Deck" while already covering three devices. Play Mode now defaults from the game's VR capability: VR-only preselects VR, non-VR preselects Flatscreen, and playable-both is left blank and required so the reporter makes a deliberate choice.

Also fixes a ReferenceError that took out the VR chip, the VR-only banner and the artwork badges together: game-page.js called loadVrIndex/vrForApp without importing them, inside a `void (async () => {})()` with no catch, so the console stayed empty. There is now a catch, and a test asserting that any file calling a guarded VR helper imports it.

## Test suite: 27 minutes to 30 seconds

The coverage-report block in `finalize_output` used a LOCAL import of `refresh_catalog`, which no namespace patch could reach, so every finalize test paginated ~95 PCGamingWiki Cargo pages at their mandatory 2.1s spacing against a community-run API. Hoisted and stubbed.

## Verified on staging

    deck-status.json   16 -> 9,829     (CS2 playable)
    most_played.json   55 -> 93
    vr-index.json      1,289 entries, 280 VR-only
    anti-cheat.json    application/json, was SPA HTML

## After merge

- **Deck Verdict Backfill** becomes dispatchable (it is not on main until this lands). 22,497 games still have no verdict and a 40-game sample says ~47% of them have one, so roughly 10,700 more. Worth running: the Deck / Machine / SteamOS browse filters read the static map, so a missing entry reads as Unknown and a Verified filter silently drops verified games. ~2.2 hours.
- **VR Category Backfill** finishes the only/supported split.
- A prod pipeline run to publish the widened data. Prod currently has the VR code but none of the VR data.

Issues stay open until verified on the production URL, per the close-on-prod rule.