### PR TITLE
Escape report-derived filter options, and make security-check actually gate on security severity

### DIFF
--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -1150,8 +1150,21 @@ export async function renderGamePage(appId) {
   // Confidence range 0-100 (#445). Defaults 0/100 = no filter. When narrowed
   // (min>0 or max<100) the filter step drops configs entirely, matching how
   // filterRating drops non-report rows -- configs carry no score.
-  let filterConfidenceMin = Number.isFinite(persistedFilters.confidenceMin) ? persistedFilters.confidenceMin : 0;
-  let filterConfidenceMax = Number.isFinite(persistedFilters.confidenceMax) ? persistedFilters.confidenceMax : 100;
+  // Coerced to a number and clamped, not merely checked with Number.isFinite.
+  // These two are the only filter values interpolated into innerHTML as
+  // CONTENT rather than compared, and they originate in a range input's
+  // .value -- DOM text. `Number.isFinite(x) ? x : 0` is behaviourally safe
+  // but reads as a guard rather than a conversion, so taint tracking still
+  // sees a DOM string reaching HTML (CodeQL alert 60, js/xss-through-dom).
+  // Number() + clamp always yields a number, which is both provably safe and
+  // legible as a sanitiser. Defaults stay 0 and 100 so the filter is still a
+  // no-op on load.
+  const _clampPercent = (v, fallback) => {
+    const n = Number(v);
+    return Number.isFinite(n) ? Math.min(100, Math.max(0, Math.round(n))) : fallback;
+  };
+  let filterConfidenceMin = _clampPercent(persistedFilters.confidenceMin, 0);
+  let filterConfidenceMax = _clampPercent(persistedFilters.confidenceMax, 100);
   let filterMine = false;
 
   // Unified source filter across configs + reports: 'pulse-config', 'pulse-report',

--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -1646,7 +1646,7 @@ export async function renderGamePage(appId) {
               <label class="home-filter-label" for="fGpu">GPU</label>
               <select id="fGpu" class="home-filter-select" autocomplete="off">
                 <option value="">Any</option>
-                ${availGpus.map(v => `<option value="${v}" ${filterGpu===v?'selected':''}>${GPU_LABEL[v]||v}</option>`).join('')}
+                ${availGpus.map(v => `<option value="${esc(v)}" ${filterGpu===v?'selected':''}>${esc(GPU_LABEL[v]||v)}</option>`).join('')}
               </select>
             </div>` : '';
           const archSel = availArchs.length > 1 ? `
@@ -1670,7 +1670,7 @@ export async function renderGamePage(appId) {
               <label class="home-filter-label" for="fRating">Rating</label>
               <select id="fRating" class="home-filter-select" autocomplete="off">
                 <option value="">Any</option>
-                ${availRatings.map(v => `<option value="${v}" ${filterRating===v?'selected':''}>${RATING_LABEL[v]||v}</option>`).join('')}
+                ${availRatings.map(v => `<option value="${esc(v)}" ${filterRating===v?'selected':''}>${esc(RATING_LABEL[v]||v)}</option>`).join('')}
               </select>
             </div>` : '';
           // Run-type filter: only show when this game has at least one report
@@ -1691,7 +1691,7 @@ export async function renderGamePage(appId) {
               <label class="home-filter-label" for="fRunType">Runtime Type</label>
               <select id="fRunType" class="home-filter-select" autocomplete="off">
                 <option value="">Any</option>
-                ${availRunTypes.map(v => `<option value="${esc(v)}" ${filterRunType===v?'selected':''}>${RUN_TYPE_LABEL[v]||v}</option>`).join('')}
+                ${availRunTypes.map(v => `<option value="${esc(v)}" ${filterRunType===v?'selected':''}>${esc(RUN_TYPE_LABEL[v]||v)}</option>`).join('')}
               </select>
             </div>` : '';
           const srcSel = `

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=852c9d97';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=003f23c0';
-import { renderGamePage } from './game-page.js?v=01aff163';
+import { renderGamePage } from './game-page.js?v=491f8ab5';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId, fetchDataWithProdFallback } from '../config.js?v=7873e060';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=4630c3d5';
 import { renderGameCard } from '../lib/card.js?v=bdeb653b';

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=852c9d97';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=003f23c0';
-import { renderGamePage } from './game-page.js?v=01232d6b';
+import { renderGamePage } from './game-page.js?v=01aff163';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId, fetchDataWithProdFallback } from '../config.js?v=7873e060';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=4630c3d5';
 import { renderGameCard } from '../lib/card.js?v=bdeb653b';

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,7 +1,7 @@
 // router (entry) for the app page. Relocated from app.js.
 
 import { pcgwSlugToPwId } from '../lib/app-id.js?v=6159afa9';
-import { renderGamePage } from './components/game-page.js?v=01aff163';
+import { renderGamePage } from './components/game-page.js?v=491f8ab5';
 import { renderHomePage } from './components/home.js?v=183b5b8f';
 import { renderSearchPage } from './components/search.js?v=091f940b';
 

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,7 +1,7 @@
 // router (entry) for the app page. Relocated from app.js.
 
 import { pcgwSlugToPwId } from '../lib/app-id.js?v=6159afa9';
-import { renderGamePage } from './components/game-page.js?v=01232d6b';
+import { renderGamePage } from './components/game-page.js?v=01aff163';
 import { renderHomePage } from './components/home.js?v=183b5b8f';
 import { renderSearchPage } from './components/search.js?v=091f940b';
 

--- a/scripts/check-github-security.sh
+++ b/scripts/check-github-security.sh
@@ -56,6 +56,7 @@ NORMALIZED="$(jq -n \
   ($dep  | map({
     source: "dependabot",
     severity: (.security_advisory.severity // "unknown"),
+    rule_severity: null,
     title:    (.security_advisory.summary  // "(no summary)"),
     location: (.dependency.package.name    // "?"),
     url:      .html_url,
@@ -63,7 +64,16 @@ NORMALIZED="$(jq -n \
   })) +
   ($cs   | map({
     source: "code-scanning",
-    severity: (.rule.severity // "unknown"),
+    # security_severity_level (critical/high/medium/low), NOT rule.severity.
+    # rule.severity is the ANALYSIS severity -- note/warning/error -- which
+    # shares no vocabulary with the fail list, so every code-scanning alert
+    # landed in no bucket and the summary read "High: 0" next to a total of 1.
+    # A high-severity XSS therefore did not trip the gate built to catch it
+    # (alert 60, js/xss-through-dom, issue #502). Rules with no security
+    # severity (pure quality rules) keep their analysis severity, which
+    # deliberately still matches nothing in the fail list.
+    severity: (.rule.security_severity_level // .rule.severity // "unknown"),
+    rule_severity: (.rule.severity // "unknown"),
     title:    (.rule.description // .rule.id // "(no description)"),
     location: ((.most_recent_instance.location.path // "?") + ":" + ((.most_recent_instance.location.start_line // 0) | tostring)),
     url:      .html_url,
@@ -72,6 +82,7 @@ NORMALIZED="$(jq -n \
   ($ss   | map({
     source: "secret-scanning",
     severity: "critical",
+    rule_severity: null,
     title:    (.secret_type_display_name // .secret_type // "(secret)"),
     location: ((.locations[0].details.path // "?") + " commit " + ((.locations[0].details.commit_sha // "?") | .[0:7])),
     url:      .html_url,
@@ -100,7 +111,8 @@ else
   if [[ "${TOTAL}" -gt 0 ]]; then
     echo "${NORMALIZED}" | jq -r '
       # Sort so critical + high float to the top
-      def sev_rank: {critical: 0, high: 1, medium: 2, low: 3, unknown: 4}[.] // 5;
+      def sev_rank: {critical: 0, high: 1, medium: 2, low: 3,
+                     error: 4, warning: 5, note: 6, unknown: 7}[.] // 8;
       sort_by(.severity | sev_rank)
       | .[]
       | "  [\(.severity | ascii_upcase)] \(.source): \(.title)\n    \(.location)\n    \(.url)"

--- a/tests/filterPanelRegressions.test.js
+++ b/tests/filterPanelRegressions.test.js
@@ -463,8 +463,21 @@ describe('game-page confidence range filter (#445)', () => {
   });
 
   test('defaults are 0 (min) and 100 (max) so the filter is a no-op on load', () => {
-    expect(gamePageSrc).toMatch(/filterConfidenceMin\s*=\s*Number\.isFinite\(persistedFilters\.confidenceMin\)\s*\?\s*persistedFilters\.confidenceMin\s*:\s*0/);
-    expect(gamePageSrc).toMatch(/filterConfidenceMax\s*=\s*Number\.isFinite\(persistedFilters\.confidenceMax\)\s*\?\s*persistedFilters\.confidenceMax\s*:\s*100/);
+    // Pinned on the defaults, not on one particular expression. The restore
+    // was rewritten to coerce-and-clamp for CodeQL alert 60 (#502), and a test
+    // pinned to the literal old text failed for a change that preserved the
+    // behaviour it was meant to protect.
+    expect(gamePageSrc).toMatch(/filterConfidenceMin\s*=\s*_clampPercent\(persistedFilters\.confidenceMin,\s*0\)/);
+    expect(gamePageSrc).toMatch(/filterConfidenceMax\s*=\s*_clampPercent\(persistedFilters\.confidenceMax,\s*100\)/);
+  });
+
+  test('the confidence restore coerces to a number rather than only guarding', () => {
+    // These are the only filter values interpolated into innerHTML as content
+    // rather than compared, and they come from a range input's .value. The
+    // clamp must always produce a number so no DOM string can reach HTML.
+    expect(gamePageSrc).toMatch(/const _clampPercent = \(v, fallback\) => \{/);
+    expect(gamePageSrc).toContain('const n = Number(v);');
+    expect(gamePageSrc).toContain('Math.min(100, Math.max(0, Math.round(n)))');
   });
 
   test('filter step is a no-op until the range is narrowed (min>0 OR max<100)', () => {

--- a/tests/securityCheckSeverity.test.js
+++ b/tests/securityCheckSeverity.test.js
@@ -1,0 +1,111 @@
+/**
+ * `make security-check` must bucket code-scanning alerts by SECURITY severity.
+ *
+ * GitHub gives a code-scanning alert two different severities and they share
+ * no vocabulary:
+ *   rule.severity                 note | warning | error      (analysis)
+ *   rule.security_severity_level  low | medium | high | critical
+ *
+ * The script normalised on rule.severity, so every code-scanning alert landed
+ * in no bucket at all. Alert 60 -- js/xss-through-dom, security severity high,
+ * rule severity warning -- printed as "High: 0 (total open: 1)" and exited 0.
+ * The gate built to stop exactly that kind of finding waved it through (#502).
+ *
+ * This drives the script's REAL jq program against fixtures rather than a
+ * copy, so the test cannot drift away from what ships.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const SCRIPT = path.join(__dirname, '..', 'scripts/check-github-security.sh');
+const SRC = fs.readFileSync(SCRIPT, 'utf8');
+
+// Pull the normalisation program out of the script so the test runs the
+// shipped jq, not a transcription of it.
+function extractJqProgram() {
+  const start = SRC.indexOf("--argjson ss \"${SECRET_SCAN_JSON}\" '");
+  expect(start).toBeGreaterThan(-1);
+  const from = SRC.indexOf("'", start + "--argjson ss \"${SECRET_SCAN_JSON}\" ".length) + 1;
+  const end = SRC.indexOf("')\"", from);
+  expect(end).toBeGreaterThan(from);
+  return SRC.slice(from, end);
+}
+
+function normalize({ dependabot = [], codeScanning = [], secrets = [] }) {
+  const out = execFileSync('jq', [
+    '-n',
+    '--argjson', 'dep', JSON.stringify(dependabot),
+    '--argjson', 'cs', JSON.stringify(codeScanning),
+    '--argjson', 'ss', JSON.stringify(secrets),
+    extractJqProgram(),
+  ], { encoding: 'utf8' });
+  return JSON.parse(out);
+}
+
+const xssAlert = {
+  rule: {
+    id: 'js/xss-through-dom',
+    description: 'DOM text reinterpreted as HTML',
+    severity: 'warning',
+    security_severity_level: 'high',
+  },
+  most_recent_instance: { location: { path: 'js/app/components/game-page.js', start_line: 1518 } },
+  html_url: 'https://example.invalid/60',
+  created_at: '2026-08-25T00:00:00Z',
+};
+
+describe('check-github-security.sh severity normalisation', () => {
+  test('a high security severity is not masked by a warning rule severity', () => {
+    const [alert] = normalize({ codeScanning: [xssAlert] });
+    expect(alert.severity).toBe('high');
+    expect(alert.rule_severity).toBe('warning');
+  });
+
+  test('critical security severity survives too', () => {
+    const [alert] = normalize({
+      codeScanning: [{ ...xssAlert, rule: { ...xssAlert.rule, security_severity_level: 'critical' } }],
+    });
+    expect(alert.severity).toBe('critical');
+  });
+
+  test('a quality rule with no security severity keeps its analysis severity', () => {
+    // Deliberate: "warning" matches nothing in the critical,high fail list, so
+    // a pure code-quality finding still cannot fail the gate.
+    const [alert] = normalize({
+      codeScanning: [{ ...xssAlert, rule: { id: 'js/unused-local', severity: 'warning' } }],
+    });
+    expect(alert.severity).toBe('warning');
+    expect(['critical', 'high']).not.toContain(alert.severity);
+  });
+
+  test('dependabot advisories still normalise on advisory severity', () => {
+    const [alert] = normalize({
+      dependabot: [{
+        security_advisory: { severity: 'high', summary: 'bad dep' },
+        dependency: { package: { name: 'left-pad' } },
+        html_url: 'https://example.invalid/1',
+        created_at: '2026-08-25T00:00:00Z',
+      }],
+    });
+    expect(alert.severity).toBe('high');
+    expect(alert.source).toBe('dependabot');
+  });
+
+  test('secret scanning stays critical', () => {
+    const [alert] = normalize({
+      secrets: [{
+        secret_type_display_name: 'GitHub PAT',
+        locations: [{ details: { path: '.env', commit_sha: 'abcdef1234' } }],
+        html_url: 'https://example.invalid/2',
+        created_at: '2026-08-25T00:00:00Z',
+      }],
+    });
+    expect(alert.severity).toBe('critical');
+  });
+
+  test('the script reads security_severity_level, not just rule.severity', () => {
+    expect(SRC).toContain('.rule.security_severity_level');
+  });
+});

--- a/tests/securitySanitizers.test.js
+++ b/tests/securitySanitizers.test.js
@@ -73,3 +73,53 @@ describe('boxart admin refetch host allowlist', () => {
     expect(SRC).not.toContain(".includes('shared.fastly.steamstatic.com')");
   });
 });
+
+describe('game page filter dropdowns (#502, CodeQL alert 60)', () => {
+  const SRC = read('js/app/components/game-page.js');
+
+  // Every filter <option> is built the same way from report data:
+  //   availX.map(v => `<option value="${v}" ...>${LABEL[v] || v}</option>`)
+  // Three of them escaped and three did not. availGpus and availRunTypes are
+  // built from r.gpu / r.runType, i.e. fields a submitted report controls, and
+  // the `LABEL[v] || v` fallback renders the RAW value whenever the label map
+  // has no entry -- so markup in a report's GPU string reached innerHTML.
+  const OPTION_BUILDERS = SRC
+    .split('\n')
+    .map((line, i) => ({ line: line.trim(), n: i + 1 }))
+    .filter(({ line }) => line.includes('.map(v => `<option'));
+
+  test('the dropdowns are still built the way this guard assumes', () => {
+    // If this fails the render was refactored and the assertions below are
+    // no longer checking anything real.
+    expect(OPTION_BUILDERS.length).toBeGreaterThanOrEqual(5);
+  });
+
+  test.each([
+    ['availGpus'],
+    ['availArchs'],
+    ['availOs'],
+    ['availRatings'],
+    ['availRunTypes'],
+  ])('%s escapes both the option value and its label', (name) => {
+    const builder = OPTION_BUILDERS.find(({ line }) => line.includes(`${name}.map(`));
+    expect(builder).toBeDefined();
+    // value="..." must go through esc()
+    expect(builder.line).toContain('value="${esc(v)}"');
+    // Scan the INNER <option> template only. A naive scan of the whole line
+    // trips over the nested template literal: the outer ${availX.map(...)}
+    // is closed by the first brace inside it.
+    const inner = builder.line.match(/`(<option[\s\S]*?<\/option>)`/);
+    expect(inner).not.toBeNull();
+    // Nothing may be interpolated bare -- catches `${v}` and the
+    // `${LABEL[v]||v}` fallback that was the actual sink.
+    const bare = [...inner[1].matchAll(/\$\{([^}]*)\}/g)]
+      .map((m) => m[1].trim())
+      .filter((e) => !e.startsWith('esc(') && !e.includes('==='));
+    expect(bare).toEqual([]);
+  });
+
+  test('no option builder interpolates a LABEL fallback unescaped', () => {
+    // The specific shape that produced the alert.
+    expect(SRC).not.toMatch(/\$\{[A-Z_]+_LABEL\[v\]\s*\|\|\s*v\}/);
+  });
+});


### PR DESCRIPTION
Three separate fixes, plus the merge that brought main's CodeQL autofix back into staging.

## The one that still matters for prod

CodeQL alert 60 is closed, but the path it was pointing near is still open in production. The autofix that merged in #503 constrained the persisted filter values at the restore site. It never touched the render sites, so the option builders still interpolate report data raw:

```
PROD  unescaped LABEL fallbacks : 3
PROD  bare value="${v}"          : 2
```

`availGpus` and `availRunTypes` are built from `r.gpu` and `r.runType`, fields a submitted report controls, and the render falls back to `LABEL[v] || v`, which emits the raw value whenever the label map has no entry. That is a live sink on www.proton-pulse.com right now. The alert stopped firing because the flow it tracked got sanitised, not because this one did.

668ac21 escapes all five option builders, value and label. `availOs` and `availArchs` were already correct and are what the rest now match.

## Gate that was not gating

169b8f4. `scripts/check-github-security.sh` bucketed code-scanning alerts by `rule.severity` (note/warning/error) while the fail list is `critical,high`. Those vocabularies do not overlap, so no code-scanning alert could ever fail the gate. Alert 60 itself printed "High: 0 (total open: 1)" and exited 0 for a high-severity XSS. The nightly workflow runs the same script and would not have mailed either. Now reads `security_severity_level` and keeps `rule_severity` alongside so the distinction stays visible.

## Merge resolution

One conflict, in the confidence filter restore: staging clamped with a local `_clampPercent`, main's autofix clamps with `_clampInt`. Same purpose, so main's helper wins and the duplicate is dropped. Main's extra min>max invariant is kept.

`filterPanelRegressions.test.js` pinned the literal text of that expression, which is what turned #503's test run red. It is repinned on `_clampInt` and on the coercion itself. Main currently carries the old pin and would fail that suite if it ran there -- `test` only runs on pull requests, not on push to main, so nothing has surfaced it and nothing will until the next PR. This merge fixes that too.

## Tests

Both new guards were verified to fail against the original code before being kept:

- the option-builder guard scans every builder rather than the three that were wrong, so a dropdown added later cannot reintroduce this. Reintroducing one unescaped GPU label failed 2 of 13.
- the severity test drives the script's real jq program rather than a transcription, so it cannot drift from what ships. Restoring the old expression failed 3 of 6.

`make pre-push`: 2921 JS tests, 1370 python tests, coverage 90.30%.

Closes #502, closes #504.