### PR TITLE
perf(pipeline): break down search-index loop timing by phase

### DIFF
--- a/scripts/pipeline/finalize.py
+++ b/scripts/pipeline/finalize.py
@@ -1057,14 +1057,29 @@ def generate_search_index(
     total_apps = len(app_ids)
     log(f"[search-index] summarizing {total_apps:,} reported apps (tier + counts + trend per app)")
     now_ts = time.time()
+    # #258: this loop's wall-clock cost grew nonlinearly across a run (5k
+    # apps in 65s, the next 5k in 209s) with no clear cause identified from
+    # the plain per-app work alone. Split the two per-app costs so the next
+    # slow run's log answers the question directly instead of requiring
+    # another cancel-and-read-the-log investigation.
+    title_summary_elapsed = 0.0
+    adult_check_elapsed = 0.0
+    loop_started = time.perf_counter()
     for processed, app_id in enumerate(app_ids, start=1):
         if processed % PROGRESS_EVERY == 0:
-            log(f"[search-index] progress: {processed:,}/{total_apps:,}")
+            log(
+                f"[search-index] progress: {processed:,}/{total_apps:,} "
+                f"(title+summary={title_summary_elapsed:.1f}s, adult-check={adult_check_elapsed:.1f}s, "
+                f"elapsed={time.perf_counter() - loop_started:.1f}s)"
+            )
+        t0 = time.perf_counter()
         app_dir = data_output_path / app_id_to_dir(app_id)
         title = _extract_title(app_dir)
         if not title:
+            title_summary_elapsed += time.perf_counter() - t0
             continue
         tier, pdb_count, pulse_count, trend = _compute_game_summary(app_dir, now_ts=now_ts)
+        title_summary_elapsed += time.perf_counter() - t0
         app_type = app_type_from_id(app_id)
         # Adult flag lives at column 8. Steam descriptors are the source
         # of truth; GOG / Epic entries stay unflagged (no equivalent
@@ -1077,16 +1092,22 @@ def generate_search_index(
         # Reported game: descriptor-check Steam apps. Force a fresh fetch when
         # the title hints adult so a poisoned empty cache entry (#185) heals
         # instead of leaking the game into browse views.
+        t1 = time.perf_counter()
         adult = (
             is_adult_app(app_id, force_refresh=bool(ADULT_TITLE_HINT_RE.search(title)))
             if app_type == "steam"
             else False
         )
+        adult_check_elapsed += time.perf_counter() - t1
         # Column 9 is the compatibility trend direction: 'improving',
         # 'declining', or '' (stable / insufficient sample). Cards read it via
         # renderGameCard's `trend` option to draw the up/down arrow.
         entries.append([app_id, title, tier, pdb_count, pulse_count, app_type, None, None, adult, trend])
         seen_ids.add(app_id)
+    log(
+        f"[search-index] loop complete: title+summary={title_summary_elapsed:.1f}s, "
+        f"adult-check={adult_check_elapsed:.1f}s, total={time.perf_counter() - loop_started:.1f}s"
+    )
 
     # Demo dedup for catalog stubs: GOG/Epic list demos as separate products
     # ("Coffee Noir DEMO" next to "Coffee Noir"). A demo stub with zero

--- a/tests/test_finalize_utils.py
+++ b/tests/test_finalize_utils.py
@@ -439,6 +439,25 @@ def test_generate_search_index_basic(tmp_path):
     assert len(index[0]) >= 10
     assert index[0][9] == ""
 
+def test_generate_search_index_logs_timing_breakdown(tmp_path, capsys):
+    # #258: the per-app loop is the single longest phase of finalize and its
+    # wall-clock cost has grown nonlinearly across a run with no identified
+    # cause. This breakdown is what lets the next slow run answer that
+    # directly from the log instead of requiring a cancel-and-inspect pass.
+    app_dir = tmp_path / "730"
+    app_dir.mkdir()
+    (app_dir / "2023.json").write_text(json.dumps([{"rating": "gold", "source": "pulse", "title": "CS2"}]))
+    (app_dir / "latest.json").write_text(json.dumps([{"title": "CS2"}]))
+
+    keys = {("730", "2023")}
+    generate_search_index(keys, tmp_path, tmp_path)
+
+    err = capsys.readouterr().err
+    assert "[search-index] loop complete:" in err
+    assert "title+summary=" in err
+    assert "adult-check=" in err
+    assert "total=" in err
+
 def test_generate_search_index_gog_stub_from_catalog(tmp_path):
     keys = set()
     gog_catalog = {"1234567890": "Swat 4"}


### PR DESCRIPTION
Refs #258 (does not close it -- diagnostic only, root cause still open).

The search-index per-app loop is the single longest phase of finalize
and its cost has grown nonlinearly across a run per the investigation
on #258 (5k apps in 65s, the next 5k in 209s), with no identified cause
because the existing heartbeat only logs app count, not where the time
inside each app goes.

Splits the loop into title+summary (local file reads only) vs
adult-check (is_adult_app, which hits Steam appdetails on a cache miss)
and logs the running split on every progress heartbeat plus a final
total. The next slow staging-finalize run's log will show directly
whether the slowdown tracks the network-bound adult check or the local
file reads, closing the "worth profiling before optimizing anything
else" gap from the last comment on #258 instead of requiring another
cancel-and-inspect pass.

No behavior change -- same tier/count/trend output, just more log lines.

Tests: new case in tests/test_finalize_utils.py asserting the breakdown
log line appears with all three fields.