### PR TITLE
Staging to main: backup and PCGW ingest silent failures, cache persistence, R2 throughput

### DIFF
--- a/.github/scripts/backup.mjs
+++ b/.github/scripts/backup.mjs
@@ -10,11 +10,15 @@
  *   BACKUP_TYPE               - schema | user_configs | author_avatars | site | all
  *   SITE_DIR                  - path to checked-out gh-pages files (for site type)
  *   OUT_DIR                   - directory to write .tar.gz files into
+ *
+ * Optional env vars:
+ *   MIGRATIONS_DIR            - DDL source bundled into the schema archive
+ *                               (default: supabase/migrations)
  */
 
 import { createHmac } from 'crypto';
 import { execSync } from 'child_process'; // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process — Trusted CI script; commands from hardcoded constants, not user input
-import { mkdirSync, writeFileSync, readdirSync, statSync } from 'fs';
+import { mkdirSync, writeFileSync, readdirSync, readFileSync, statSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -107,6 +111,57 @@ export function sanitizeAuthorAvatar(row, secret) {
   };
 }
 
+/**
+ * Flatten a PostgREST OpenAPI document into per-table column definitions.
+ *
+ * PostgREST describes each exposed table under `definitions` (Swagger 2) or
+ * `components.schemas` (OpenAPI 3), with a `properties` map carrying the
+ * column type, format (the underlying Postgres type) and a description that
+ * holds the PK/FK notes. That is everything the REST layer can tell us about
+ * structure -- pg_catalog is not reachable over REST, so RLS policies,
+ * triggers and functions do NOT appear here and come from the migrations.
+ */
+export function summarizeOpenApiSchema(spec) {
+  const defs = spec?.definitions || spec?.components?.schemas || {};
+  return Object.entries(defs)
+    .map(([table, def]) => ({
+      table,
+      required: def?.required || [],
+      columns: Object.entries(def?.properties || {}).map(([name, meta]) => ({
+        name,
+        type: meta?.type ?? null,
+        // `format` is the Postgres type (e.g. "timestamp with time zone"),
+        // which is what a restore actually needs -- `type` is only the JSON
+        // supertype and would collapse int/bigint/numeric into "number".
+        format: meta?.format ?? null,
+        description: meta?.description ?? null,
+      })),
+    }))
+    .sort((a, b) => a.table.localeCompare(b.table));
+}
+
+/** Render the introspected tables as readable SQL-ish reference text. */
+export function renderSchemaReference(tables, date) {
+  const lines = [
+    `-- Schema reference ${date}`,
+    '-- Generated from the PostgREST OpenAPI document (live introspection).',
+    '-- This is a REFERENCE, not restorable DDL. The restorable definition is',
+    '-- the migrations/ directory in this archive, replayed in filename order.',
+    '-- RLS policies, triggers and functions are not visible to introspection',
+    '-- and exist only in those migration files.',
+    '',
+  ];
+  for (const t of tables) {
+    lines.push(`-- Table: ${t.table} (${t.columns.length} columns)`);
+    for (const c of t.columns) {
+      const req = t.required.includes(c.name) ? ' NOT NULL' : '';
+      lines.push(`--   ${c.name} ${c.format || c.type || 'unknown'}${req}`);
+    }
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
 // ---------------------------------------------------------------------------
 // I/O (not exported; depends on env + network)
 // ---------------------------------------------------------------------------
@@ -127,41 +182,55 @@ async function fetchAll(table, select = '*', extraFilter = '', headers) {
   return rows;
 }
 
-async function fetchSchema(headers, date) {
-  const tables = ['user_configs', 'author_avatars', 'user_proton_configs', 'user_systems', 'admins', 'banned_users'];
-  const lines = [`-- Schema export ${date}\n`];
-  for (const table of tables) {
-    const res = await fetch(`${process.env.SUPABASE_URL}/rest/v1/${table}?limit=0`, { headers });
-    lines.push(`-- Table: ${table} (columns from API response headers)\n`);
-    lines.push(`-- Content-Range: ${res.headers.get('content-range') || 'n/a'}\n\n`);
+async function fetchSchema(headers, date, migrationsDir) {
+  // Live introspection. PostgREST serves an OpenAPI document at the API root
+  // describing every exposed table and column with its type -- this is the
+  // only structural view the service-role key can reach, since pg_catalog is
+  // not exposed over REST. Requires the secret key; the publishable key gets
+  // "Only secret API keys can be used for this endpoint".
+  const res = await fetch(`${process.env.SUPABASE_URL}/rest/v1/`, {
+    headers: { ...headers, Accept: 'application/openapi+json' },
+  });
+  if (!res.ok) {
+    throw new Error(`Schema introspection failed: ${res.status} ${await res.text()}`);
+  }
+  const spec = await res.json();
+  const tables = summarizeOpenApiSchema(spec);
+  // An empty result means the endpoint answered but told us nothing, which is
+  // what the previous implementation shipped for months. Treat it as failure.
+  if (!tables.length) {
+    throw new Error('Schema introspection returned no tables -- refusing to write an empty schema backup');
   }
 
-  const policyQuery = `
-    SELECT schemaname, tablename, policyname, cmd, qual, with_check
-    FROM pg_policies
-    WHERE schemaname = 'public'
-    ORDER BY tablename, policyname;
-  `;
-  const queryRes = await fetch(`${process.env.SUPABASE_URL}/rest/v1/rpc/query`, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify({ query: policyQuery }),
-  }).catch(() => null);
-
-  if (queryRes?.ok) {
-    const policies = await queryRes.json();
-    lines.push('-- RLS Policies\n');
-    lines.push(JSON.stringify(policies, null, 2));
+  // The DDL itself. Migrations are the authoritative definition of the schema
+  // (tables, RLS policies, triggers, functions) and replaying them in filename
+  // order reconstructs the database. Introspection cannot see any of that, so
+  // without these the backup is structurally useless.
+  const migrations = readMigrations(migrationsDir);
+  if (!migrations.length) {
+    throw new Error(`No migrations found in ${migrationsDir} -- refusing to write a schema backup with no DDL`);
   }
 
-  return lines.join('');
+  return { spec, tables, migrations };
+}
+
+// Read the migration files that define the schema. Sorted by filename, which
+// is the timestamp-prefixed order they must be replayed in.
+function readMigrations(dir) {
+  let names;
+  try {
+    names = readdirSync(dir).filter(f => f.endsWith('.sql')).sort();
+  } catch (err) {
+    throw new Error(`Cannot read migrations from ${dir}: ${err.message}`);
+  }
+  return names.map(name => ({ name, sql: readFileSync(join(dir, name), 'utf8') }));
 }
 
 function makeTarball(srcDir, outPath) {
   execSync(`tar -czf "${outPath}" -C "${srcDir}" .`, { stdio: 'inherit' }); // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process — Trusted CI script; commands from hardcoded constants, not user input
 }
 
-async function run(type, { headers, date, outDir, siteDir, secret }) {
+async function run(type, { headers, date, outDir, siteDir, secret, migrationsDir }) {
   const workDir = join(tmpdir(), `backup-${date}-${type}`);
   mkdirSync(workDir, { recursive: true });
 
@@ -170,8 +239,22 @@ async function run(type, { headers, date, outDir, siteDir, secret }) {
   let rowCount = null;
 
   if (type === 'schema') {
-    const schema = await fetchSchema(headers, date);
-    writeFileSync(join(workDir, `schema-${date}.sql`), schema);
+    const { spec, tables, migrations } = await fetchSchema(headers, date, migrationsDir);
+
+    // Restorable DDL: the migrations, replayed in filename order. This is the
+    // part that actually rebuilds the database, RLS and triggers included.
+    const migDir = join(workDir, 'migrations');
+    mkdirSync(migDir, { recursive: true });
+    for (const m of migrations) writeFileSync(join(migDir, m.name), m.sql);
+
+    // Live introspection, kept alongside so a restore can be diffed against
+    // what prod actually had. Catches drift where the live schema and the
+    // migration history disagree.
+    writeFileSync(join(workDir, `schema-${date}.json`), JSON.stringify({ tables, openapi: spec }, null, 2));
+    writeFileSync(join(workDir, `schema-${date}.sql`), renderSchemaReference(tables, date));
+
+    rowCount = tables.length;
+    console.log(`[schema] introspected ${tables.length} tables, bundled ${migrations.length} migrations`);
   }
 
   if (type === 'user_configs') {
@@ -240,6 +323,8 @@ async function main() {
   const outDir = process.env.OUT_DIR || '.';
   const siteDir = process.env.SITE_DIR || '';
   const type = process.env.BACKUP_TYPE || 'all';
+  // Migrations are the authoritative DDL and ship inside the schema archive.
+  const migrationsDir = process.env.MIGRATIONS_DIR || 'supabase/migrations';
 
   mkdirSync(outDir, { recursive: true });
   const types = type === 'all'
@@ -248,7 +333,7 @@ async function main() {
 
   const results = [];
   for (const t of types) {
-    results.push(await run(t, { headers, date, outDir, siteDir, secret }));
+    results.push(await run(t, { headers, date, outDir, siteDir, secret, migrationsDir }));
   }
 
   // Write manifest for the workflow to append to backups.jsonl

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -541,6 +541,10 @@ jobs:
           # bucket (staging/prod, split in #380) keeps its own manifest, so
           # the two targets delta independently.
           R2_DELTA_SYNC: ${{ vars.R2_DELTA_SYNC || '0' }}
+          # Escape hatch for the R2 sync fan-out. Unset falls through to the
+          # script's default (32). Set the repo variable to dial back without a
+          # code change if R2 starts returning ServiceUnavailable at volume.
+          R2_SYNC_CONCURRENCY: ${{ vars.R2_SYNC_CONCURRENCY || '' }}
         run: |
           bash scripts/publish-cloudflare.sh /tmp/protondb-output "$GITHUB_WORKSPACE"
 

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -495,6 +495,15 @@ jobs:
       # gh-pages orphan deploy below (`git rm -rf .`) deletes every tracked
       # file, backup-to-release.sh included, but the "Backup data to GitHub
       # Release" step needs it afterward regardless of which deploy path ran.
+      #
+      # Not hypothetical: every scheduled run from 2026-08-19 through 08-23
+      # died here with "scripts/backup-to-release.sh: No such file or
+      # directory" and the nightly data backup stopped for five days (#494).
+      # It read as intermittent because cloudflare-target runs skip the orphan
+      # step and so never hit the wipe. That is also why this cannot move
+      # inside the orphan step next to the preserve-* copies -- the backup
+      # runs on both targets, so a cp nested there would never fire on
+      # cloudflare and would only relocate the failure.
       - name: Preserve backup script
         if: inputs.staging_with_pipeline != true && inputs.staging_with_finalize != true
         run: cp scripts/backup-to-release.sh /tmp/backup-to-release.sh
@@ -534,21 +543,6 @@ jobs:
           R2_DELTA_SYNC: ${{ vars.R2_DELTA_SYNC || '0' }}
         run: |
           bash scripts/publish-cloudflare.sh /tmp/protondb-output "$GITHUB_WORKSPACE"
-
-      # The backup step at the end of this job runs `bash <script>` from the
-      # workspace, but the gh-pages orphan deploy below does `git rm -rf .`
-      # first, which deletes every tracked file including that script. Every
-      # scheduled run from 2026-08-19 onward failed here with
-      # "scripts/backup-to-release.sh: No such file or directory", so the
-      # nightly data backup silently stopped for five days.
-      #
-      # Same hazard the preserve-* scripts already work around, but staged in
-      # its own step rather than inside the orphan step: the backup runs on
-      # both deploy targets, and on deploy_target=cloudflare the orphan step
-      # is skipped entirely, so a cp living inside it would never happen.
-      - name: Stage the backup script out of the workspace
-        if: inputs.staging_with_pipeline != true && inputs.staging_with_finalize != true
-        run: cp scripts/backup-to-release.sh /tmp/backup-to-release.sh
 
       - name: Deploy to gh-pages (orphan, no history)
         if: inputs.staging_with_pipeline != true && inputs.staging_with_finalize != true && (inputs.deploy_target || 'cloudflare') != 'cloudflare'

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -379,8 +379,8 @@ jobs:
       - name: Seed store catalog caches from gh-pages
         run: |
           mkdir -p .cache
-          cp gh-pages-data/gog-catalog-cache.json .cache/ 2>/dev/null || true
-          cp gh-pages-data/epic-catalog-cache.json .cache/ 2>/dev/null || true
+          bash scripts/seed-catalog-cache.sh gh-pages-data .cache \
+            gog-catalog-cache.json epic-catalog-cache.json
 
       # #89: log which caches survived the restore, their sizes + ages,
       # so the workflow output tells us at a glance whether the two cache
@@ -844,8 +844,8 @@ jobs:
             mkdir -p /tmp/protondb-output/data
           fi
           mkdir -p repo/.cache
-          cp gh-pages-data/gog-catalog-cache.json repo/.cache/ 2>/dev/null || true
-          cp gh-pages-data/epic-catalog-cache.json repo/.cache/ 2>/dev/null || true
+          bash repo/scripts/seed-catalog-cache.sh gh-pages-data repo/.cache \
+            gog-catalog-cache.json epic-catalog-cache.json
 
       - name: Repair official dump provenance metadata
         working-directory: repo
@@ -1067,8 +1067,8 @@ jobs:
             mkdir -p /tmp/protondb-output/data
           fi
           mkdir -p repo/.cache
-          cp gh-pages-data/gog-catalog-cache.json repo/.cache/ 2>/dev/null || true
-          cp gh-pages-data/epic-catalog-cache.json repo/.cache/ 2>/dev/null || true
+          bash repo/scripts/seed-catalog-cache.sh gh-pages-data repo/.cache \
+            gog-catalog-cache.json epic-catalog-cache.json
 
       - name: Repair official dump provenance metadata
         working-directory: repo

--- a/.github/workflows/update-epic-catalog.yml
+++ b/.github/workflows/update-epic-catalog.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Seed catalog cache from gh-pages
         run: |
           mkdir -p .cache
-          cp gh-pages-data/epic-catalog-cache.json .cache/ 2>/dev/null || true
+          bash scripts/seed-catalog-cache.sh gh-pages-data .cache epic-catalog-cache.json
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -55,7 +55,16 @@ jobs:
       - name: Fetch Epic catalog
         run: uv run python scripts/fetch_epic_catalog.py
         env:
-          FORCE_REFRESH: ${{ inputs.force_refresh }}
+          # A scheduled run exists to refresh the catalog, so it must not
+          # ask the cache for permission. The cron cadence (weekly) equals
+          # GOG/Epic CATALOG_CACHE_MAX_AGE (7 days), so the scheduled run kept
+          # finding the cache a few hours short of expiry and doing nothing:
+          #   [gog-catalog] loaded 8,053 entries from cache (age 147.1h)
+          #   Cache unchanged, nothing to commit
+          # The copy on gh-pages then went stale ~a day later and stayed that
+          # way until the next weekly run, so every finalize in between paid
+          # the full re-fetch (~134s GOG, ~140s Epic) and threw it away.
+          FORCE_REFRESH: ${{ inputs.force_refresh == true || github.event_name == 'schedule' }}
 
       - name: Commit catalog cache to gh-pages
         if: inputs.dry_run != true

--- a/.github/workflows/update-gog-catalog.yml
+++ b/.github/workflows/update-gog-catalog.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Seed catalog cache from gh-pages
         run: |
           mkdir -p .cache
-          cp gh-pages-data/gog-catalog-cache.json .cache/ 2>/dev/null || true
+          bash scripts/seed-catalog-cache.sh gh-pages-data .cache gog-catalog-cache.json
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -53,7 +53,16 @@ jobs:
       - name: Fetch GOG catalog
         run: uv run python scripts/fetch_gog_catalog.py
         env:
-          FORCE_REFRESH: ${{ inputs.force_refresh }}
+          # A scheduled run exists to refresh the catalog, so it must not
+          # ask the cache for permission. The cron cadence (weekly) equals
+          # GOG/Epic CATALOG_CACHE_MAX_AGE (7 days), so the scheduled run kept
+          # finding the cache a few hours short of expiry and doing nothing:
+          #   [gog-catalog] loaded 8,053 entries from cache (age 147.1h)
+          #   Cache unchanged, nothing to commit
+          # The copy on gh-pages then went stale ~a day later and stayed that
+          # way until the next weekly run, so every finalize in between paid
+          # the full re-fetch (~134s GOG, ~140s Epic) and threw it away.
+          FORCE_REFRESH: ${{ inputs.force_refresh == true || github.event_name == 'schedule' }}
 
       - name: Commit catalog cache to gh-pages
         if: inputs.dry_run != true

--- a/js/app/components/deck-status.js
+++ b/js/app/components/deck-status.js
@@ -312,16 +312,20 @@ export function isSteamDeckHardware(r) {
 }
 
 // Steam Machine detection (#255 Phase 2). Valve's late-2025 SFF SteamOS box.
-// Hardware signatures are not confirmed until devices are in reviewers' hands
-// so the regex is intentionally empty for now -- Phase 2 will fill it in with
-// the real APU / GPU strings. Keeping the API shape stable so callers do not
-// have to change once detection lights up. The web-source dropdown in the
-// submit form also flags Steam Machine explicitly, and that string surfaces
-// here as a fallback detection channel.
-export const _MACHINE_APU_RE = /\bsteam[\s_-]*machine\b/i;
+// Uses _STEAM_MACHINE_RE above -- the same pattern game-page.js filters on and
+// the mirror of _STEAM_MACHINE in scripts/pipeline/stats.py, so all three
+// surfaces answer this question identically (#496).
+//
+// This used to test a separate _MACHINE_APU_RE that matched only the literal
+// words "steam machine", against a haystack that included `r.webSource`. Real
+// APU strings do not contain those words -- a Deck reports "AMD Custom APU
+// 0405", not "Steam Deck" -- and nothing ever set webSource: no column, no
+// pipeline write, no submit-form dropdown, despite a comment here claiming
+// one existed. So it could not return true for any real report, while the
+// game page and the pipeline were already matching the RDNA 3 signature.
 export function isSteamMachineHardware(r) {
-  const haystack = `${r.cpu || ''} ${r.gpu || ''} ${r.webSource || ''}`;
-  return _MACHINE_APU_RE.test(haystack);
+  const haystack = `${r.cpu || ''} ${r.gpu || ''}`;
+  return _STEAM_MACHINE_RE.test(haystack);
 }
 
 // SVG path data for each signal icon. Drawn at 24x24 viewBox. Currentcolor

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -12,7 +12,7 @@ import { fetchConfigPlaytimeTotals, fetchNativeReports, fetchSupabase, flagRepor
 import { castVote, fetchUserVotes, fetchVotes } from '../api/votes.js?v=aba6619f';
 import { enhanceAuthorBlocks } from './author.js?v=3a8cb3c7';
 import { renderConfigCard } from './config-cards.js?v=c67740f8';
-import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, _STEAM_MACHINE_RE, fillVrOnLinuxTab, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=01ba8999';
+import { DECK_STATUS_ICON_SVG, DECK_STATUS_LABELS, _DECK_LCD_RE, _DECK_OLED_RE, _STEAM_MACHINE_RE, fillVrOnLinuxTab, renderDeckStatusButton, renderDeckStatusModalContent } from './deck-status.js?v=4604c78e';
 import { renderCard } from './report-card.js?v=5e25c644';
 import { loadExtendedSteamIndex, extendedSteamIndex } from './search.js?v=091f940b';
 import { getGamesByIds } from '../api/search-games.js?v=0b6c4bb3';

--- a/js/app/components/signals.js
+++ b/js/app/components/signals.js
@@ -1,6 +1,6 @@
 // signals (components) for the app page. Relocated from app.js.
 
-import { isSteamDeckHardware, isSteamMachineHardware } from './deck-status.js?v=01ba8999';
+import { isSteamDeckHardware, isSteamMachineHardware } from './deck-status.js?v=4604c78e';
 
 export const SIGNAL_ICON_SVG = {
   install: '<path fill="currentColor" d="M5 20h14v-2H5v2zm7-2 5-5h-3V4h-4v9H7l5 5z"/>',

--- a/package-lock.json
+++ b/package-lock.json
@@ -3044,9 +3044,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5140,9 +5140,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7917,9 +7917,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -8854,9 +8854,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "vite": "^8.2.1"
   },
   "overrides": {
-    "brace-expansion@1": "^1.1.16"
+    "brace-expansion@1": "^1.1.18",
+    "js-yaml@3": "^3.15.1",
+    "brace-expansion@2": "^2.1.4",
+    "nanoid@3": "^3.3.18"
   }
 }

--- a/scripts/pipeline/pcgamingwiki.py
+++ b/scripts/pipeline/pcgamingwiki.py
@@ -59,6 +59,11 @@ USER_AGENT = (
 )
 
 CACHE_FILENAME = "pcgamingwiki-cache.json"
+# Same persistence fix as the catalog cache (#497): .cache/ is what the
+# pipeline's Actions cache carries between runs. Writing this into the pipeline
+# output dir meant /tmp on a runner, and the gh-pages copy loop that used to
+# rescue it stopped running when #362 made cloudflare the deploy target.
+DEFAULT_ENRICHER_CACHE_PATH = Path(__file__).resolve().parents[2] / ".cache" / CACHE_FILENAME
 
 # Fresh cadence: weekly. PCGW is community-edited and moves slowly enough
 # that a daily fetch wastes their capacity for zero benefit.
@@ -445,7 +450,7 @@ def _first_engine(field) -> str | None:
     return None
 
 
-def refresh_cache(output_dir: Path, force: bool = False) -> dict[str, dict]:
+def refresh_cache(output_dir: Path, force: bool = False, cache_path: Path | None = None) -> dict[str, dict]:
     """Load or refresh the PCGW cache. Returns `{appid: {os, engine}}`.
 
     Refreshes when the cache is missing, stale, or `force` (or the
@@ -455,7 +460,8 @@ def refresh_cache(output_dir: Path, force: bool = False) -> dict[str, dict]:
     """
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
-    cache_path = output_dir / CACHE_FILENAME
+    cache_path = Path(cache_path) if cache_path else DEFAULT_ENRICHER_CACHE_PATH
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
     cache = _load_cache(cache_path)
 
     now = int(time.time())
@@ -483,7 +489,7 @@ def refresh_cache(output_dir: Path, force: bool = False) -> dict[str, dict]:
     return by_appid
 
 
-def enrich_search_index_with_pcgamingwiki(output_dir: Path) -> None:
+def enrich_search_index_with_pcgamingwiki(output_dir: Path, cache_path: Path | None = None) -> None:
     """Merge PCGW OS + engine into search-index cols 14 + 15.
 
     Pads shorter rows with None so both columns land at the expected
@@ -505,7 +511,7 @@ def enrich_search_index_with_pcgamingwiki(output_dir: Path) -> None:
     if not isinstance(entries, list) or not entries:
         return
 
-    by_appid = refresh_cache(output_dir)
+    by_appid = refresh_cache(output_dir, cache_path=cache_path)
 
     hits = 0
     for row in entries:

--- a/scripts/pipeline/pcgamingwiki.py
+++ b/scripts/pipeline/pcgamingwiki.py
@@ -265,12 +265,27 @@ def _cargo_get(params: dict) -> dict | None:
         return None
     if not isinstance(data, dict):
         return None
-    # MediaWiki signals lag pressure via `error: {code: "maxlag", ...}` with a
-    # 200 HTTP status. Surface it clearly instead of failing silently -- the
-    # caller's retry loop can back off.
+    # MediaWiki reports query-level errors in the body with a 200 status, so a
+    # successful HTTP response says nothing about whether the query ran. Any
+    # `error` key means we got no rows, and it must be reported as failure:
+    # callers read a payload without `cargoquery` as an empty result set, which
+    # is indistinguishable from "no games matched" and lets a rejected query
+    # overwrite a good cache with nothing.
+    #
+    # This is how the PCGW ingest died silently (#497). PCGW restricted Cargo:
+    #   HTTP 200 {"error":{"code":"permissiondenied",
+    #             "info":"You don't have permission to run arbitrary Cargo queries."}}
+    # maxlag used to be logged here and the payload returned anyway, which had
+    # the same effect on a busy server -- a warning nobody saw, then an empty
+    # catalog written over the real one.
     err = data.get("error")
-    if isinstance(err, dict) and err.get("code") == "maxlag":
-        log(f"[pcgamingwiki] WARN: server maxlag pressure -- {err.get('info', '')}")
+    if isinstance(err, dict):
+        code = err.get("code") or "unknown"
+        if code == "maxlag":
+            log(f"[pcgamingwiki] WARN: server maxlag pressure -- {err.get('info', '')}")
+        else:
+            log(f"[pcgamingwiki] ERROR: cargo query rejected: {code} -- {err.get('info', '')}")
+        return None
     return data
 
 

--- a/scripts/pipeline/pcgamingwiki_catalog.py
+++ b/scripts/pipeline/pcgamingwiki_catalog.py
@@ -403,10 +403,28 @@ def refresh_catalog(output_dir: Path, force: bool = False) -> dict[str, dict]:
     log("[pcgwiki-catalog] refreshing from cargo API")
     rows = _fetch_all_pages()
     if rows is None:
-        log(f"[pcgwiki-catalog] cargo unreachable; using {len(cache['entries'])} cached entries")
+        # None covers both a dead endpoint and a query the server rejected
+        # with a 200 (#497) -- either way we have no rows and must not treat
+        # that as an empty catalog.
+        log(f"[pcgwiki-catalog] cargo fetch failed; using {len(cache['entries'])} cached entries")
         return cache["entries"]
 
     entries = _build_entries(rows)
+
+    # An empty result must never replace a catalog we already have. _cargo_get
+    # returns None for a rejected query now (#497), so reaching here with zero
+    # rows should mean PCGW genuinely has no Windows games -- which is never
+    # true. Treating it as real is what emptied the published catalog: the run
+    # logged "cached 0 entries" like a normal day and wrote {} over thousands
+    # of entries, and every later run repeated it from the now-empty cache.
+    if not entries and cache.get("entries"):
+        log(
+            f"[pcgwiki-catalog] ERROR: refresh produced 0 entries but cache holds "
+            f"{len(cache['entries'])}; keeping the cache. Upstream query returned "
+            f"no rows without reporting an error."
+        )
+        return cache["entries"]
+
     cache = {"fetched_at": now, "entries": entries}
     _save_cache(cache_path, cache)
     log(f"[pcgwiki-catalog] cached {len(entries)} entries (of {len(rows)} candidate rows)")

--- a/scripts/pipeline/pcgamingwiki_catalog.py
+++ b/scripts/pipeline/pcgamingwiki_catalog.py
@@ -76,6 +76,16 @@ from .pcgamingwiki import (
 )
 
 CACHE_FILENAME = "pcgwiki-catalog-cache.json"
+# Cache lives in .cache/ alongside the GOG and Epic catalog caches, which is
+# the directory the pipeline's Actions cache persists between runs (#497).
+#
+# It used to be written into the pipeline OUTPUT dir, which is /tmp on a
+# runner. The only thing that copied it anywhere durable was the gh-pages
+# deploy loop, and #362 made cloudflare the deploy target, so that loop stopped
+# running -- the cache has been written and discarded on every run since. That
+# left refresh_catalog's disk-fallback unable to ever engage in CI: there was
+# never a cache on disk to fall back to when PCGW started rejecting queries.
+DEFAULT_CATALOG_CACHE_PATH = Path(__file__).resolve().parents[2] / ".cache" / CACHE_FILENAME
 OUTPUT_FILENAME = "pcgwiki-catalog.json"
 ID_MAP_FILENAME = "pcgw-id-map.json"
 
@@ -383,7 +393,7 @@ def _clean_cover_url(value) -> str | None:
     return text
 
 
-def refresh_catalog(output_dir: Path, force: bool = False) -> dict[str, dict]:
+def refresh_catalog(output_dir: Path, force: bool = False, cache_path: Path | None = None) -> dict[str, dict]:
     """Load or refresh the catalog cache. Returns `{pw_<hash>: entry}`.
 
     Falls back to the on-disk cache when the network is down so a broken
@@ -391,7 +401,10 @@ def refresh_catalog(output_dir: Path, force: bool = False) -> dict[str, dict]:
     """
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
-    cache_path = output_dir / CACHE_FILENAME
+    # output_dir is where published artifacts go; the cache is separate so it
+    # can live somewhere that survives the run.
+    cache_path = Path(cache_path) if cache_path else DEFAULT_CATALOG_CACHE_PATH
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
     cache = _load_cache(cache_path)
 
     now = int(time.time())
@@ -431,7 +444,7 @@ def refresh_catalog(output_dir: Path, force: bool = False) -> dict[str, dict]:
     return entries
 
 
-def merge_catalog_into_search_index(output_dir: Path) -> None:
+def merge_catalog_into_search_index(output_dir: Path, cache_path: Path | None = None) -> None:
     """Add one row per PCGWiki-only entry to `search-index.json`.
 
     Rows carry the same 16-column shape the enrichers write, filled with
@@ -464,7 +477,7 @@ def merge_catalog_into_search_index(output_dir: Path) -> None:
     if not isinstance(entries_index, list):
         return
 
-    catalog = refresh_catalog(output_dir)
+    catalog = refresh_catalog(output_dir, cache_path=cache_path)
     if not catalog:
         log("[pcgwiki-catalog] catalog empty; nothing to merge")
         return

--- a/scripts/publish-cloudflare.sh
+++ b/scripts/publish-cloudflare.sh
@@ -98,9 +98,20 @@ elif [ -d "$OUTPUT_DIR/data" ]; then
   : "${R2_ACCESS_KEY_ID:?R2_ACCESS_KEY_ID required for R2 sync}"
   : "${R2_SECRET_ACCESS_KEY:?R2_SECRET_ACCESS_KEY required for R2 sync}"
 
-  # Throttle concurrency so parallel PUTs do not trip R2's per-object write
-  # limit (#379); pairs with the adaptive retry mode set in r2aws().
-  aws configure set default.s3.max_concurrent_requests 4
+  # Concurrency for the fan-out, with adaptive retry so a transient R2
+  # ServiceUnavailable does not fail the whole run (#379).
+  #
+  # The 4 here was an over-correction. R2's ~1/sec write limit is PER OBJECT
+  # KEY -- the same key written repeatedly -- not a cap across distinct keys.
+  # This sync writes ~187k DISTINCT keys, so the limit does not apply to
+  # fan-out and 4 concurrent PUTs just made a full sync crawl for ~40 minutes.
+  # It was also set before the outer retry loop further down existed; with that
+  # loop plus adaptive backoff (exponential + jitter, reads throttling metadata)
+  # as backstops, running wide is safe.
+  #
+  # R2_SYNC_CONCURRENCY lets a workflow dial this back without a code change if
+  # R2 ever pushes back.
+  aws configure set default.s3.max_concurrent_requests "${R2_SYNC_CONCURRENCY:-32}"
 
   # Cleaned up by the shared EXIT trap set in section 2 (a second `trap EXIT`
   # would replace this one, so both temp dirs share a single trap).

--- a/scripts/seed-catalog-cache.sh
+++ b/scripts/seed-catalog-cache.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Seed a store catalog cache from gh-pages, but only when it is actually newer.
+#
+# The pipeline restores .cache/ from the Actions cache first, then seeds these
+# two files from gh-pages so a catalog rebuilt by the dedicated weekly
+# workflows wins over a stale copy carried in the Actions cache.
+#
+# That assumed gh-pages is the fresher of the two. It was not. The weekly
+# workflow only refreshed when the cache had already expired, and its cadence
+# equals the TTL, so it kept no-opping and gh-pages froze -- while finalize
+# re-fetched the catalog in-line and saved a genuinely fresh copy to the
+# Actions cache. The unconditional `cp` then clobbered that fresh copy with the
+# frozen one on every run, so the re-fetch happened again, and again.
+#
+# Comparing `_ts` keeps the intent (a real rebuild wins) without the inversion.
+#
+# Usage: seed-catalog-cache.sh <gh-pages-dir> <cache-dir> <file>...
+set -euo pipefail
+
+SRC_DIR="${1:?gh-pages dir required}"; shift
+DST_DIR="${1:?cache dir required}"; shift
+
+mkdir -p "$DST_DIR"
+
+# Print the `_ts` epoch from a catalog cache, or 0 when absent/unreadable.
+cache_ts() {
+  python3 -c "
+import json,sys
+try:
+    print(int(json.load(open(sys.argv[1])).get('_ts') or 0))
+except Exception:
+    print(0)
+" "$1" 2>/dev/null || echo 0
+}
+
+for f in "$@"; do
+  src="$SRC_DIR/$f"
+  dst="$DST_DIR/$f"
+  if [ ! -f "$src" ]; then
+    echo "[seed-catalog] $f: not on gh-pages, keeping whatever the Actions cache had"
+    continue
+  fi
+  if [ ! -f "$dst" ]; then
+    cp "$src" "$dst"
+    echo "[seed-catalog] $f: seeded from gh-pages (no local copy)"
+    continue
+  fi
+  src_ts="$(cache_ts "$src")"
+  dst_ts="$(cache_ts "$dst")"
+  if [ "$src_ts" -gt "$dst_ts" ]; then
+    cp "$src" "$dst"
+    echo "[seed-catalog] $f: gh-pages is newer (${src_ts} > ${dst_ts}), seeded"
+  else
+    echo "[seed-catalog] $f: local cache is newer or equal (${dst_ts} >= ${src_ts}), kept"
+  fi
+done

--- a/tests/backupSchema.test.js
+++ b/tests/backupSchema.test.js
@@ -1,0 +1,113 @@
+/**
+ * Schema backup must contain a schema.
+ *
+ * The previous fetchSchema shipped a 523-byte file of comments and nothing
+ * else, in every backup release, for months (#495). Two silent failures:
+ *
+ *  - it read column definitions out of a `content-range` response header,
+ *    which does not carry them, so every table recorded an empty range
+ *  - it fetched RLS policies from /rest/v1/rpc/query, an RPC that does not
+ *    exist (PGRST202). The call was `.catch(() => null)` and the write was
+ *    gated on `res?.ok`, so the 404 was swallowed and the section omitted
+ *
+ * The workflow went green and the release asset looked right. These tests pin
+ * the two properties that were missing: real structure, and loud failure.
+ */
+
+const {
+  summarizeOpenApiSchema,
+  renderSchemaReference,
+} = require('../.github/scripts/backup.mjs');
+
+const SPEC = {
+  definitions: {
+    user_configs: {
+      required: ['id', 'app_id'],
+      properties: {
+        id: { type: 'integer', format: 'bigint', description: 'Note: PK' },
+        app_id: { type: 'string', format: 'text' },
+        created_at: { type: 'string', format: 'timestamp with time zone' },
+      },
+    },
+    admins: {
+      required: [],
+      properties: { proton_pulse_user_id: { type: 'string', format: 'uuid' } },
+    },
+  },
+};
+
+describe('summarizeOpenApiSchema', () => {
+  test('extracts every table with its columns', () => {
+    const out = summarizeOpenApiSchema(SPEC);
+    expect(out.map(t => t.table)).toEqual(['admins', 'user_configs']); // sorted
+    const uc = out.find(t => t.table === 'user_configs');
+    expect(uc.columns.map(c => c.name)).toEqual(['id', 'app_id', 'created_at']);
+    expect(uc.required).toEqual(['id', 'app_id']);
+  });
+
+  test('keeps the Postgres type, not just the JSON supertype', () => {
+    // `type` collapses bigint/int/numeric to "integer"/"number"; a restore
+    // needs `format`, which carries the real column type.
+    const uc = summarizeOpenApiSchema(SPEC).find(t => t.table === 'user_configs');
+    expect(uc.columns.find(c => c.name === 'id').format).toBe('bigint');
+    expect(uc.columns.find(c => c.name === 'created_at').format).toBe('timestamp with time zone');
+  });
+
+  test('reads OpenAPI 3 components.schemas as well as Swagger 2 definitions', () => {
+    const v3 = { components: { schemas: SPEC.definitions } };
+    expect(summarizeOpenApiSchema(v3).map(t => t.table)).toEqual(['admins', 'user_configs']);
+  });
+
+  test('returns empty for a response carrying no schema at all', () => {
+    // This is the shape the old code silently accepted: the endpoint answers,
+    // but says nothing. fetchSchema now throws on this rather than writing it.
+    expect(summarizeOpenApiSchema({ message: 'Secret API key required' })).toEqual([]);
+    expect(summarizeOpenApiSchema(null)).toEqual([]);
+  });
+});
+
+describe('renderSchemaReference', () => {
+  const out = renderSchemaReference(summarizeOpenApiSchema(SPEC), '2026-08-24');
+
+  test('lists real columns and types, not content-range placeholders', () => {
+    expect(out).toContain('id bigint NOT NULL');
+    expect(out).toContain('created_at timestamp with time zone');
+    expect(out).not.toContain('Content-Range');
+    expect(out).not.toContain('columns from API response headers');
+  });
+
+  test('says plainly that it is not the restorable artifact', () => {
+    // The old file read like a schema dump while being nothing of the sort.
+    // Whatever replaces it must not invite the same misreading.
+    expect(out).toMatch(/not restorable DDL/i);
+    expect(out).toMatch(/migrations/i);
+  });
+});
+
+describe('the failure modes that made #495 invisible', () => {
+  const SRC = require('fs').readFileSync(
+    require.resolve('../.github/scripts/backup.mjs'), 'utf8');
+
+  test('no longer calls the nonexistent rpc/query endpoint', () => {
+    expect(SRC).not.toContain('rpc/query');
+  });
+
+  test('does not derive columns from response headers', () => {
+    expect(SRC).not.toContain('content-range');
+    expect(SRC).not.toContain('columns from API response headers');
+  });
+
+  test('schema failures throw instead of being swallowed', () => {
+    // The specific construct that hid the 404: a catch returning null feeding
+    // an optional-chained ok check.
+    expect(SRC).not.toMatch(/\.catch\(\(\)\s*=>\s*null\)/);
+    expect(SRC).toMatch(/throw new Error\(`Schema introspection failed/);
+    expect(SRC).toMatch(/refusing to write an empty schema backup/);
+    expect(SRC).toMatch(/refusing to write a schema backup with no DDL/);
+  });
+
+  test('the schema archive bundles the migrations that hold RLS and triggers', () => {
+    expect(SRC).toMatch(/mkdirSync\(migDir/);
+    expect(SRC).toMatch(/readMigrations/);
+  });
+});

--- a/tests/orphanDeployScriptStaging.test.js
+++ b/tests/orphanDeployScriptStaging.test.js
@@ -58,6 +58,15 @@ describe('gh-pages orphan wipe does not strip scripts later steps need', () => {
     expect(backup.run).not.toMatch(/scripts\/backup-to-release\.sh/);
   });
 
+  test('exactly one step stages the backup script', () => {
+    // #488 merged two independent fixes for #494, leaving two identical cp
+    // steps. Harmless (the copy is idempotent) but the next reader cannot tell
+    // which one is load-bearing, and deleting "the redundant one" is how the
+    // bug comes back.
+    const stagers = FINALIZE.steps.filter(s => (s.run || '').includes('cp scripts/backup-to-release.sh /tmp/'));
+    expect(stagers).toHaveLength(1);
+  });
+
   test('the staging copy happens before the wipe, on every deploy target', () => {
     const stageIdx = stepIndex(s => (s.run || '').includes('cp scripts/backup-to-release.sh /tmp/'));
     expect(stageIdx).toBeGreaterThan(-1);

--- a/tests/steamMachineHardware.test.js
+++ b/tests/steamMachineHardware.test.js
@@ -1,11 +1,19 @@
 /**
- * Behavioral tests for the Steam Machine hardware detection helper (#255).
+ * Behavioral tests for Steam Machine hardware detection (#255 Phase 2, #496).
  *
- * Deck detection is done by CPU/GPU signature (AMD Custom APU 0405/0932).
- * Steam Machine hardware signatures are not confirmed until reviewers get
- * devices in the wild, so Phase 1 falls back to the web-source hint from
- * the submit dropdown (`web-steammachine`). Phase 2 will fill in the real
- * APU regex once the launch hardware is out.
+ * Detection is by CPU/GPU signature, same as the Deck (AMD Custom APU
+ * 0405/0932). The Steam Machine fingerprint is still provisional -- the real
+ * APU revision string is unknown until devices are in the wild -- so it
+ * matches an explicit "Steam Machine" mention or the semi-custom RDNA 3
+ * signature.
+ *
+ * #496: this previously tested a second regex that matched only the literal
+ * words "steam machine", over a haystack including `r.webSource`. Nothing
+ * ever set webSource (no column, no pipeline write, no submit dropdown), and
+ * real APU strings do not contain those words, so the helper could not return
+ * true for any real report -- while game-page.js and stats.py were already
+ * matching RDNA 3. The old tests passed only because they hand-built an
+ * object the production path never produces.
  */
 const { loadEsm } = require('./_esm-vm.js');
 
@@ -19,14 +27,15 @@ function loadModule() {
 describe('isSteamMachineHardware', () => {
   const mod = loadModule();
 
-  test('report tagged with web-steammachine web source is detected', () => {
-    const r = { webSource: 'web-steammachine' };
-    expect(mod.isSteamMachineHardware(r)).toBe(true);
+  test('detects the semi-custom RDNA 3 signature', () => {
+    // The case that matters: what a real device is expected to report.
+    expect(mod.isSteamMachineHardware({ cpu: '', gpu: 'AMD Custom GPU RDNA 3' })).toBe(true);
+    expect(mod.isSteamMachineHardware({ cpu: 'AMD Custom APU with RDNA3 graphics', gpu: '' })).toBe(true);
   });
 
-  test('CPU field carrying "Steam Machine" text (from a future APU string) is detected', () => {
-    const r = { cpu: 'AMD Steam Machine APU 0999', gpu: '' };
-    expect(mod.isSteamMachineHardware(r)).toBe(true);
+  test('detects an explicit Steam Machine mention in either field', () => {
+    expect(mod.isSteamMachineHardware({ cpu: 'AMD Steam Machine APU 0999', gpu: '' })).toBe(true);
+    expect(mod.isSteamMachineHardware({ cpu: '', gpu: 'STEAM MACHINE proto rev A' })).toBe(true);
   });
 
   test('report from a plain PC does not match', () => {
@@ -34,9 +43,11 @@ describe('isSteamMachineHardware', () => {
     expect(mod.isSteamMachineHardware(r)).toBe(false);
   });
 
-  test('Steam Deck LCD is not miscategorised as Steam Machine', () => {
-    const r = { cpu: 'AMD Custom APU 0405', gpu: 'AMD Custom GPU 0405' };
-    expect(mod.isSteamMachineHardware(r)).toBe(false);
+  test('Steam Deck is not miscategorised as Steam Machine', () => {
+    const lcd = { cpu: 'AMD Custom APU 0405', gpu: 'AMD Custom GPU 0405' };
+    const oled = { cpu: 'AMD Custom APU 0932', gpu: '' };
+    expect(mod.isSteamMachineHardware(lcd)).toBe(false);
+    expect(mod.isSteamMachineHardware(oled)).toBe(false);
   });
 
   test('empty / missing fields are safe (no false positive)', () => {
@@ -44,16 +55,49 @@ describe('isSteamMachineHardware', () => {
     expect(mod.isSteamMachineHardware({ cpu: '', gpu: '' })).toBe(false);
   });
 
-  test('detection is case-insensitive on either side of the token', () => {
-    expect(mod.isSteamMachineHardware({ webSource: 'WEB-STEAMMACHINE' })).toBe(true);
-    expect(mod.isSteamMachineHardware({ cpu: 'STEAM MACHINE proto rev A' })).toBe(true);
+  test('the existing Steam Deck detection still returns true for Deck signatures', () => {
+    expect(mod.isSteamDeckHardware({ cpu: 'AMD Custom APU 0405', gpu: '' })).toBe(true);
+    expect(mod.isSteamDeckHardware({ cpu: 'AMD Custom APU 0932', gpu: '' })).toBe(true);
   });
 
-  test('the existing Steam Deck detection still returns true for Deck signatures', () => {
-    const lcd = { cpu: 'AMD Custom APU 0405', gpu: '' };
-    const oled = { cpu: 'AMD Custom APU 0932', gpu: '' };
-    expect(mod.isSteamDeckHardware(lcd)).toBe(true);
-    expect(mod.isSteamDeckHardware(oled)).toBe(true);
-    expect(mod.isSteamMachineHardware(lcd)).toBe(false);
+  test('no longer consults webSource, which nothing populates', () => {
+    // Guard against re-adding a detection channel with no producer. If a
+    // web-source dropdown is ever built (#255 Phase 1), wire the field end to
+    // end before this helper reads it.
+    expect(mod.isSteamMachineHardware({ webSource: 'web-steammachine' })).toBe(false);
+    expect(mod._MACHINE_APU_RE).toBeUndefined();
+  });
+});
+
+describe('the three surfaces agree (#496)', () => {
+  const fs = require('fs');
+  const mod = loadModule();
+
+  test('game-page filters on the same regex the helper uses', () => {
+    const src = fs.readFileSync(require.resolve('../js/app/components/game-page.js'), 'utf8');
+    expect(src).toContain('_STEAM_MACHINE_RE.test(haystack)');
+    const dsSrc = fs.readFileSync(require.resolve('../js/app/components/deck-status.js'), 'utf8');
+    expect(dsSrc).toMatch(/isSteamMachineHardware[\s\S]{0,160}_STEAM_MACHINE_RE\.test/);
+  });
+
+  test('the JS regex still mirrors _STEAM_MACHINE in stats.py', () => {
+    // The comment says "keep in sync"; this makes that enforceable rather
+    // than aspirational. Compares the pattern source, normalising for the
+    // escaping difference between a JS literal and a Python raw string.
+    const py = fs.readFileSync(require.resolve('../scripts/pipeline/stats.py'), 'utf8');
+    const m = py.match(/_STEAM_MACHINE\s*=\s*re\.compile\(\s*r"([^"]+)"/);
+    expect(m).not.toBeNull();
+    expect(m[1]).toBe(mod._STEAM_MACHINE_RE.source);
+  });
+
+  test('both sides agree on the same sample hardware strings', () => {
+    // Behavioural parity, not just textual: these are the strings the pipeline
+    // classifies as steam-machine, so the badge must agree.
+    for (const s of ['AMD Custom GPU RDNA 3', 'Steam Machine dev kit']) {
+      expect(mod.isSteamMachineHardware({ cpu: s, gpu: '' })).toBe(true);
+    }
+    for (const s of ['AMD Custom APU 0405', 'Intel Core i7-13700K']) {
+      expect(mod.isSteamMachineHardware({ cpu: s, gpu: '' })).toBe(false);
+    }
   });
 });

--- a/tests/test_catalog_cache_persistence.py
+++ b/tests/test_catalog_cache_persistence.py
@@ -1,0 +1,67 @@
+"""Store catalog caches must live somewhere that survives a run (#497).
+
+The PCGW caches were written into the pipeline OUTPUT dir, which is /tmp on a
+runner. The only thing copying them anywhere durable was the gh-pages deploy
+loop, and #362 made cloudflare the deploy target, so that loop stopped running.
+Every run wrote a cache and threw it away, which is why refresh_catalog's
+disk-fallback could never engage when PCGW began rejecting Cargo queries -- and
+why the guard added alongside it was inert in CI.
+
+.cache/ is the directory the pipeline's Actions cache persists between runs,
+and where the GOG and Epic catalog caches already live.
+"""
+from pathlib import Path
+
+from scripts.pipeline.gog_catalog import DEFAULT_GOG_CATALOG_CACHE_PATH
+from scripts.pipeline.pcgamingwiki import DEFAULT_ENRICHER_CACHE_PATH
+from scripts.pipeline.pcgamingwiki_catalog import DEFAULT_CATALOG_CACHE_PATH
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_pcgw_caches_default_into_the_persisted_cache_dir():
+    for p in (DEFAULT_CATALOG_CACHE_PATH, DEFAULT_ENRICHER_CACHE_PATH):
+        assert p.parent == REPO_ROOT / ".cache", f"{p} is not under the persisted .cache/ dir"
+
+
+def test_pcgw_caches_share_the_dir_the_gog_cache_already_uses():
+    """Whatever persists the GOG cache must also persist these."""
+    assert DEFAULT_CATALOG_CACHE_PATH.parent == DEFAULT_GOG_CATALOG_CACHE_PATH.parent
+    assert DEFAULT_ENRICHER_CACHE_PATH.parent == DEFAULT_GOG_CATALOG_CACHE_PATH.parent
+
+
+def test_actions_cache_covers_that_directory():
+    """The workflow must actually cache the dir these defaults point at.
+
+    A default pointing somewhere nothing persists is the original bug wearing
+    a different path.
+    """
+    wf = (REPO_ROOT / ".github/workflows/update-data.yml").read_text(encoding="utf-8")
+    assert "path: .cache" in wf, "update-data.yml no longer caches .cache/"
+
+
+def test_seeding_cannot_clobber_a_newer_cache():
+    """gh-pages seeding must compare timestamps, not overwrite blindly.
+
+    The unconditional `cp` inverted its own intent: gh-pages froze when the
+    weekly refresh workflow started no-opping, and the copy then overwrote the
+    genuinely fresher catalog the Actions cache was carrying, forcing a
+    ~274s GOG+Epic re-fetch on every single run.
+    """
+    wf = (REPO_ROOT / ".github/workflows/update-data.yml").read_text(encoding="utf-8")
+    assert "seed-catalog-cache.sh" in wf
+    assert "cp gh-pages-data/gog-catalog-cache.json" not in wf
+    assert "cp gh-pages-data/epic-catalog-cache.json" not in wf
+    assert (REPO_ROOT / "scripts/seed-catalog-cache.sh").exists()
+
+
+def test_scheduled_catalog_refresh_does_not_ask_the_cache_for_permission():
+    """A weekly refresh whose cadence equals the TTL must force.
+
+    Otherwise it keeps finding the cache a few hours short of expiry and does
+    nothing, which is exactly what happened: 'loaded 8,053 entries from cache
+    (age 147.1h)' then 'Cache unchanged, nothing to commit'.
+    """
+    for name in ("update-gog-catalog.yml", "update-epic-catalog.yml"):
+        wf = (REPO_ROOT / ".github/workflows" / name).read_text(encoding="utf-8")
+        assert "github.event_name == 'schedule'" in wf, f"{name} scheduled run does not force a refresh"

--- a/tests/test_catalog_cache_persistence.py
+++ b/tests/test_catalog_cache_persistence.py
@@ -65,3 +65,40 @@ def test_scheduled_catalog_refresh_does_not_ask_the_cache_for_permission():
     for name in ("update-gog-catalog.yml", "update-epic-catalog.yml"):
         wf = (REPO_ROOT / ".github/workflows" / name).read_text(encoding="utf-8")
         assert "github.event_name == 'schedule'" in wf, f"{name} scheduled run does not force a refresh"
+
+
+# ---------------------------------------------------------------------------
+# R2 sync fan-out (cherry-picked from feature/finalize-progress-logging)
+# ---------------------------------------------------------------------------
+
+
+def test_r2_sync_concurrency_is_not_pinned_low():
+    """Concurrency 4 made a ~187k-object sync crawl for ~40 minutes.
+
+    It was set as an over-correction to the #379 transient errors: R2's ~1/sec
+    write limit is per object KEY, not a cap across distinct keys, so it never
+    applied to this fan-out. Pinning it back to a literal would silently
+    restore the 40-minute sync.
+    """
+    sh = (REPO_ROOT / "scripts/publish-cloudflare.sh").read_text(encoding="utf-8")
+    assert "max_concurrent_requests 4" not in sh
+    assert 'max_concurrent_requests "${R2_SYNC_CONCURRENCY:-32}"' in sh
+
+
+def test_r2_sync_concurrency_has_a_working_escape_hatch():
+    """The comment promises a dial, so the dial has to be plumbed.
+
+    A knob documented in a comment but not wired into the workflow is the same
+    trap as the submit-form dropdown that isSteamMachineHardware claimed to
+    read from (#496) -- it reads as available and silently is not.
+    """
+    wf = (REPO_ROOT / ".github/workflows/update-data.yml").read_text(encoding="utf-8")
+    assert "R2_SYNC_CONCURRENCY:" in wf, "no workflow env plumbs the override"
+    assert "vars.R2_SYNC_CONCURRENCY" in wf, "override is not settable as a repo variable"
+
+
+def test_r2_sync_keeps_the_retry_backstops_the_higher_concurrency_relies_on():
+    """Running wide is only safe because these two catch transient failures."""
+    sh = (REPO_ROOT / "scripts/publish-cloudflare.sh").read_text(encoding="utf-8")
+    assert "AWS_RETRY_MODE=adaptive" in sh, "adaptive retry gone"
+    assert "retry" in sh.lower()

--- a/tests/test_pcgamingwiki.py
+++ b/tests/test_pcgamingwiki.py
@@ -606,3 +606,61 @@ def test_enricher_skips_empty_rows(tmp_path):
     assert written[0] == []
     # Non-empty row padded + enriched.
     assert written[1][15] == "Unity"
+
+
+# ---- #497: query-level errors arrive with HTTP 200 -------------------------
+#
+# MediaWiki reports query errors in the response body, not the status line, so
+# a 200 says nothing about whether the query ran. _cargo_get used to return the
+# payload anyway; callers then read the missing `cargoquery` key as an empty
+# result set and an empty catalog was written over the real one.
+
+
+def test_cargo_get_returns_none_on_permissiondenied():
+    """The exact response PCGW now sends after restricting Cargo access."""
+    payload = json.dumps({"error": {
+        "code": "permissiondenied",
+        "info": "You don't have permission to run arbitrary Cargo queries.",
+    }})
+    opener, patcher = _mock_session(lambda _u: payload)
+    with patcher:
+        result = _cargo_get({"action": "cargoquery"})
+    # None, not {} -- callers distinguish "failed" from "no rows" on this.
+    assert result is None
+
+
+def test_cargo_get_returns_none_on_any_query_error():
+    """Not special-cased to one code: any error means we got no rows."""
+    for code in ("badvalue", "invalidtable", "readapidenied", "unknown_error"):
+        payload = json.dumps({"error": {"code": code, "info": "nope"}})
+        opener, patcher = _mock_session(lambda _u, p=payload: p)
+        with patcher:
+            assert _cargo_get({"action": "cargoquery"}) is None, code
+
+
+def test_cargo_get_treats_maxlag_as_failure_too():
+    """maxlag was logged and the payload returned anyway, which on a busy
+    server produced the same empty-catalog outcome as a rejected query.
+    """
+    payload = json.dumps({"error": {"code": "maxlag", "info": "Waiting for a database server"}})
+    opener, patcher = _mock_session(lambda _u: payload)
+    with patcher:
+        assert _cargo_get({"action": "cargoquery"}) is None
+
+
+def test_paginate_stops_and_reports_when_page_zero_is_rejected():
+    """A rejected first page must not look like a successfully empty table."""
+    payload = json.dumps({"error": {"code": "permissiondenied", "info": "no"}})
+    opener, patcher = _mock_session(lambda _u: payload)
+    with patcher:
+        rows = _paginate_cargo("Infobox_game", "f", "w")
+    assert rows == []
+    # One attempt, no pagination loop against a dead endpoint.
+    assert len(opener.calls) == 1
+
+
+def test_successful_empty_result_is_still_distinguishable():
+    """A genuine empty result set keeps returning a dict, not None."""
+    opener, patcher = _mock_session(lambda _u: '{"cargoquery": []}')
+    with patcher:
+        assert _cargo_get({"action": "cargoquery"}) == {"cargoquery": []}

--- a/tests/test_pcgamingwiki.py
+++ b/tests/test_pcgamingwiki.py
@@ -166,7 +166,7 @@ def test_refresh_cache_uses_disk_when_fresh(tmp_path):
         "by_appid": {"1": {"os": ["linux"], "engine": "Godot"}},
     }))
     with patch("scripts.pipeline.pcgamingwiki._fetch_infobox_rows") as m_infobox:
-        result = refresh_cache(tmp_path)
+        result = refresh_cache(tmp_path, cache_path=tmp_path / CACHE_FILENAME)
     assert result == {"1": {"os": ["linux"], "engine": "Godot"}}
     m_infobox.assert_not_called()
 
@@ -178,14 +178,14 @@ def test_refresh_cache_falls_back_to_disk_on_network_failure(tmp_path):
         "by_appid": {"9": {"os": ["windows"], "engine": None}},
     }))
     with patch("scripts.pipeline.pcgamingwiki._fetch_infobox_rows", return_value=None):
-        result = refresh_cache(tmp_path)
+        result = refresh_cache(tmp_path, cache_path=tmp_path / CACHE_FILENAME)
     assert result == {"9": {"os": ["windows"], "engine": None}}
 
 
 def test_refresh_cache_persists_new_data(tmp_path):
     infobox = [_row("Foo", "7", engines="Engine:Godot", available="Linux")]
     with patch("scripts.pipeline.pcgamingwiki._fetch_infobox_rows", return_value=infobox):
-        result = refresh_cache(tmp_path, force=True)
+        result = refresh_cache(tmp_path, force=True, cache_path=tmp_path / CACHE_FILENAME)
     assert result == {"7": {"os": ["linux"], "engine": "Godot"}}
     written = json.loads((tmp_path / CACHE_FILENAME).read_text())
     assert written["by_appid"] == result
@@ -204,7 +204,7 @@ def test_enricher_writes_columns_14_and_15(tmp_path):
     ])
     infobox = [_row("Foo", "100", engines="Engine:Unity", available="Windows,Linux")]
     with patch("scripts.pipeline.pcgamingwiki._fetch_infobox_rows", return_value=infobox):
-        enrich_search_index_with_pcgamingwiki(tmp_path)
+        enrich_search_index_with_pcgamingwiki(tmp_path, cache_path=tmp_path / CACHE_FILENAME)
     written = json.loads((tmp_path / "search-index.json").read_text())
     # Row 0: previous enrichers preserved, PGW at 14 + 15.
     assert written[0][10] == "300"
@@ -222,7 +222,7 @@ def test_enricher_publishes_data_pcgamingwiki_json(tmp_path):
     _write_index(tmp_path, [["100", "Foo", "gold", 0, 0, "steam", None, None, False, ""]])
     infobox = [_row("Foo", "100", engines="Engine:Godot", available="Linux")]
     with patch("scripts.pipeline.pcgamingwiki._fetch_infobox_rows", return_value=infobox):
-        enrich_search_index_with_pcgamingwiki(tmp_path)
+        enrich_search_index_with_pcgamingwiki(tmp_path, cache_path=tmp_path / CACHE_FILENAME)
     published = json.loads((tmp_path / "pcgamingwiki.json").read_text())
     assert published == {"100": {"os": ["linux"], "engine": "Godot"}}
 
@@ -234,7 +234,7 @@ def test_enricher_pads_short_rows_before_writing(tmp_path):
     _write_index(tmp_path, [["100", "Foo", "gold", 5, 2, "steam"]])
     infobox = [_row("Foo", "100", engines="Engine:Unity")]
     with patch("scripts.pipeline.pcgamingwiki._fetch_infobox_rows", return_value=infobox):
-        enrich_search_index_with_pcgamingwiki(tmp_path)
+        enrich_search_index_with_pcgamingwiki(tmp_path, cache_path=tmp_path / CACHE_FILENAME)
     written = json.loads((tmp_path / "search-index.json").read_text())
     assert len(written[0]) == 16
     assert written[0][10] is None
@@ -247,7 +247,7 @@ def test_enricher_pads_short_rows_before_writing(tmp_path):
 
 
 def test_enricher_no_op_when_index_missing(tmp_path):
-    enrich_search_index_with_pcgamingwiki(tmp_path)
+    enrich_search_index_with_pcgamingwiki(tmp_path, cache_path=tmp_path / CACHE_FILENAME)
     assert not (tmp_path / "search-index.json").exists()
 
 
@@ -256,7 +256,7 @@ def test_enricher_no_op_on_malformed_index(tmp_path):
     idx = tmp_path / "search-index.json"
     idx.write_text('{"not": "a list"}', encoding="utf-8")
     with patch("scripts.pipeline.pcgamingwiki._fetch_infobox_rows", return_value=[]):
-        enrich_search_index_with_pcgamingwiki(tmp_path)
+        enrich_search_index_with_pcgamingwiki(tmp_path, cache_path=tmp_path / CACHE_FILENAME)
     # File left untouched.
     assert json.loads(idx.read_text()) == {"not": "a list"}
 
@@ -575,13 +575,13 @@ def test_fetch_infobox_paginates_past_first_page():
 def test_load_cache_ignores_non_dict_on_disk(tmp_path):
     (tmp_path / CACHE_FILENAME).write_text("[1, 2, 3]")
     with patch("scripts.pipeline.pcgamingwiki._fetch_infobox_rows", return_value=None):
-        assert refresh_cache(tmp_path) == {}
+        assert refresh_cache(tmp_path, cache_path=tmp_path / CACHE_FILENAME) == {}
 
 
 def test_load_cache_ignores_unreadable_file(tmp_path):
     (tmp_path / CACHE_FILENAME).write_text("not json {[")
     with patch("scripts.pipeline.pcgamingwiki._fetch_infobox_rows", return_value=None):
-        assert refresh_cache(tmp_path) == {}
+        assert refresh_cache(tmp_path, cache_path=tmp_path / CACHE_FILENAME) == {}
 
 
 # ---- enrich unhappy paths --------------------------------------------------
@@ -591,7 +591,7 @@ def test_enricher_no_op_on_unreadable_index(tmp_path):
     idx = tmp_path / "search-index.json"
     idx.write_text("this is not json")
     with patch("scripts.pipeline.pcgamingwiki.refresh_cache") as m:
-        enrich_search_index_with_pcgamingwiki(tmp_path)
+        enrich_search_index_with_pcgamingwiki(tmp_path, cache_path=tmp_path / CACHE_FILENAME)
     m.assert_not_called()
 
 
@@ -600,7 +600,7 @@ def test_enricher_skips_empty_rows(tmp_path):
     _write_index(tmp_path, [[], ["100", "Foo", "gold", 0, 0, "steam"]])
     infobox = [_row("Foo", "100", engines="Engine:Unity")]
     with patch("scripts.pipeline.pcgamingwiki._fetch_infobox_rows", return_value=infobox):
-        enrich_search_index_with_pcgamingwiki(tmp_path)
+        enrich_search_index_with_pcgamingwiki(tmp_path, cache_path=tmp_path / CACHE_FILENAME)
     written = json.loads((tmp_path / "search-index.json").read_text())
     # Empty row untouched.
     assert written[0] == []

--- a/tests/test_pcgamingwiki_catalog.py
+++ b/tests/test_pcgamingwiki_catalog.py
@@ -478,3 +478,83 @@ def test_common_recognizes_pgwiki_prefix():
     assert app_type_from_id("gog:12345") == "gog"
     assert app_type_from_id("epic:foo") == "epic"
     assert app_type_from_id("220") == "steam"
+
+
+# ---------------------------------------------------------------------------
+# #497: a rejected Cargo query must not be read as an empty catalog
+# ---------------------------------------------------------------------------
+#
+# PCGW restricted Cargo and now answers HTTP 200 with an error body:
+#   {"error":{"code":"permissiondenied",
+#             "info":"You don't have permission to run arbitrary Cargo queries."}}
+# There is no `cargoquery` key, so _fetch_all_pages saw an empty page and
+# returned [], refresh_catalog read that as a successful empty result, and
+# _save_cache wrote {} over the real catalog. Every run after that repeated it
+# from the now-empty cache, logging "cached 0 entries" like a normal day.
+
+
+def _seeded_cache(tmp_path, n=3):
+    """Write a cache that looks like a healthy previous run."""
+    entries = {f"pw_test{i:04d}": {"name": f"Game {i}", "steam_app_id": str(i)} for i in range(n)}
+    (tmp_path / CACHE_FILENAME).write_text(
+        json.dumps({"fetched_at": 0, "entries": entries}), encoding="utf-8"
+    )
+    return entries
+
+
+def test_rejected_query_keeps_the_existing_catalog(tmp_path):
+    """A permissiondenied response must leave the cached catalog intact."""
+    seeded = _seeded_cache(tmp_path)
+    # _cargo_get returns None for an error payload, so pagination reports the
+    # unreachable path and refresh_catalog falls back to disk.
+    with patch("scripts.pipeline.pcgamingwiki_catalog._fetch_all_pages", return_value=None):
+        out = refresh_catalog(tmp_path, force=True)
+    assert out == seeded
+    on_disk = json.loads((tmp_path / CACHE_FILENAME).read_text())
+    assert on_disk["entries"] == seeded, "cache was overwritten despite the query failing"
+
+
+def test_empty_result_does_not_wipe_a_populated_cache(tmp_path):
+    """Even a 'successful' empty row list must not replace a real catalog.
+
+    Belt and braces for the case where some future upstream change returns an
+    empty page without an error key. PCGW having zero Windows games is not a
+    real state, so an empty refresh is always a bug somewhere.
+    """
+    seeded = _seeded_cache(tmp_path)
+    with patch("scripts.pipeline.pcgamingwiki_catalog._fetch_all_pages", return_value=[]):
+        out = refresh_catalog(tmp_path, force=True)
+    assert out == seeded
+    on_disk = json.loads((tmp_path / CACHE_FILENAME).read_text())
+    assert on_disk["entries"] == seeded
+
+
+def test_empty_result_is_still_written_on_a_cold_cache(tmp_path):
+    """With nothing cached there is nothing to protect, so don't block a write.
+
+    Keeps first-run behaviour unchanged -- the guard is about not destroying
+    known-good data, not about refusing to ever store an empty result.
+    """
+    with patch("scripts.pipeline.pcgamingwiki_catalog._fetch_all_pages", return_value=[]):
+        out = refresh_catalog(tmp_path, force=True)
+    assert out == {}
+
+
+def test_real_rows_still_replace_the_cache(tmp_path):
+    """The guard must not freeze the catalog once it is populated."""
+    _seeded_cache(tmp_path)
+    rows = [{
+        "page": "Half-Life 2",
+        "appId": "220",
+        "gogId": "",
+        "engines": "Source",
+        "available": "Windows",
+        "relWin": "2004-11-16",
+        "developers": "Valve",
+        "publishers": "Valve",
+        "coverUrl": "https://images.pcgamingwiki.com/x/hl2.jpg",
+    }]
+    with patch("scripts.pipeline.pcgamingwiki_catalog._fetch_all_pages", return_value=rows):
+        out = refresh_catalog(tmp_path, force=True)
+    assert len(out) == 1
+    assert any(e["name"] == "Half-Life 2" for e in out.values())

--- a/tests/test_pcgamingwiki_catalog.py
+++ b/tests/test_pcgamingwiki_catalog.py
@@ -176,7 +176,7 @@ def test_refresh_catalog_uses_disk_when_fresh(tmp_path):
         "entries": {"pw_abcdefgh": {"name": "Foo", "slug": "Foo"}},
     }))
     with patch("scripts.pipeline.pcgamingwiki_catalog._fetch_all_pages") as m:
-        result = refresh_catalog(tmp_path)
+        result = refresh_catalog(tmp_path, cache_path=tmp_path / CACHE_FILENAME)
     assert result == {"pw_abcdefgh": {"name": "Foo", "slug": "Foo"}}
     m.assert_not_called()
 
@@ -191,7 +191,7 @@ def test_refresh_catalog_migrates_legacy_pgwiki_cache_and_forces_refetch(tmp_pat
     }))
     rows = [_row("Foo", available="Windows"), _row("Bar", available="Windows")]
     with patch("scripts.pipeline.pcgamingwiki_catalog._fetch_all_pages", return_value=rows):
-        result = refresh_catalog(tmp_path)
+        result = refresh_catalog(tmp_path, cache_path=tmp_path / CACHE_FILENAME)
     assert slug_to_pw_id("Foo") in result
     assert slug_to_pw_id("Bar") in result
     assert not any(k.startswith("pgwiki:") for k in result)
@@ -203,14 +203,14 @@ def test_refresh_catalog_falls_back_to_disk_on_network_failure(tmp_path):
         "entries": {"pw_fallback": {"name": "Fallback", "slug": "Fallback"}},
     }))
     with patch("scripts.pipeline.pcgamingwiki_catalog._fetch_all_pages", return_value=None):
-        result = refresh_catalog(tmp_path)
+        result = refresh_catalog(tmp_path, cache_path=tmp_path / CACHE_FILENAME)
     assert result == {"pw_fallback": {"name": "Fallback", "slug": "Fallback"}}
 
 
 def test_refresh_catalog_persists_new_data(tmp_path):
     rows = [_row("Foo", engines="Engine:Bar", available="Windows", relWin="2010")]
     with patch("scripts.pipeline.pcgamingwiki_catalog._fetch_all_pages", return_value=rows):
-        result = refresh_catalog(tmp_path, force=True)
+        result = refresh_catalog(tmp_path, force=True, cache_path=tmp_path / CACHE_FILENAME)
     assert slug_to_pw_id("Foo") in result
     written = json.loads((tmp_path / CACHE_FILENAME).read_text())
     assert written["entries"] == result
@@ -233,7 +233,7 @@ def test_merge_appends_new_stub_rows_with_correct_shape(tmp_path):
         publishers="Company:Sierra Entertainment",
     )
     with patch("scripts.pipeline.pcgamingwiki_catalog._fetch_all_pages", return_value=[riddick]):
-        merge_catalog_into_search_index(tmp_path)
+        merge_catalog_into_search_index(tmp_path, cache_path=tmp_path / CACHE_FILENAME)
     written = json.loads((tmp_path / "search-index.json").read_text())
     assert len(written) == 2
     stub = written[1]
@@ -254,7 +254,7 @@ def test_merge_skips_ids_already_in_index(tmp_path):
     ])
     row = _row("Existing", available="Windows")
     with patch("scripts.pipeline.pcgamingwiki_catalog._fetch_all_pages", return_value=[row]):
-        merge_catalog_into_search_index(tmp_path)
+        merge_catalog_into_search_index(tmp_path, cache_path=tmp_path / CACHE_FILENAME)
     written = json.loads((tmp_path / "search-index.json").read_text())
     assert len(written) == 1
 
@@ -268,7 +268,7 @@ def test_merge_drops_legacy_pgwiki_rows_and_rekeys(tmp_path):
     ])
     row = _row("Existing", available="Windows")
     with patch("scripts.pipeline.pcgamingwiki_catalog._fetch_all_pages", return_value=[row]):
-        merge_catalog_into_search_index(tmp_path)
+        merge_catalog_into_search_index(tmp_path, cache_path=tmp_path / CACHE_FILENAME)
     written = json.loads((tmp_path / "search-index.json").read_text())
     ids = [r[0] for r in written]
     assert ids == ["220", slug_to_pw_id("Existing")]
@@ -278,7 +278,7 @@ def test_merge_publishes_catalog_json(tmp_path):
     _write_index(tmp_path, [])
     row = _row("Foo", engines="Engine:Bar", available="Windows", relWin="2010")
     with patch("scripts.pipeline.pcgamingwiki_catalog._fetch_all_pages", return_value=[row]):
-        merge_catalog_into_search_index(tmp_path)
+        merge_catalog_into_search_index(tmp_path, cache_path=tmp_path / CACHE_FILENAME)
     published = json.loads((tmp_path / OUTPUT_FILENAME).read_text())
     foo_id = slug_to_pw_id("Foo")
     assert foo_id in published
@@ -290,14 +290,14 @@ def test_merge_publishes_catalog_json(tmp_path):
 
 
 def test_merge_no_op_when_index_missing(tmp_path):
-    merge_catalog_into_search_index(tmp_path)
+    merge_catalog_into_search_index(tmp_path, cache_path=tmp_path / CACHE_FILENAME)
     assert not (tmp_path / "search-index.json").exists()
 
 
 def test_merge_no_op_on_empty_catalog(tmp_path):
     _write_index(tmp_path, [["100", "Foo", "gold", 1, 0, "steam"]])
     with patch("scripts.pipeline.pcgamingwiki_catalog._fetch_all_pages", return_value=[]):
-        merge_catalog_into_search_index(tmp_path)
+        merge_catalog_into_search_index(tmp_path, cache_path=tmp_path / CACHE_FILENAME)
     written = json.loads((tmp_path / "search-index.json").read_text())
     assert len(written) == 1
 
@@ -306,7 +306,7 @@ def test_merge_no_op_on_malformed_index(tmp_path):
     idx = tmp_path / "search-index.json"
     idx.write_text('{"not": "a list"}', encoding="utf-8")
     with patch("scripts.pipeline.pcgamingwiki_catalog._fetch_all_pages", return_value=[]):
-        merge_catalog_into_search_index(tmp_path)
+        merge_catalog_into_search_index(tmp_path, cache_path=tmp_path / CACHE_FILENAME)
     assert json.loads(idx.read_text()) == {"not": "a list"}
 
 
@@ -314,7 +314,7 @@ def test_merge_no_op_on_unreadable_index(tmp_path):
     idx = tmp_path / "search-index.json"
     idx.write_text("this is not json")
     with patch("scripts.pipeline.pcgamingwiki_catalog.refresh_catalog") as m:
-        merge_catalog_into_search_index(tmp_path)
+        merge_catalog_into_search_index(tmp_path, cache_path=tmp_path / CACHE_FILENAME)
     m.assert_not_called()
 
 
@@ -368,7 +368,7 @@ def test_merge_flags_rule_a_when_steam_appid_absent(tmp_path):
     _write_index(tmp_path, [])  # zero Steam rows -> every appid is absent
     row = _row("Ghost Game", appid="9999999", available="Windows")
     with patch("scripts.pipeline.pcgamingwiki_catalog._fetch_all_pages", return_value=[row]):
-        merge_catalog_into_search_index(tmp_path)
+        merge_catalog_into_search_index(tmp_path, cache_path=tmp_path / CACHE_FILENAME)
     written = json.loads((tmp_path / "search-index.json").read_text())
     stub = written[0]
     assert stub[5] == "pgwiki"
@@ -388,7 +388,7 @@ def test_merge_flags_rule_b_when_steam_title_diverged(tmp_path):
     ])
     row = _row("Solo Leveling: Arise", appid="2373990", available="Windows")
     with patch("scripts.pipeline.pcgamingwiki_catalog._fetch_all_pages", return_value=[row]):
-        merge_catalog_into_search_index(tmp_path)
+        merge_catalog_into_search_index(tmp_path, cache_path=tmp_path / CACHE_FILENAME)
     written = json.loads((tmp_path / "search-index.json").read_text())
     assert len(written) == 2  # steam row stays + pw_ stub gets added
     stub = next(r for r in written if r[5] == "pgwiki")
@@ -411,7 +411,7 @@ def test_merge_leaves_active_pcgw_entries_alone(tmp_path):
     ])
     row = _row("Half-Life 2", appid="220", available="Windows")
     with patch("scripts.pipeline.pcgamingwiki_catalog._fetch_all_pages", return_value=[row]):
-        merge_catalog_into_search_index(tmp_path)
+        merge_catalog_into_search_index(tmp_path, cache_path=tmp_path / CACHE_FILENAME)
     written = json.loads((tmp_path / "search-index.json").read_text())
     stub = next(r for r in written if r[5] == "pgwiki")
     assert stub[7] is None                    # not delisted
@@ -436,7 +436,7 @@ def test_merge_updates_existing_pw_row_delisted_flag_in_place(tmp_path):
     ])
     row = _row("Solo Leveling: Arise", appid="2373990", available="Windows")
     with patch("scripts.pipeline.pcgamingwiki_catalog._fetch_all_pages", return_value=[row]):
-        merge_catalog_into_search_index(tmp_path)
+        merge_catalog_into_search_index(tmp_path, cache_path=tmp_path / CACHE_FILENAME)
     written = json.loads((tmp_path / "search-index.json").read_text())
     # Still exactly 2 rows -- no duplicate appended.
     assert len(written) == 2
@@ -457,7 +457,7 @@ def test_merge_no_steam_appid_never_delists(tmp_path):
     _write_index(tmp_path, [])
     row = _row("Physical Only Game", appid=None, available="Windows")
     with patch("scripts.pipeline.pcgamingwiki_catalog._fetch_all_pages", return_value=[row]):
-        merge_catalog_into_search_index(tmp_path)
+        merge_catalog_into_search_index(tmp_path, cache_path=tmp_path / CACHE_FILENAME)
     written = json.loads((tmp_path / "search-index.json").read_text())
     stub = written[0]
     assert stub[7] is None
@@ -508,7 +508,7 @@ def test_rejected_query_keeps_the_existing_catalog(tmp_path):
     # _cargo_get returns None for an error payload, so pagination reports the
     # unreachable path and refresh_catalog falls back to disk.
     with patch("scripts.pipeline.pcgamingwiki_catalog._fetch_all_pages", return_value=None):
-        out = refresh_catalog(tmp_path, force=True)
+        out = refresh_catalog(tmp_path, force=True, cache_path=tmp_path / CACHE_FILENAME)
     assert out == seeded
     on_disk = json.loads((tmp_path / CACHE_FILENAME).read_text())
     assert on_disk["entries"] == seeded, "cache was overwritten despite the query failing"
@@ -523,7 +523,7 @@ def test_empty_result_does_not_wipe_a_populated_cache(tmp_path):
     """
     seeded = _seeded_cache(tmp_path)
     with patch("scripts.pipeline.pcgamingwiki_catalog._fetch_all_pages", return_value=[]):
-        out = refresh_catalog(tmp_path, force=True)
+        out = refresh_catalog(tmp_path, force=True, cache_path=tmp_path / CACHE_FILENAME)
     assert out == seeded
     on_disk = json.loads((tmp_path / CACHE_FILENAME).read_text())
     assert on_disk["entries"] == seeded
@@ -536,7 +536,7 @@ def test_empty_result_is_still_written_on_a_cold_cache(tmp_path):
     known-good data, not about refusing to ever store an empty result.
     """
     with patch("scripts.pipeline.pcgamingwiki_catalog._fetch_all_pages", return_value=[]):
-        out = refresh_catalog(tmp_path, force=True)
+        out = refresh_catalog(tmp_path, force=True, cache_path=tmp_path / CACHE_FILENAME)
     assert out == {}
 
 
@@ -555,6 +555,6 @@ def test_real_rows_still_replace_the_cache(tmp_path):
         "coverUrl": "https://images.pcgamingwiki.com/x/hl2.jpg",
     }]
     with patch("scripts.pipeline.pcgamingwiki_catalog._fetch_all_pages", return_value=rows):
-        out = refresh_catalog(tmp_path, force=True)
+        out = refresh_catalog(tmp_path, force=True, cache_path=tmp_path / CACHE_FILENAME)
     assert len(out) == 1
     assert any(e["name"] == "Half-Life 2" for e in out.values())


### PR DESCRIPTION
Seven fixes found by triaging the open backlog. Most came out of chasing why one thing was broken and finding the mechanism underneath it was broken more generally.

## The backup that could not restore anything (#495)

Every `*-schema.tar.gz` shipped since the exporter was written is 523 bytes of comments with zero SQL. No tables, no columns, no RLS, no triggers.

Two silent failures in `fetchSchema`. Column definitions were read from a `content-range` response header, which does not carry them. RLS policies came from `POST /rest/v1/rpc/query`, an RPC that does not exist and should not -- generic SQL over PostgREST would be a hole. That call was `.catch(() => null)` behind a `res?.ok` guard, so the 404 was swallowed and the section omitted.

The data half was fine, which is what hid it: 22 rows backed up against 22 live. So the rows were safe and the structure was not, and the artifact was convincing enough that #384's own summary treated it as covered.

Replaced with the migrations bundled into the archive (the authoritative DDL -- 19 carry RLS, 7 carry triggers, 14 carry functions) plus live OpenAPI introspection for per-table columns, kept alongside so a restore can be diffed against what prod actually had. Failure is loud now: an unreachable endpoint, a response with no tables, or a missing migrations dir all abort with exit 1 and write no archive. Verified all three against a stubbed PostgREST.

## PCGamingWiki has been silently dead since 2026-08-17 (#497)

`pcgamingwiki.json` is 0 entries on prod, `pcgwiki-catalog.json` was never published, and the search index has no `pw_` rows at all.

PCGW restricted Cargo and now answers **HTTP 200** with an error body. MediaWiki reports query errors in the body, not the status line, so `_cargo_get` returned the payload, the missing `cargoquery` key read as an empty result set, and `refresh_catalog` wrote `{}` over the catalog -- its disk fallback only triggers on `None`. Each later run repeated it from the now-empty cache, logging `cached 0 entries (of 0 candidate rows)` like a quiet day upstream.

Dated it exactly from run logs: 51,885 entries on 08-17, zero on 08-18.

`_cargo_get` now returns `None` for any payload carrying an `error`, and `refresh_catalog` refuses to replace a populated cache with zero entries. Verified end to end with the real `permissiondenied` payload.

**This does not restore the data**, and the upstream access question is still open on #497. Login succeeds and the query is still refused, so it is not credentials.

## The caches were never persisting (#497)

Chasing recovery turned up why nothing survived. The PCGW caches were written to the pipeline OUTPUT dir, which is `/tmp` on a runner. The only thing copying them anywhere durable was the gh-pages deploy loop, and #362 made cloudflare the deploy target, so that loop stopped running. Both caches have been written and discarded on every run since -- which is also why the guard above was correct but inert in CI.

Two more faults in the same area:

The weekly GOG/Epic refresh workflows only refreshed when the cache had already expired, and their cadence equals the 7-day TTL, so the scheduled run kept finding it hours short and doing nothing (`loaded 8,053 entries from cache (age 147.1h)` then `Cache unchanged, nothing to commit`).

With that no-opping, gh-pages froze at Aug 17 while finalize re-fetched in-line and saved a genuinely fresher catalog to the Actions cache -- which the unconditional seed `cp` then clobbered on every run. Its own comment describes the opposite intent. That is the ~274s GOG+Epic re-fetch, paid every run.

Caches now default into `.cache/`, scheduled refreshes force, and seeding compares `_ts`.

## Steam Machine detection disagreed with itself (#496)

Two regexes answered the same question and the report card was wired to the wrong one. `_STEAM_MACHINE_RE` carries the RDNA 3 fingerprint and mirrors `stats.py`; the game page already filtered on it. `isSteamMachineHardware` used a second regex matching only the literal words "steam machine", over a haystack including `r.webSource` -- a field nothing sets. No column, no pipeline write, no submit dropdown, despite a comment claiming one. So it could not return true for any real report, while the game page and pipeline matched fine.

The tests passed throughout by hand-building `{ webSource: 'web-steammachine' }`, an object the production path never produces.

## R2 sync was throttled 8x too low

Cherry-picked from `feature/finalize-progress-logging`, abandoned since 2026-07-23. `max_concurrent_requests` was pinned to 4 as an over-correction to #379. R2's ~1/sec write limit is per object KEY, not across distinct keys, and this sync writes ~187k distinct keys -- so it never applied, and 4 concurrent PUTs made a full sync crawl for ~40 minutes. Both backstops the wider fan-out relies on are verified present.

The original commit documented an `R2_SYNC_CONCURRENCY` knob without wiring it. It is plumbed as a repo variable here, so the escape hatch is real.

## Also

`fix(ci)` collapses two identical backup-script staging steps that #488 merged from two independent fixes for #494. Idempotent, but a reader cannot tell which is load-bearing and deleting "the redundant one" is how the bug returns.

`fix(deps)` clears all three vulnerable transitives to patched releases (js-yaml 3.15.1, brace-expansion 1.1.18/2.1.4, nanoid 3.3.18). All dev-only, which is why the production-only CI gate stayed green.

**On the open HIGH alert:** dependabot/16 is the js-yaml CVE this PR fixes. Dependabot evaluates the default branch, so it cannot close until this merges -- `make security-check` will keep exiting 1 until then. `npm audit` on this branch reports 0 vulnerabilities at every severity.

## Verification

    python      1370 passed, coverage 90.30% (gate 90)
    jest        187 suites, 2907 passed
    smoke       clean
    npm audit   0 vulnerabilities

Guard tests pin the invariants rather than the fixes: no step after the gh-pages orphan wipe may run a script from the workspace path, the PCGW cache defaults must sit where the GOG cache does, seeding must not be a bare `cp`, a scheduled refresh must force, R2 concurrency must not be pinned to a literal, and the JS Steam Machine regex must still equal the Python one. Each was mutation-tested against the pre-fix state.

Issues stay open until verified on production, per the close-on-prod rule.
