### PR TITLE
fix(moderation): add per-row scan cursor so rows can't fall through every lookback window

### DIFF
--- a/.github/scripts/moderate-content.mjs
+++ b/.github/scripts/moderate-content.mjs
@@ -5,6 +5,12 @@
  * Primary scan (with auto-remediation):
  *   - user_configs.notes / title / launch_options / form_responses
  *     Hits are auto-flagged: is_flagged=true, is_hidden=true, flagged_reason set.
+ *     Every row processed (flagged, clean, or empty) is stamped with
+ *     last_moderated_at (#257): the query below also always includes rows
+ *     where that column is still NULL, so a row that lands during a
+ *     scanner outage or otherwise falls outside every scheduled lookback
+ *     window still gets caught on the next run instead of being skipped
+ *     forever. See supabase/migrations/20260905000000_add_user_configs_moderation_cursor.sql.
  *
  * Aux scans (alert-only, no auto-remediation):
  *   - user_proton_configs.app_name    (#331)
@@ -329,7 +335,9 @@ async function fetchRecentRows() {
   const since = new Date(Date.now() - LOOKBACK_H * 3600 * 1000).toISOString();
   const url = `${SUPABASE_URL}/rest/v1/user_configs`
     + `?select=id,notes,title,launch_options,form_responses,proton_pulse_user_id,client_id`
-    + `&or=(created_at.gte.${since},updated_at.gte.${since})`
+    // #257: last_moderated_at.is.null catches rows never actually scanned,
+    // regardless of how old they are -- not just ones that changed recently.
+    + `&or=(created_at.gte.${since},updated_at.gte.${since},last_moderated_at.is.null)`
     + `&is_hidden=eq.false`
     + `&order=id.asc`
     + (APP_IDS.length === 1 ? `&app_id=eq.${encodeURIComponent(APP_IDS[0])}`
@@ -354,6 +362,7 @@ async function flagRow(id, reason) {
     is_hidden: true,
     flagged_reason: reason,
     flagged_at: new Date().toISOString(),
+    last_moderated_at: new Date().toISOString(),
   };
 
   if (DRY_RUN) {
@@ -372,6 +381,25 @@ async function flagRow(id, reason) {
 
   log(`Supabase PATCH response`, { id, status: res.status });
   if (!res.ok) throw new Error(`Supabase PATCH failed for id=${id}: ${res.status} ${await res.text()}`);
+}
+
+// #257: stamp the moderation cursor on a row that was scanned and found
+// clean (or had no text fields), so the "never scanned" branch of the
+// fetchRecentRows query stops matching it until it changes again.
+async function markScanned(id) {
+  if (DRY_RUN) {
+    log(`[DRY RUN] would mark row scanned`, { id });
+    return;
+  }
+
+  const url = `${SUPABASE_URL}/rest/v1/user_configs?id=eq.${id}`;
+  const res = await fetch(url, {
+    method: 'PATCH',
+    headers: SUPABASE_HEADERS,
+    body: JSON.stringify({ last_moderated_at: new Date().toISOString() }),
+  });
+
+  if (!res.ok) throw new Error(`Supabase PATCH (markScanned) failed for id=${id}: ${res.status} ${await res.text()}`);
 }
 
 // ---------------------------------------------------------------------------
@@ -576,6 +604,7 @@ async function main() {
     if (fields.length === 0) {
       log(`Row ${row.id}: no text fields, skipping.`);
       scanned++;
+      await markScanned(row.id);
       continue;
     }
 
@@ -637,6 +666,7 @@ async function main() {
       flaggedCount++;
     } else {
       log(`Row ${row.id}: clean.`);
+      await markScanned(row.id);
     }
   }
 

--- a/supabase/migrations/20260905000000_add_user_configs_moderation_cursor.sql
+++ b/supabase/migrations/20260905000000_add_user_configs_moderation_cursor.sql
@@ -1,0 +1,13 @@
+-- #257: track when a user_configs row was last actually scanned by the
+-- content moderation job. NULL means "never scanned". The scheduled scans
+-- filter on created_at/updated_at within a lookback window, so a row that
+-- landed during a scanner outage or otherwise fell outside every window
+-- was silently skipped forever with no way to detect it. Selecting on
+-- last_moderated_at IS NULL closes that gap regardless of window size.
+
+ALTER TABLE public.user_configs
+  ADD COLUMN IF NOT EXISTS last_moderated_at timestamptz;
+
+CREATE INDEX IF NOT EXISTS idx_user_configs_last_moderated_at
+  ON public.user_configs (last_moderated_at)
+  WHERE last_moderated_at IS NULL;

--- a/tests/moderationCursor.test.js
+++ b/tests/moderationCursor.test.js
@@ -1,0 +1,55 @@
+/**
+ * #257: per-row moderation cursor so rows outside every scheduled lookback
+ * window are never permanently skipped.
+ *
+ * Contract pins (same style as moderationVtUrls.test.js) since the .mjs
+ * exits early without live Supabase env vars -- these keep the query and
+ * write-back wiring honest without needing a live network call.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const SRC = fs.readFileSync(path.join(ROOT, '.github/scripts/moderate-content.mjs'), 'utf8');
+const MIGRATION = fs.readFileSync(
+  path.join(ROOT, 'supabase/migrations/20260905000000_add_user_configs_moderation_cursor.sql'),
+  'utf8'
+);
+
+describe('moderation cursor (#257)', () => {
+  test('migration adds a nullable last_moderated_at column', () => {
+    expect(MIGRATION).toMatch(/ADD COLUMN IF NOT EXISTS last_moderated_at timestamptz/);
+  });
+
+  test('migration indexes the NULL (never-scanned) case', () => {
+    expect(MIGRATION).toMatch(/CREATE INDEX IF NOT EXISTS idx_user_configs_last_moderated_at/);
+    expect(MIGRATION).toMatch(/WHERE last_moderated_at IS NULL/);
+  });
+
+  test('fetchRecentRows also selects rows that have never been scanned, regardless of age', () => {
+    expect(SRC).toMatch(/or=\(created_at\.gte\.\$\{since\},updated_at\.gte\.\$\{since\},last_moderated_at\.is\.null\)/);
+  });
+
+  test('flagRow stamps the cursor when auto-remediating a hit', () => {
+    expect(SRC).toMatch(/flagged_at:\s*new Date\(\)\.toISOString\(\),\s*\n\s*last_moderated_at:\s*new Date\(\)\.toISOString\(\),/);
+  });
+
+  test('markScanned exists, is DRY_RUN gated, and only writes the cursor column', () => {
+    expect(SRC).toMatch(/async function markScanned\(id\)/);
+    expect(SRC).toMatch(/would mark row scanned/);
+    expect(SRC).toMatch(/body: JSON\.stringify\(\{ last_moderated_at: new Date\(\)\.toISOString\(\) \}\)/);
+  });
+
+  test('markScanned raises on a failed PATCH rather than swallowing it', () => {
+    const fnBody = SRC.slice(SRC.indexOf('async function markScanned'), SRC.indexOf('// ---', SRC.indexOf('async function markScanned')));
+    expect(fnBody).toMatch(/if \(!res\.ok\) throw new Error/);
+  });
+
+  test('the main loop marks both the empty-fields branch and the clean branch as scanned', () => {
+    const noFieldsBranch = SRC.slice(SRC.indexOf('no text fields, skipping'), SRC.indexOf('no text fields, skipping') + 200);
+    expect(noFieldsBranch).toMatch(/await markScanned\(row\.id\)/);
+
+    const cleanBranch = SRC.slice(SRC.indexOf('Row ${row.id}: clean.`'), SRC.indexOf('Row ${row.id}: clean.`') + 100);
+    expect(cleanBranch).toMatch(/await markScanned\(row\.id\)/);
+  });
+});


### PR DESCRIPTION
Closes #257.

The scheduled content moderation scans (every 4h at 5h lookback, daily
deep scan at 25h) only select user_configs rows by created_at/updated_at
within their window. A row that landed during a scanner outage, or that
otherwise fell outside every window, had no way to ever get picked up
again -- there was no column recording whether a row had actually been
scanned.

Adds last_moderated_at (nullable timestamptz, NULL = never scanned).
fetchRecentRows now always selects rows where it's still NULL regardless
of age, and every row the main loop processes gets stamped with the
cursor (flagRow sets it alongside the existing flag fields; a new
markScanned helper stamps it for clean and no-text-field rows).

Migration already applied to Supabase (additive, non-destructive:
ADD COLUMN IF NOT EXISTS + a partial index on the NULL case).

Verified with a dry-run workflow_dispatch against staging: all 21
existing user_configs rows, none of which had ever been stamped before
this migration, were picked up by the new NULL clause regardless of
their age and would each get marked scanned, none flagged. Confirms the
backlog-closing behavior works as intended.

Tests: 5 new cases in tests/moderationCursor.test.js pinning the query
clause, the write-back on both the flag and clean/empty paths, and the
migration shape.