### PR TITLE
feat(app): persist the Mine filter chip, hide it when signed out

### DIFF
--- a/js/app/components/game-page.js
+++ b/js/app/components/game-page.js
@@ -1173,7 +1173,14 @@ export async function renderGamePage(appId) {
   let filterConfidenceMin = _clampInt(persistedFilters.confidenceMin, 0, 100, 0);
   let filterConfidenceMax = _clampInt(persistedFilters.confidenceMax, 0, 100, 100);
   if (filterConfidenceMin > filterConfidenceMax) filterConfidenceMin = filterConfidenceMax;
-  let filterMine = false;
+  // #390: signed-out visitors have no "me" to filter by -- the chip is
+  // hidden entirely for them (see the sort-bar template below), and the
+  // persisted value is dropped rather than honoured so it can't silently
+  // filter everything out if they save while signed in, sign out, then
+  // come back later. window._ppMyUserId is resolved (awaited) before this
+  // component's render() runs, so it's already final here.
+  const _signedIn = !!window._ppMyUserId;
+  let filterMine = _signedIn && !!persistedFilters.mine;
 
   // Unified source filter across configs + reports: 'pulse-config', 'pulse-report',
   // 'protondb', or '' for any. Falls back to the shared-across-site value
@@ -1197,6 +1204,10 @@ export async function renderGamePage(appId) {
       runType: filterRunType, device: filterDevice,
       minPlaytime: filterMinPlaytime, source: filterSource,
       confidenceMin: filterConfidenceMin, confidenceMax: filterConfidenceMax,
+      // #390: filterMine can only be true while _signedIn (the toggle is
+      // hidden otherwise), so this never saves a mine=true snapshot under
+      // the wrong identity.
+      mine: filterMine,
     };
   }
 
@@ -1803,7 +1814,7 @@ export async function renderGamePage(appId) {
         <div class="sort-bar">
           <button class="${sortMode==='recent'?'active':''}" data-sort="recent">Recent</button>
           <button class="${sortMode==='votes'?'active':''}" data-sort="votes">Top Voted</button>
-          <button class="sort-mine-btn${filterMine?' active':''}" data-action="toggle-mine">Mine</button>
+          ${_signedIn ? `<button class="sort-mine-btn${filterMine?' active':''}" data-action="toggle-mine">Mine</button>` : ''}
         </div>
       </div>
 
@@ -1833,6 +1844,11 @@ export async function renderGamePage(appId) {
     );
     el.querySelector('.sort-mine-btn')?.addEventListener('click', () => {
       filterMine = !filterMine;
+      // #390: persist the same way the other filter chips do -- cache into
+      // the session snapshot immediately (survives SPA nav) and mark the
+      // Save button dirty; nothing lands in localStorage until Save.
+      _cacheField('mine', filterMine);
+      _updateSaveButtonState();
       refreshReports();
     });
 

--- a/js/app/components/search.js
+++ b/js/app/components/search.js
@@ -2,7 +2,7 @@
 
 import { estimateScore } from '../../shared/scoring.js?v=852c9d97';
 import { fetchMatchingPulseConfigs, fetchMatchingPulseReportAppIds } from '../api/reports.js?v=003f23c0';
-import { renderGamePage } from './game-page.js?v=baeecb0a';
+import { renderGamePage } from './game-page.js?v=0c1eb15e';
 import { STEAM_IMG, SITE_ROOT, USES_PROD_DATA, storeLabelFromAppId, fetchDataWithProdFallback } from '../config.js?v=7873e060';
 import { daysAgo, esc, withTimeout } from '../utils.js?v=4630c3d5';
 import { renderGameCard } from '../lib/card.js?v=bdeb653b';

--- a/js/app/router.js
+++ b/js/app/router.js
@@ -1,7 +1,7 @@
 // router (entry) for the app page. Relocated from app.js.
 
 import { pcgwSlugToPwId } from '../lib/app-id.js?v=6159afa9';
-import { renderGamePage } from './components/game-page.js?v=baeecb0a';
+import { renderGamePage } from './components/game-page.js?v=0c1eb15e';
 import { renderHomePage } from './components/home.js?v=183b5b8f';
 import { renderSearchPage } from './components/search.js?v=091f940b';
 

--- a/tests/gamePageMineFilterPersist.test.js
+++ b/tests/gamePageMineFilterPersist.test.js
@@ -1,0 +1,53 @@
+/**
+ * #390: "My Reports" filter chip on the game reports page.
+ *
+ * Structural tests only -- game-page.js is a large IIFE that does its work
+ * against real DOM + localStorage. Same pattern as filterSaveExplicit.test.js.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const src = fs.readFileSync(
+  path.join(__dirname, '..', 'js', 'app', 'components', 'game-page.js'),
+  'utf8'
+);
+
+describe('#390 "Mine" filter chip', () => {
+  test('matches reports by BOTH client_id and proton_pulse_user_id', () => {
+    const idx = src.indexOf('if (filterMine) {');
+    expect(idx).toBeGreaterThan(0);
+    const slice = src.slice(idx, idx + 300);
+    expect(slice).toContain('getWebClientId()');
+    expect(slice).toContain('window._ppMyUserId');
+    expect(slice).toMatch(/r\.clientId === myCid/);
+    expect(slice).toMatch(/r\.protonPulseUserId === myPpid/);
+  });
+
+  test('the chip is hidden entirely when signed out, not just disabled', () => {
+    expect(src).toContain('const _signedIn = !!window._ppMyUserId;');
+    expect(src).toMatch(/\$\{_signedIn \? `<button class="sort-mine-btn/);
+  });
+
+  test('filterMine only initializes true while signed in', () => {
+    expect(src).toContain('let filterMine = _signedIn && !!persistedFilters.mine;');
+  });
+
+  test('mine is part of the persisted filter snapshot, same as the other chips', () => {
+    const idx = src.indexOf('function _filterSnapshot()');
+    expect(idx).toBeGreaterThan(0);
+    const slice = src.slice(idx, idx + 700);
+    expect(slice).toContain('mine: filterMine');
+  });
+
+  test('toggling Mine caches into the session snapshot and marks Save dirty, like the dropdown filters', () => {
+    const idx = src.indexOf("el.querySelector('.sort-mine-btn')?.addEventListener('click'");
+    expect(idx).toBeGreaterThan(0);
+    const slice = src.slice(idx, idx + 500);
+    expect(slice).toContain("_cacheField('mine', filterMine)");
+    expect(slice).toContain('_updateSaveButtonState()');
+    expect(slice).toContain('refreshReports()');
+    // Same explicit-Save contract as every other filter (#415 slice 1):
+    // toggling must not itself touch localStorage.
+    expect(slice).not.toContain('localStorage.setItem');
+  });
+});


### PR DESCRIPTION
Closes #390.

The Mine toggle on a game page's report list always reset to off on
every load and rendered even for signed-out visitors with nothing to
filter by, unlike the panel's other filter chips (rating, source, gpu,
etc.) which persist across navigation and only ever apply to the
identity they're scoped to.

- Hidden entirely when signed out (window._ppMyUserId is resolved
  before this component renders, so the check is synchronous at
  render time).
- Restored from the persisted filter snapshot on load, gated on being
  signed in, so a stale mine=true from a previous session under a
  different identity can't silently apply.
- Added to _filterSnapshot() so it's part of the explicit Save/dirty
  contract from #415 slice 1, and cached into the session snapshot on
  toggle the same way the dropdown filters already do.

The matching logic itself (client_id + proton_pulse_user_id) was
already correct; only persistence and visibility were missing.

Verified on staging (v1.13.0 . 7f42122) per the checklist posted on
#390 and confirmed by the user.

Also filed #516 separately: scripts/smoke.sh turned out to be an empty
file (accidentally wiped in an unrelated commit back in June), so the
usual automated render-path smoke check has been a silent no-op this
whole time. Not fixed here -- out of scope for this change.

Tests: 5 new cases in tests/gamePageMineFilterPersist.test.js.